### PR TITLE
feat: add alternate green shades

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,7 @@
 $color-burgundy: #f05411;
 $color-green: #34783d;
+$color-green_shade_hi: #5ab867; // 20% lighter than $color-green
+$color-green_shade_lo: #153119; // 20% darker than $color-green
 $color-white: #ffffff;
 
 .logo.vite:hover {


### PR DESCRIPTION
## Summary
- add lighter and darker green variants to the color palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden for sass-embedded)*
- `npm run build` *(fails: preprocessor dependency "sass-embedded" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4107c2660832ab001712dddaf436b