### PR TITLE
Refactor sidebar nav into text links

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,10 @@
       <h1>Arklowdun</h1>
       <p class="tagline">Home management</p>
       <nav class="nav">
-        <button id="nav-files" class="active" aria-pressed="true">Files</button>
-        <button id="nav-calendar" aria-pressed="false">Calendar</button>
+        <a id="nav-dashboard" class="active" href="#" aria-current="page">Dashboard</a>
+        <a id="nav-primary" href="#">Primary</a>
+        <a id="nav-secondary" href="#">Secondary</a>
+        <a id="nav-tertiary" href="#">Tertiary</a>
       </nav>
     </aside>
     <main id="view" class="container"></main>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,61 +1,62 @@
 // Simple tabbed UI scaffold for Arklowdun
 
-type View = "files" | "calendar";
+type View = "dashboard" | "primary" | "secondary" | "tertiary";
 
 const viewEl = () => document.querySelector<HTMLElement>("#view");
-const btnFiles = () => document.querySelector<HTMLButtonElement>("#nav-files");
-const btnCalendar = () =>
-  document.querySelector<HTMLButtonElement>("#nav-calendar");
+const linkDashboard = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-dashboard");
+const linkPrimary = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-primary");
+const linkSecondary = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-secondary");
+const linkTertiary = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-tertiary");
 
 function setActive(tab: View) {
-  const filesBtn = btnFiles();
-  const calBtn = btnCalendar();
-  filesBtn?.classList.toggle("active", tab === "files");
-  calBtn?.classList.toggle("active", tab === "calendar");
-  filesBtn?.setAttribute("aria-pressed", String(tab === "files"));
-  calBtn?.setAttribute("aria-pressed", String(tab === "calendar"));
+  const tabs: Record<View, HTMLAnchorElement | null> = {
+    dashboard: linkDashboard(),
+    primary: linkPrimary(),
+    secondary: linkSecondary(),
+    tertiary: linkTertiary(),
+  };
+  (Object.keys(tabs) as View[]).forEach((name) => {
+    const el = tabs[name];
+    const active = name === tab;
+    el?.classList.toggle("active", active);
+    if (active) el?.setAttribute("aria-current", "page");
+    else el?.removeAttribute("aria-current");
+  });
 }
 
-function renderFiles() {
+function renderBlank(title: string) {
   const el = viewEl();
   if (!el) return;
-  el.innerHTML = `
-    <section>
-      <h2>Files</h2>
-      <p>Connect a folder to manage your home documents.</p>
-      <div class="row">
-        <button id="choose-folder">Choose Folder</button>
-        <button id="new-file" disabled title="Coming soon">New File</button>
-      </div>
-      <div id="file-list" class="list empty">No folder selected.</div>
-    </section>
-  `;
-}
-
-function renderCalendar() {
-  const el = viewEl();
-  if (!el) return;
-  el.innerHTML = `
-    <section>
-      <h2>Calendar</h2>
-      <p>Track events, reminders, and recurring tasks (coming soon).</p>
-      <div class="row">
-        <button disabled title="Coming soon">Add Event</button>
-        <button disabled title="Coming soon">Import .ics</button>
-      </div>
-      <div class="calendar-empty">Calendar view placeholder</div>
-    </section>
-  `;
+  el.innerHTML = `<section><h2>${title}</h2></section>`;
 }
 
 function navigate(to: View) {
   setActive(to);
-  if (to === "files") renderFiles();
-  else renderCalendar();
+  const title = to.charAt(0).toUpperCase() + to.slice(1);
+  renderBlank(title);
 }
 
 window.addEventListener("DOMContentLoaded", () => {
-  btnFiles()?.addEventListener("click", () => navigate("files"));
-  btnCalendar()?.addEventListener("click", () => navigate("calendar"));
-  navigate("files");
+  linkDashboard()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("dashboard");
+  });
+  linkPrimary()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("primary");
+  });
+  linkSecondary()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("secondary");
+  });
+  linkTertiary()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("tertiary");
+  });
+  navigate("dashboard");
 });
+

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,7 @@
 $color-burgundy: #f05411;
 $color-green: #34783d;
+$color-burgundy_pastel: #f69870;
+$color-green_pastel: #71c17c;
 $color-green_shade_hi: #5ab867; // 20% lighter than $color-green
 $color-green_shade_lo: #153119; // 20% darker than $color-green
 $color-white: #ffffff;
@@ -117,6 +119,8 @@ button {
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  background-color: $color-white;
+  color: $color-burgundy;
 }
 .tagline {
   opacity: 0.8;
@@ -128,10 +132,8 @@ button {
   gap: 0.5rem;
   margin-top: 1rem;
 }
-.nav button.active {
-  border-color: $color-burgundy;
-  background-color: $color-green;
-  color: $color-white;
+.nav a.active {
+  color: $color-green;
 }
 
 .list.empty, .calendar-empty {


### PR DESCRIPTION
## Summary
- add pastel green and burgundy color variables
- switch sidebar nav to text links for Dashboard, Primary, Secondary and Tertiary
- style sidebar with white background and burgundy text; active link shows green

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Preprocessor dependency "sass-embedded" not found)


------
https://chatgpt.com/codex/tasks/task_e_68b415eac740832aa7b36f492173ff02