### PR TITLE
feat: add calendar view with event storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         <a id="nav-primary" href="#">Primary</a>
         <a id="nav-secondary" href="#">Secondary</a>
         <a id="nav-tertiary" href="#">Tertiary</a>
+        <a id="nav-calendar" href="#">Calendar</a>
       </nav>
     </aside>
     <main id="view" class="container"></main>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,5 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tauri-plugin-notification = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,89 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+use tauri::Manager;
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Event {
+    id: u32,
+    title: String,
+    datetime: String,
+    reminder: Option<i64>,
+}
+
+fn events_path(app: &tauri::AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .expect("app data dir")
+        .join("events.json")
+}
+
+fn read_events(app: &tauri::AppHandle) -> Vec<Event> {
+    let path = events_path(app);
+    if let Ok(data) = fs::read_to_string(path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+fn write_events(app: &tauri::AppHandle, events: &Vec<Event>) -> Result<(), String> {
+    let path = events_path(app);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let data = serde_json::to_string(events).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())
+}
+
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+fn get_events(app: tauri::AppHandle) -> Result<Vec<Event>, String> {
+    Ok(read_events(&app))
+}
+
+#[tauri::command]
+fn add_event(app: tauri::AppHandle, mut event: Event) -> Result<Event, String> {
+    let mut events = read_events(&app);
+    let next_id = events.iter().map(|e| e.id).max().unwrap_or(0) + 1;
+    event.id = next_id;
+    events.push(event.clone());
+    write_events(&app, &events)?;
+    Ok(event)
+}
+
+#[tauri::command]
+fn update_event(app: tauri::AppHandle, event: Event) -> Result<(), String> {
+    let mut events = read_events(&app);
+    if let Some(e) = events.iter_mut().find(|e| e.id == event.id) {
+        *e = event;
+        write_events(&app, &events)
+    } else {
+        Err("Event not found".into())
+    }
+}
+
+#[tauri::command]
+fn delete_event(app: tauri::AppHandle, id: u32) -> Result<(), String> {
+    let mut events = read_events(&app);
+    let len_before = events.len();
+    events.retain(|e| e.id != id);
+    if events.len() == len_before {
+        return Err("Event not found".into());
+    }
+    write_events(&app, &events)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .plugin(tauri_plugin_notification::init())
+        .invoke_handler(tauri::generate_handler![
+            get_events,
+            add_event,
+            update_event,
+            delete_event
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/CalendarView.ts
+++ b/src/CalendarView.ts
@@ -1,0 +1,120 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "./notification";
+
+export interface CalendarEvent {
+  id: number;
+  title: string;
+  datetime: string; // ISO string
+  reminder?: number; // timestamp in ms
+}
+
+async function fetchEvents(): Promise<CalendarEvent[]> {
+  return await invoke<CalendarEvent[]>("get_events");
+}
+
+async function saveEvent(event: Omit<CalendarEvent, "id">): Promise<CalendarEvent> {
+  return await invoke<CalendarEvent>("add_event", { event });
+}
+
+function renderMonth(root: HTMLElement, events: CalendarEvent[]) {
+  root.innerHTML = "";
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const lastDate = new Date(year, month + 1, 0).getDate();
+
+  const table = document.createElement("table");
+  const headerRow = document.createElement("tr");
+  ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].forEach((d) => {
+    const th = document.createElement("th");
+    th.textContent = d;
+    headerRow.appendChild(th);
+  });
+  table.appendChild(headerRow);
+
+  let row = document.createElement("tr");
+  for (let i = 0; i < firstDay; i++) row.appendChild(document.createElement("td"));
+  for (let day = 1; day <= lastDate; day++) {
+    if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
+      table.appendChild(row);
+      row = document.createElement("tr");
+    }
+    const cell = document.createElement("td");
+    cell.innerHTML = `<div class="date">${day}</div>`;
+    const dateStr = new Date(year, month, day).toISOString().split("T")[0];
+    const dayEvents = events.filter((e) => e.datetime.startsWith(dateStr));
+    dayEvents.forEach((ev) => {
+      const div = document.createElement("div");
+      div.className = "event";
+      div.textContent = ev.title;
+      cell.appendChild(div);
+    });
+    row.appendChild(cell);
+  }
+  table.appendChild(row);
+  root.appendChild(table);
+}
+
+async function scheduleNotifications(events: CalendarEvent[]) {
+  let granted = await isPermissionGranted();
+  if (!granted) {
+    granted = (await requestPermission()) === "granted";
+  }
+  if (!granted) return;
+  const now = Date.now();
+  events.forEach((ev) => {
+    if (ev.reminder && ev.reminder > now) {
+      setTimeout(() => {
+        sendNotification({
+          title: ev.title,
+          body: new Date(ev.datetime).toLocaleString(),
+        });
+      }, ev.reminder - now);
+    }
+  });
+}
+
+export async function CalendarView(container: HTMLElement) {
+  const section = document.createElement("section");
+  section.innerHTML = `
+    <h2>Calendar</h2>
+    <div id="calendar"></div>
+    <form id="event-form">
+      <input id="event-title" type="text" placeholder="Title" required />
+      <input id="event-datetime" type="datetime-local" required />
+      <button type="submit">Add Event</button>
+    </form>
+  `;
+  container.innerHTML = "";
+  container.appendChild(section);
+
+  const calendarEl = section.querySelector<HTMLElement>("#calendar");
+  const form = section.querySelector<HTMLFormElement>("#event-form");
+  const titleInput = section.querySelector<HTMLInputElement>("#event-title");
+  const dateInput = section.querySelector<HTMLInputElement>("#event-datetime");
+
+  let events = await fetchEvents();
+  if (calendarEl) renderMonth(calendarEl, events);
+  scheduleNotifications(events);
+
+  form?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    if (!titleInput || !dateInput) return;
+    const dt = new Date(dateInput.value);
+    const ev = await saveEvent({
+      title: titleInput.value,
+      datetime: dt.toISOString(),
+      reminder: dt.getTime(),
+    });
+    events.push(ev);
+    if (calendarEl) renderMonth(calendarEl, events);
+    scheduleNotifications([ev]);
+    form.reset();
+  });
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,13 @@
 // Simple tabbed UI scaffold for Arklowdun
 
-type View = "dashboard" | "primary" | "secondary" | "tertiary";
+import { CalendarView } from "./CalendarView";
+
+type View =
+  | "dashboard"
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "calendar";
 
 const viewEl = () => document.querySelector<HTMLElement>("#view");
 const linkDashboard = () =>
@@ -11,6 +18,8 @@ const linkSecondary = () =>
   document.querySelector<HTMLAnchorElement>("#nav-secondary");
 const linkTertiary = () =>
   document.querySelector<HTMLAnchorElement>("#nav-tertiary");
+const linkCalendar = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-calendar");
 
 function setActive(tab: View) {
   const tabs: Record<View, HTMLAnchorElement | null> = {
@@ -18,6 +27,7 @@ function setActive(tab: View) {
     primary: linkPrimary(),
     secondary: linkSecondary(),
     tertiary: linkTertiary(),
+    calendar: linkCalendar(),
   };
   (Object.keys(tabs) as View[]).forEach((name) => {
     const el = tabs[name];
@@ -36,6 +46,12 @@ function renderBlank(title: string) {
 
 function navigate(to: View) {
   setActive(to);
+  const el = viewEl();
+  if (!el) return;
+  if (to === "calendar") {
+    CalendarView(el);
+    return;
+  }
   const title = to.charAt(0).toUpperCase() + to.slice(1);
   renderBlank(title);
 }
@@ -56,6 +72,10 @@ window.addEventListener("DOMContentLoaded", () => {
   linkTertiary()?.addEventListener("click", (e) => {
     e.preventDefault();
     navigate("tertiary");
+  });
+  linkCalendar()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("calendar");
   });
   navigate("dashboard");
 });

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -1,0 +1,20 @@
+export async function isPermissionGranted(): Promise<boolean> {
+  return (
+    (await (window as any).__TAURI__?.notification?.isPermissionGranted?.()) ??
+    false
+  );
+}
+
+export async function requestPermission(): Promise<string> {
+  return (
+    (await (window as any).__TAURI__?.notification?.requestPermission?.()) ??
+    "denied"
+  );
+}
+
+export async function sendNotification(options: {
+  title: string;
+  body: string;
+}): Promise<void> {
+  await (window as any).__TAURI__?.notification?.sendNotification?.(options);
+}


### PR DESCRIPTION
## Summary
- introduce CalendarView component with simple month grid
- persist events via Tauri commands and JSON file
- wire up calendar navigation and basic notification scheduling

## Testing
- `npm run build` *(fails: Preprocessor dependency "sass-embedded" not found)*
- `cargo test` *(fails: failed to get `serde` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b4197bd010832a860e65f0a7f4974a