### PR TITLE
refactor: replace deprecated Sass lighten function

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,9 @@
+@use "sass:color";
+
 $color-burgundy: #f05411;
 $color-green: #34783d;
-$color-burgundy_pastel: lighten($color-burgundy, 50%);
-$color-green_pastel: lighten($color-green, 50%);
+$color-burgundy_pastel: color.adjust($color-burgundy, $lightness: 50%);
+$color-green_pastel: color.adjust($color-green, $lightness: 50%);
 $color-green_shade_hi: #5ab867; // 20% lighter than $color-green
 $color-green_shade_lo: #153119; // 20% darker than $color-green
 $color-white: #ffffff;


### PR DESCRIPTION
## Summary
- replace deprecated `lighten()` with `color.adjust()` in styles
- import `sass:color` module

## Testing
- `npm run build` *(fails: Cannot find module '@tauri-apps/plugin-opener', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b457423cb4832a9ce0f8c0f1da7efe