### PR TITLE
feat: add settings view and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
           <a id="nav-files" href="#">Files</a>
           <a id="nav-calendar" href="#">Calendar</a>
           <a id="nav-shopping" href="#">Shopping List</a>
+          <a id="nav-settings" href="#">Settings</a>
       </nav>
     </aside>
     <main id="view" class="container"></main>

--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -1,0 +1,10 @@
+export function SettingsView(container: HTMLElement) {
+  const section = document.createElement("section");
+  section.innerHTML = `
+    <h2>Settings</h2>
+    <p>Manage application preferences.</p>
+  `;
+  container.innerHTML = "";
+  container.appendChild(section);
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { VehiclesView } from "./VehiclesView";
 import { PetsView } from "./PetsView";
 import { FamilyView } from "./FamilyView";
 import { PropertyView } from "./PropertyView";
+import { SettingsView } from "./SettingsView";
 
 type View =
   | "dashboard"
@@ -25,7 +26,8 @@ type View =
   | "property"
   | "vehicles"
   | "pets"
-  | "family";
+  | "family"
+  | "settings";
 
 const viewEl = () => document.querySelector<HTMLElement>("#view");
 const linkDashboard = () =>
@@ -53,6 +55,8 @@ const linkVehicles = () =>
 const linkPets = () => document.querySelector<HTMLAnchorElement>("#nav-pets");
 const linkFamily = () =>
   document.querySelector<HTMLAnchorElement>("#nav-family");
+const linkSettings = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-settings");
 
 function setActive(tab: View) {
   const tabs: Record<View, HTMLAnchorElement | null> = {
@@ -69,6 +73,7 @@ function setActive(tab: View) {
     vehicles: linkVehicles(),
     pets: linkPets(),
     family: linkFamily(),
+    settings: linkSettings(),
   };
   (Object.keys(tabs) as View[]).forEach((name) => {
     const el = tabs[name];
@@ -124,6 +129,10 @@ function navigate(to: View) {
   }
   if (to === "family") {
     FamilyView(el);
+    return;
+  }
+  if (to === "settings") {
+    SettingsView(el);
     return;
   }
   const title = to.charAt(0).toUpperCase() + to.slice(1);
@@ -182,6 +191,10 @@ window.addEventListener("DOMContentLoaded", () => {
   linkFamily()?.addEventListener("click", (e) => {
     e.preventDefault();
     navigate("family");
+  });
+  linkSettings()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("settings");
   });
   navigate("dashboard");
 });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -134,9 +134,14 @@ button {
   flex-direction: column;
   gap: 0.5rem;
   margin-top: 1rem;
+  flex: 1;
 }
 .nav a.active {
   color: $color-green;
+}
+
+#nav-settings {
+  margin-top: auto;
 }
 
 .list.empty, .calendar-empty {


### PR DESCRIPTION
## Summary
- add settings view component
- link settings page from sidebar and support navigation
- pin settings link to bottom with flexbox styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Property 'open' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b46aa4baac832a9c2aee3fa6b6ce60