### PR TITLE
Add draggable Notes view with persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arklowdun is a desktop app for home management, centered around a filestore and a calendar.
 
-Current state: basic app shell with two tabs (Files, Calendar). The Files view uses Tauri's dialog and filesystem plugins to browse and manage the local file system, while the Calendar stores events on disk. Functionality will be implemented iteratively.
+Current state: basic app shell with three tabs (Files, Calendar, Notes). The Files view uses Tauri's dialog and filesystem plugins to browse and manage the local file system, the Calendar stores events on disk, and the Notes view lets you create draggable colored notes that persist to disk. Functionality will be implemented iteratively.
 
 ## Roadmap (initial)
 

--- a/index.html
+++ b/index.html
@@ -17,17 +17,18 @@
         <a id="nav-secondary" href="#">Secondary</a>
         <a id="nav-tertiary" href="#">Tertiary</a>
         <a id="nav-bills" href="#">Bills</a>
-          <a id="nav-insurance" href="#">Insurance</a>
-          <a id="nav-property" href="#">Property</a>
-          <a id="nav-vehicles" href="#">Vehicles</a>
-          <a id="nav-pets" href="#">Pets</a>
-          <a id="nav-family" href="#">Family</a>
-          <a id="nav-inventory" href="#">Inventory</a>
-          <a id="nav-budget" href="#">Budget</a>
-          <a id="nav-files" href="#">Files</a>
-          <a id="nav-calendar" href="#">Calendar</a>
-          <a id="nav-shopping" href="#">Shopping List</a>
-          <a id="nav-settings" href="#">Settings</a>
+        <a id="nav-insurance" href="#">Insurance</a>
+        <a id="nav-property" href="#">Property</a>
+        <a id="nav-vehicles" href="#">Vehicles</a>
+        <a id="nav-pets" href="#">Pets</a>
+        <a id="nav-family" href="#">Family</a>
+        <a id="nav-inventory" href="#">Inventory</a>
+        <a id="nav-budget" href="#">Budget</a>
+        <a id="nav-files" href="#">Files</a>
+        <a id="nav-calendar" href="#">Calendar</a>
+        <a id="nav-shopping" href="#">Shopping List</a>
+        <a id="nav-notes" href="#">Notes</a>
+        <a id="nav-settings" href="#">Settings</a>
       </nav>
     </aside>
     <main id="view" class="container"></main>

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -1,0 +1,133 @@
+import { readTextFile, writeTextFile, mkdir, BaseDirectory } from "@tauri-apps/plugin-fs";
+import { join } from "@tauri-apps/api/path";
+
+interface Note {
+  id: number;
+  text: string;
+  color: string;
+  x: number;
+  y: number;
+}
+
+const STORE_DIR = "Arklowdun";
+const FILE_NAME = "notes.json";
+
+async function loadNotes(): Promise<Note[]> {
+  try {
+    const p = await join(STORE_DIR, FILE_NAME);
+    const json = await readTextFile(p, { baseDir: BaseDirectory.AppLocalData });
+    return JSON.parse(json) as Note[];
+  } catch {
+    return [];
+  }
+}
+
+async function saveNotes(notes: Note[]): Promise<void> {
+  await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
+  const p = await join(STORE_DIR, FILE_NAME);
+  await writeTextFile(p, JSON.stringify(notes, null, 2), { baseDir: BaseDirectory.AppLocalData });
+}
+
+let nextId = 1;
+
+export async function NotesView(container: HTMLElement) {
+  const section = document.createElement("section");
+  section.innerHTML = `
+    <h2>Notes</h2>
+    <form id="note-form">
+      <input id="note-text" type="text" placeholder="Note" required />
+      <input id="note-color" type="color" value="#ffff88" />
+      <button type="submit">Add</button>
+    </form>
+    <div id="notes-canvas" class="notes-canvas"></div>
+  `;
+  container.innerHTML = "";
+  container.appendChild(section);
+
+  const form = section.querySelector<HTMLFormElement>("#note-form");
+  const textInput = section.querySelector<HTMLInputElement>("#note-text");
+  const colorInput = section.querySelector<HTMLInputElement>("#note-color");
+  const canvas = section.querySelector<HTMLDivElement>("#notes-canvas")!;
+
+  let notes: Note[] = await loadNotes();
+  nextId = notes.reduce((m, n) => Math.max(m, n.id), 0) + 1;
+
+  let saveTimer: number | undefined;
+  const saveSoon = () => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => saveNotes(notes), 250);
+  };
+
+  function render() {
+    canvas.innerHTML = "";
+    notes.forEach((note) => {
+      const el = document.createElement("div");
+      el.className = "note";
+      el.style.backgroundColor = note.color;
+      el.style.left = note.x + "px";
+      el.style.top = note.y + "px";
+      const textarea = document.createElement("textarea");
+      textarea.value = note.text;
+      textarea.addEventListener("input", () => {
+        note.text = textarea.value;
+        saveSoon();
+      });
+      el.appendChild(textarea);
+      const del = document.createElement("button");
+      del.className = "delete";
+      del.textContent = "\u00d7";
+      del.addEventListener("click", () => {
+        notes = notes.filter((n) => n.id !== note.id);
+        saveNotes(notes).then(render);
+      });
+      el.appendChild(del);
+
+      el.addEventListener("pointerdown", (e) => {
+        if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLButtonElement) return;
+        e.preventDefault();
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const origX = note.x;
+        const origY = note.y;
+        el.classList.add("dragging");
+        el.setPointerCapture(e.pointerId);
+        function onMove(ev: PointerEvent) {
+          const maxX = canvas.clientWidth - el.offsetWidth;
+          const maxY = canvas.clientHeight - el.offsetHeight;
+          note.x = Math.max(0, Math.min(maxX, origX + (ev.clientX - startX)));
+          note.y = Math.max(0, Math.min(maxY, origY + (ev.clientY - startY)));
+          el.style.left = note.x + "px";
+          el.style.top = note.y + "px";
+        }
+        function onUp() {
+          el.removeEventListener("pointermove", onMove);
+          el.removeEventListener("pointerup", onUp);
+          el.classList.remove("dragging");
+          saveSoon();
+        }
+        el.addEventListener("pointermove", onMove);
+        el.addEventListener("pointerup", onUp);
+      });
+
+      canvas.appendChild(el);
+    });
+  }
+
+  render();
+
+  form?.addEventListener("submit", (e) => {
+    e.preventDefault();
+    if (!textInput || !colorInput) return;
+    const note: Note = {
+      id: nextId++,
+      text: textInput.value,
+      color: colorInput.value,
+      x: 10,
+      y: 10,
+    };
+    notes.push(note);
+    saveNotes(notes).then(render);
+    form.reset();
+    colorInput.value = "#ffff88";
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { PropertyView } from "./PropertyView";
 import { SettingsView } from "./SettingsView";
 import { InventoryView } from "./InventoryView";
 import { BudgetView } from "./BudgetView";
+import { NotesView } from "./NotesView";
 
 type View =
   | "dashboard"
@@ -31,6 +32,7 @@ type View =
   | "family"
   | "inventory"
   | "budget"
+  | "notes"
   | "settings";
 
 const viewEl = () => document.querySelector<HTMLElement>("#view");
@@ -63,6 +65,8 @@ const linkInventory = () =>
   document.querySelector<HTMLAnchorElement>("#nav-inventory");
 const linkBudget = () =>
   document.querySelector<HTMLAnchorElement>("#nav-budget");
+const linkNotes = () =>
+  document.querySelector<HTMLAnchorElement>("#nav-notes");
 const linkSettings = () =>
   document.querySelector<HTMLAnchorElement>("#nav-settings");
 
@@ -83,6 +87,7 @@ function setActive(tab: View) {
     family: linkFamily(),
     inventory: linkInventory(),
     budget: linkBudget(),
+    notes: linkNotes(),
     settings: linkSettings(),
   };
   (Object.keys(tabs) as View[]).forEach((name) => {
@@ -147,6 +152,10 @@ function navigate(to: View) {
   }
   if (to === "budget") {
     BudgetView(el);
+    return;
+  }
+  if (to === "notes") {
+    NotesView(el);
     return;
   }
   if (to === "settings") {
@@ -217,6 +226,10 @@ window.addEventListener("DOMContentLoaded", () => {
   linkBudget()?.addEventListener("click", (e) => {
     e.preventDefault();
     navigate("budget");
+  });
+  linkNotes()?.addEventListener("click", (e) => {
+    e.preventDefault();
+    navigate("notes");
   });
   linkSettings()?.addEventListener("click", (e) => {
     e.preventDefault();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -171,3 +171,41 @@ button {
     color: $color-white;
   }
 }
+
+.notes-canvas {
+  position: relative;
+  min-height: 300px;
+}
+
+.note {
+  position: absolute;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.note.dragging {
+  cursor: grabbing;
+}
+
+.note textarea {
+  border: none;
+  background: transparent;
+  resize: none;
+  width: 100px;
+  height: 100px;
+  font: inherit;
+  outline: none;
+}
+
+.note button.delete {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add Notes view for creating, editing, and deleting colored notes
- persist notes to Tauri local filesystem
- integrate Notes into navigation and router with pointer-based dragging and debounced saves
- document Notes view in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@tauri-apps/plugin-opener' and related Tauri modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b472b7b2d0832abce7c40a1c14b7ac