### PR TITLE
feat: set minimum window size

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,9 @@
       {
         "title": "arklowdun",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "minWidth": 600,
+        "minHeight": 400
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary
- add minimum window size constraints to the Tauri config

## Testing
- `npm install`
- `npm run tauri build` *(fails: Property 'open' does not exist on type 'typeof import("@tauri-apps/plugin-opener")')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a92a4094832aa640c6cdc98882ac