### PR TITLE
Ensure app fills viewport and match window background

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
       {
         "title": "arklowdun",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "backgroundColor": "#ffffffff"
       }
     ],
     "security": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -31,10 +31,36 @@ $color-white: #ffffff;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
 }
+/* 1) Make the document able to match the viewport */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%; // lets 100% height descendants work
+  background: inherit; // keeps existing colour system; removes “edge” gaps
+}
 
+/* 4) Optional: avoid micro scrollbars during rapid resize */
 body {
   display: flex;
   margin: 0;
+  overflow: hidden; // switch to 'auto' if you need full-page scroll
+}
+
+/* 2) Ensure your app root always covers the viewport */
+#app {
+  min-height: 100vh; // desktop Tauri: vh is fine
+  min-width: 100vw;
+  display: flex; // if you already use flex, keep it; otherwise harmless
+  flex-direction: column;
+}
+
+/* 3) The primary content area should absorb extra space cleanly */
+#content,
+main {
+  flex: 1 1 auto;
+  min-height: 0; // critical: prevents flex children forcing overflow gaps
+  overflow: auto; // or 'hidden' if you manage internal scrolls
 }
 
 .container {


### PR DESCRIPTION
## Summary
- Ensure `html`, `body`, and the app root cover the viewport and prevent overflow gaps
- Sync Tauri window background with the app's background color

## Testing
- `npm install`
- `npm run build` *(fails: Property 'open' does not exist on type ...)*


------
https://chatgpt.com/codex/tasks/task_e_68b4af673da4832a9e4c63f9eb6d548c