### PR TITLE
Use backend command for default household id

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,11 @@ fn delete_event(app: tauri::AppHandle, state: tauri::State<state::AppState>, id:
     write_events(&app, &events)
 }
 
+#[tauri::command]
+fn get_default_household_id(state: tauri::State<state::AppState>) -> String {
+    state.default_household_id.clone()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -181,7 +186,8 @@ pub fn run() {
             get_events,
             add_event,
             update_event,
-            delete_event
+            delete_event,
+            get_default_household_id
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/BillsView.ts
+++ b/src/BillsView.ts
@@ -62,7 +62,8 @@ async function loadBills(): Promise<Bill[]> {
     });
     if (changed) await saveBills(arr as Bill[]);
     return arr as Bill[];
-  } catch {
+  } catch (e) {
+    console.error("loadBills failed:", e);
     return [];
   }
 }

--- a/src/FamilyView.ts
+++ b/src/FamilyView.ts
@@ -36,7 +36,8 @@ async function loadMembers(): Promise<FamilyMember[]> {
     });
     if (changed) await saveMembers(arr as FamilyMember[]);
     return arr as FamilyMember[];
-  } catch {
+  } catch (e) {
+    console.error("loadMembers failed:", e);
     return [];
   }
 }

--- a/src/InsuranceView.ts
+++ b/src/InsuranceView.ts
@@ -62,7 +62,8 @@ async function loadPolicies(): Promise<Policy[]> {
     });
     if (changed) await savePolicies(arr as Policy[]);
     return arr as Policy[];
-  } catch {
+  } catch (e) {
+    console.error("loadPolicies failed:", e);
     return [];
   }
 }

--- a/src/InventoryView.ts
+++ b/src/InventoryView.ts
@@ -56,7 +56,8 @@ async function loadItems(): Promise<InventoryItem[]> {
     });
     if (changed) await saveItems(arr as InventoryItem[]);
     return arr as InventoryItem[];
-  } catch {
+  } catch (e) {
+    console.error("loadItems failed:", e);
     return [];
   }
 }

--- a/src/PetsView.ts
+++ b/src/PetsView.ts
@@ -62,7 +62,8 @@ async function loadPets(): Promise<Pet[]> {
     });
     if (changed) await savePets(arr as Pet[]);
     return arr as Pet[];
-  } catch {
+  } catch (e) {
+    console.error("loadPets failed:", e);
     return [];
   }
 }

--- a/src/PropertyView.ts
+++ b/src/PropertyView.ts
@@ -58,7 +58,8 @@ async function loadDocuments(): Promise<PropertyDocument[]> {
     });
     if (changed) await saveDocuments(arr as PropertyDocument[]);
     return arr as PropertyDocument[];
-  } catch {
+  } catch (e) {
+    console.error("loadDocuments failed:", e);
     return [];
   }
 }

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -76,7 +76,8 @@ async function loadVehicles(): Promise<Vehicle[]> {
     });
     if (changed) await saveVehicles(arr as Vehicle[]);
     return arr as Vehicle[];
-  } catch {
+  } catch (e) {
+    console.error("loadVehicles failed:", e);
     return [];
   }
 }

--- a/src/db/household.ts
+++ b/src/db/household.ts
@@ -1,20 +1,10 @@
-import { openDb } from "./open";
-import { newUuidV7 } from "./id";
-import { nowMs } from "./time";
+import { invoke } from "@tauri-apps/api/core";
 
 export async function defaultHouseholdId(): Promise<string> {
-  const db = await openDb();
-  const rows = await db.select<{ id: string }[]>(
-    "SELECT id FROM household LIMIT 1",
-    []
-  );
-  if (rows.length > 0) return rows[0].id;
-
-  const id = newUuidV7();
-  const now = nowMs();
-  await db.execute(
-    "INSERT INTO household (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
-    [id, "Default", now, now]
-  );
-  return id;
+  try {
+    return await invoke<string>("get_default_household_id");
+  } catch (e) {
+    console.warn("Household id lookup failed; using fallback", e);
+    return "default";
+  }
 }


### PR DESCRIPTION
## Summary
- expose `get_default_household_id` command from backend and register handler
- call the command from `defaultHouseholdId` with a safe fallback
- log errors in data loaders instead of silently returning empty lists

## Testing
- `npm run build`
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68f5ff86c832aac866e106f6008df