### PR TITLE
Add position columns and ordering utilities

### DIFF
--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -49,6 +49,17 @@ Soft deletion and restoration are exposed via Tauri commands:
 and toggle `deleted_at`. Deleting the current default household returns the
 replacement id so callers can refresh local state.
 
+## Ordering
+
+Some domain tables maintain a user-defined ordering using a `position INTEGER`
+column that defaults to `0`. Rows are unique per household and position via a
+partial `(household_id, position)` index that ignores soft-deleted rows.
+Repository helpers provide a `renumber_positions` routine which compacts
+positions starting from zero, and reordering helpers run inside database
+transactions to ensure consistency. To avoid unique-index conflicts during
+reorders, active rows are first shifted out of the way before applying new
+positions. Queries that return ordered data should sort by `position, created_at`.
+
 ## Generating IDs
 
 ```ts

--- a/migrations/202509020900_add_positions.sql
+++ b/migrations/202509020900_add_positions.sql
@@ -1,0 +1,122 @@
+-- id: 202509020900_add_positions
+-- checksum: a619c37adf7207c53c6a5f17bcb0334ee405708caa7b6892d301427cd3296836
+
+BEGIN;
+
+-- 1) Add columns (no index yet)
+ALTER TABLE bills              ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE policies           ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE property_documents ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE inventory_items    ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE vehicles           ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE pets               ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE family_members     ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE budget_categories  ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+-- 2) Backfill positions per household, compacting from 0
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM bills
+  WHERE deleted_at IS NULL
+)
+UPDATE bills
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = bills.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM policies
+  WHERE deleted_at IS NULL
+)
+UPDATE policies
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = policies.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM property_documents
+  WHERE deleted_at IS NULL
+)
+UPDATE property_documents
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = property_documents.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM inventory_items
+  WHERE deleted_at IS NULL
+)
+UPDATE inventory_items
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = inventory_items.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM vehicles
+  WHERE deleted_at IS NULL
+)
+UPDATE vehicles
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = vehicles.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM pets
+  WHERE deleted_at IS NULL
+)
+UPDATE pets
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = pets.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM family_members
+  WHERE deleted_at IS NULL
+)
+UPDATE family_members
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = family_members.id)
+WHERE id IN (SELECT id FROM ordered);
+
+WITH ordered AS (
+  SELECT id,
+         ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY created_at, id) - 1 AS new_pos
+  FROM budget_categories
+  WHERE deleted_at IS NULL
+)
+UPDATE budget_categories
+SET position = (SELECT new_pos FROM ordered WHERE ordered.id = budget_categories.id)
+WHERE id IN (SELECT id FROM ordered);
+
+-- 3) Partial unique indexes (ignore soft-deleted rows)
+CREATE UNIQUE INDEX IF NOT EXISTS bills_household_position_idx
+  ON bills(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS policies_household_position_idx
+  ON policies(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS property_documents_household_position_idx
+  ON property_documents(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS inventory_items_household_position_idx
+  ON inventory_items(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS vehicles_household_position_idx
+  ON vehicles(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pets_household_position_idx
+  ON pets(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS family_members_household_position_idx
+  ON family_members(household_id, position) WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS budget_categories_household_position_idx
+  ON budget_categories(household_id, position) WHERE deleted_at IS NULL;
+
+COMMIT;

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -20,6 +20,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
         "202509020800_add_deleted_at.sql",
         include_str!("../../migrations/202509020800_add_deleted_at.sql"),
     ),
+    (
+        "202509020900_add_positions.sql",
+        include_str!("../../migrations/202509020900_add_positions.sql"),
+    ),
 ];
 
 pub async fn init_db(app: &AppHandle) -> anyhow::Result<SqlitePool> {

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -1,4 +1,4 @@
-use sqlx::SqlitePool;
+use sqlx::{Executor, SqlitePool};
 
 use crate::time::now_ms;
 
@@ -56,3 +56,74 @@ pub async fn clear_deleted_at(pool: &SqlitePool, table: &str, id: &str) -> anyho
     }
     Ok(())
 }
+
+
+pub async fn renumber_positions<'a, E>(
+    exec: E,
+    table: &str,
+    household_id: &str,
+) -> anyhow::Result<()>
+where
+    E: Executor<'a, Database = sqlx::Sqlite>,
+{
+    ensure_table(table)?;
+    let sql = format!(
+        r#"
+        WITH ordered AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (ORDER BY position, created_at, id) - 1 AS new_pos
+            FROM {table}
+            WHERE household_id = ? AND deleted_at IS NULL
+        )
+        UPDATE {table}
+        SET position = (
+            SELECT new_pos FROM ordered WHERE ordered.id = {table}.id
+        )
+        WHERE id IN (SELECT id FROM ordered)
+        "#
+    );
+    sqlx::query(&sql).bind(household_id).execute(exec).await?;
+    Ok(())
+}
+
+pub async fn reorder_positions(
+    pool: &SqlitePool,
+    table: &str,
+    household_id: &str,
+    updates: &[(String, i64)],
+) -> anyhow::Result<()> {
+    ensure_table(table)?;
+    let mut tx = pool.begin().await?;
+    let now = now_ms();
+
+    let bump_sql = format!(
+        "UPDATE {table} \
+         SET position = position + 1000000, updated_at = ? \
+         WHERE household_id = ? AND deleted_at IS NULL",
+    );
+    sqlx::query(&bump_sql)
+        .bind(now)
+        .bind(household_id)
+        .execute(&mut *tx)
+        .await?;
+
+    let update_sql = format!(
+        "UPDATE {table} \
+         SET position = ?, updated_at = ? \
+         WHERE id = ? AND household_id = ?",
+    );
+    for (id, pos) in updates {
+        sqlx::query(&update_sql)
+            .bind(pos)
+            .bind(now)
+            .bind(id)
+            .bind(household_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    renumber_positions(&mut *tx, table, household_id).await?;
+    tx.commit().await?;
+    Ok(())
+}
+

--- a/src/BillsView.ts
+++ b/src/BillsView.ts
@@ -79,9 +79,14 @@ async function loadBills(): Promise<Bill[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await saveBills(arr as Bill[]);
     return arr as Bill[];
   } catch (e) {
@@ -175,6 +180,7 @@ export async function BillsView(container: HTMLElement) {
       due_date: dueTs,
       document: docInput.value,
       reminder,
+      position: bills.length,
       household_id: await defaultHouseholdId(),
       created_at: now,
       updated_at: now,

--- a/src/BudgetView.ts
+++ b/src/BudgetView.ts
@@ -53,6 +53,10 @@ async function loadData(): Promise<BudgetData> {
           c.household_id = hh;
           changed = true;
         }
+        if (typeof c.position !== 'number') {
+          c.position = 0;
+          changed = true;
+        }
         if ("deletedAt" in c) {
           c.deleted_at = c.deletedAt;
           delete c.deletedAt;
@@ -61,6 +65,7 @@ async function loadData(): Promise<BudgetData> {
         return c;
       })
       .filter((c: any) => c.deleted_at == null);
+    data.categories.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     data.expenses = data.expenses
       .map((e: any) => {
         let id = e.id;
@@ -232,6 +237,7 @@ export async function BudgetView(container: HTMLElement) {
       id: newUuidV7(),
       name: catName.value,
       monthly_budget: Number(catBudget.value),
+      position: data.categories.length,
       household_id: await defaultHouseholdId(),
       created_at: now,
       updated_at: now,

--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -79,6 +79,10 @@ async function loadJson<T>(file: string): Promise<T[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       if ("deletedAt" in i) {
         (i as any).deleted_at = i.deletedAt;
         delete i.deletedAt;
@@ -87,6 +91,7 @@ async function loadJson<T>(file: string): Promise<T[]> {
       return i as T;
     });
     arr = arr.filter((i: any) => (i as any).deleted_at == null);
+    arr.sort((a: any, b: any) => (a as any).position - (b as any).position || (a as any).created_at - (b as any).created_at);
     if (changed) {
       await writeTextFile(p, JSON.stringify(arr), { baseDir: BaseDirectory.AppLocalData });
     }

--- a/src/FamilyView.ts
+++ b/src/FamilyView.ts
@@ -40,6 +40,10 @@ async function loadMembers(): Promise<FamilyMember[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       if ("deletedAt" in i) {
         i.deleted_at = i.deletedAt;
         delete i.deletedAt;
@@ -48,6 +52,7 @@ async function loadMembers(): Promise<FamilyMember[]> {
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await saveMembers(arr as FamilyMember[]);
     return arr as FamilyMember[];
   } catch (e) {
@@ -120,6 +125,7 @@ export async function FamilyView(container: HTMLElement) {
         birthday: bday.getTime(),
         notes: "",
         documents: [],
+        position: members.length,
         household_id: await defaultHouseholdId(),
         created_at: now,
         updated_at: now,

--- a/src/InsuranceView.ts
+++ b/src/InsuranceView.ts
@@ -74,6 +74,10 @@ async function loadPolicies(): Promise<Policy[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       if ("deletedAt" in i) {
         i.deleted_at = i.deletedAt;
         delete i.deletedAt;
@@ -82,6 +86,7 @@ async function loadPolicies(): Promise<Policy[]> {
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await savePolicies(arr as Policy[]);
     return arr as Policy[];
   } catch (e) {
@@ -173,6 +178,7 @@ export async function InsuranceView(container: HTMLElement) {
       due_date: dueTs,
       document: docInput.value,
       reminder,
+      position: policies.length,
       household_id: await defaultHouseholdId(),
       created_at: now,
       updated_at: now,

--- a/src/InventoryView.ts
+++ b/src/InventoryView.ts
@@ -76,6 +76,10 @@ async function loadItems(): Promise<InventoryItem[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       if ("deletedAt" in i) {
         i.deleted_at = i.deletedAt;
         delete i.deletedAt;
@@ -84,6 +88,7 @@ async function loadItems(): Promise<InventoryItem[]> {
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await saveItems(arr as InventoryItem[]);
     return arr as InventoryItem[];
   } catch (e) {
@@ -182,6 +187,7 @@ export async function InventoryView(container: HTMLElement) {
       warranty_expiry: warrantyLocalNoon.getTime(),
       document: docInput.value,
       reminder,
+      position: items.length,
       household_id: await defaultHouseholdId(),
       created_at: now,
       updated_at: now,

--- a/src/PetsView.ts
+++ b/src/PetsView.ts
@@ -94,9 +94,14 @@ async function loadPets(): Promise<Pet[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await savePets(arr as Pet[]);
     return arr as Pet[];
   } catch (e) {
@@ -183,6 +188,7 @@ export async function PetsView(container: HTMLElement) {
         name: nameInput.value,
         type: typeInput.value,
         medical: [],
+        position: pets.length,
         household_id: await defaultHouseholdId(),
         created_at: now,
         updated_at: now,

--- a/src/PropertyView.ts
+++ b/src/PropertyView.ts
@@ -70,6 +70,10 @@ async function loadDocuments(): Promise<PropertyDocument[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       if ("deletedAt" in i) {
         i.deleted_at = i.deletedAt;
         delete i.deletedAt;
@@ -78,6 +82,7 @@ async function loadDocuments(): Promise<PropertyDocument[]> {
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await saveDocuments(arr as PropertyDocument[]);
     return arr as PropertyDocument[];
   } catch (e) {
@@ -192,6 +197,7 @@ export async function PropertyView(container: HTMLElement) {
       renewal_date: dueTs,
       document: docInput.value,
       reminder,
+      position: docs.length,
       household_id: await defaultHouseholdId(),
       created_at: now,
       updated_at: now,

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -140,9 +140,14 @@ async function loadVehicles(): Promise<Vehicle[]> {
         i.household_id = hh;
         changed = true;
       }
+      if (typeof i.position !== 'number') {
+        i.position = 0;
+        changed = true;
+      }
       return i;
     });
     arr = arr.filter((i: any) => i.deleted_at == null);
+    arr.sort((a: any, b: any) => a.position - b.position || a.created_at - b.created_at);
     if (changed) await saveVehicles(arr as Vehicle[]);
     return arr as Vehicle[];
   } catch (e) {
@@ -274,6 +279,7 @@ export async function VehiclesView(container: HTMLElement) {
         mot_reminder: motReminder,
         service_reminder: serviceReminder,
         maintenance: [],
+        position: vehicles.length,
         household_id: await defaultHouseholdId(),
         created_at: now,
         updated_at: now,

--- a/src/db/position.ts
+++ b/src/db/position.ts
@@ -1,0 +1,51 @@
+import type Database from "@tauri-apps/plugin-sql";
+import { openDb } from "./open";
+import { nowMs } from "./time";
+
+export async function renumberPositions(
+  table: string,
+  householdId: string,
+  db?: Database,
+): Promise<void> {
+  const conn = db ?? (await openDb());
+  await conn.execute(
+    `WITH ordered AS (
+       SELECT id, ROW_NUMBER() OVER (ORDER BY position, created_at, id) - 1 AS new_pos
+       FROM ${table}
+       WHERE household_id = ? AND deleted_at IS NULL
+     )
+     UPDATE ${table}
+     SET position = (SELECT new_pos FROM ordered WHERE ordered.id = ${table}.id)
+     WHERE id IN (SELECT id FROM ordered)`,
+    [householdId]
+  );
+}
+
+export async function reorderPositions(
+  table: string,
+  householdId: string,
+  updates: { id: string; position: number }[],
+): Promise<void> {
+  const db = await openDb();
+  await db.execute("BEGIN");
+  try {
+    const now = nowMs();
+    await db.execute(
+      `UPDATE ${table} SET position = position + 1000000, updated_at = ?
+       WHERE household_id = ? AND deleted_at IS NULL`,
+      [now, householdId],
+    );
+
+    const updateSql = `UPDATE ${table} SET position = ?, updated_at = ?
+      WHERE id = ? AND household_id = ?`;
+    for (const { id, position } of updates) {
+      await db.execute(updateSql, [position, now, id, householdId]);
+    }
+
+    await renumberPositions(table, householdId, db);
+    await db.execute("COMMIT");
+  } catch (e) {
+    await db.execute("ROLLBACK");
+    throw e;
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,6 +5,7 @@ export interface Bill {
   document: string; // file path
   reminder?: number; // timestamp ms
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -17,6 +18,7 @@ export interface Policy {
   document: string; // file path
   reminder?: number; // timestamp ms
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -29,6 +31,7 @@ export interface PropertyDocument {
   document: string; // file path
   reminder?: number; // timestamp ms
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -56,6 +59,7 @@ export interface Vehicle {
   service_reminder?: number; // timestamp ms
   maintenance: MaintenanceEntry[];
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -80,6 +84,7 @@ export interface Pet {
   type: string;
   medical: PetMedicalRecord[];
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -92,6 +97,7 @@ export interface FamilyMember {
   notes: string;
   documents: string[]; // file paths
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -105,6 +111,7 @@ export interface InventoryItem {
   document: string; // file path
   reminder?: number; // timestamp ms
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;
@@ -115,6 +122,7 @@ export interface BudgetCategory {
   name: string;
   monthly_budget: number;
   household_id?: string;
+  position: number;
   created_at: number;
   updated_at: number;
   deleted_at?: number;


### PR DESCRIPTION
## Summary
- backfill unique positions and add partial `(household_id, position)` indexes in migration
- ensure renumber helpers use SQLite-friendly CTEs
- expose `position` field in models and persist/sort ordering in loaders
- document household-position uniqueness and ordering strategy
- shift rows out of the way before reordering to avoid unique index conflicts

## Testing
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b6c814bfa0832abc2d966ad2cad822