### PR TITLE
feat: add scoped helpers for listing active records

### DIFF
--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -49,6 +49,30 @@ Soft deletion and restoration are exposed via Tauri commands:
 and toggle `deleted_at`. Deleting the current default household returns the
 replacement id so callers can refresh local state.
 
+### Listing Active Rows
+
+Repository helpers automatically filter out soft-deleted rows and apply standard ordering.
+
+```ts
+import { listActive, firstActive } from "../src/db/repo";
+
+// Household-scoped listing (recommended)
+const bills = await listActive("bills", { householdId });
+
+// Fetch the first active row
+const firstBill = await firstActive("bills", { householdId });
+```
+
+```rust
+use crate::repo;
+
+// Household-scoped and first row
+if let Some(row) = repo::first_active(&pool, "bills", Some(&household_id), None).await? {
+    let id: String = row.try_get("id")?;
+    // ...
+}
+```
+
 ## Ordering
 
 Some domain tables maintain a user-defined ordering using a `position INTEGER`

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -1,0 +1,85 @@
+const DOMAIN_TABLES = [
+  "household",
+  "events",
+  "bills",
+  "policies",
+  "property_documents",
+  "inventory_items",
+  "vehicles",
+  "vehicle_maintenance",
+  "pets",
+  "pet_medical",
+  "family_members",
+  "budget_categories",
+  "expenses",
+] as const;
+
+type DomainTable = (typeof DOMAIN_TABLES)[number];
+
+const ORDER_MAP: Record<DomainTable, string> = {
+  household: "created_at, id",
+  events: "created_at, id",
+  bills: "position, created_at, id",
+  policies: "position, created_at, id",
+  property_documents: "position, created_at, id",
+  inventory_items: "position, created_at, id",
+  vehicles: "position, created_at, id",
+  vehicle_maintenance: "created_at, id",
+  pets: "position, created_at, id",
+  pet_medical: "created_at, id",
+  family_members: "position, created_at, id",
+  budget_categories: "position, created_at, id",
+  expenses: "created_at, id",
+};
+
+const ALLOWED_ORDERS = new Set(Object.values(ORDER_MAP));
+
+function ensureTable(table: string): void {
+  if (!DOMAIN_TABLES.includes(table as any)) {
+    throw new Error("invalid table");
+  }
+}
+
+export interface ListOptions {
+  householdId?: string;
+  orderBy?: string; // must match one of ALLOWED_ORDERS
+  limit?: number;
+  offset?: number;
+}
+
+import type Database from "@tauri-apps/plugin-sql";
+import { openDb } from "./open";
+
+export async function listActive<T = any>(
+  table: DomainTable,
+  opts: ListOptions = {},
+): Promise<T[]> {
+  ensureTable(table);
+  const db: Database = await openDb();
+  const order =
+    opts.orderBy && ALLOWED_ORDERS.has(opts.orderBy)
+      ? opts.orderBy
+      : ORDER_MAP[table];
+
+  const scoped = table !== "household" && opts.householdId;
+  const where = scoped
+    ? `WHERE deleted_at IS NULL AND household_id = ?`
+    : `WHERE deleted_at IS NULL`;
+
+  const lim = Number.isFinite(opts.limit) ? ` LIMIT ${opts.limit}` : "";
+  const off = Number.isFinite(opts.offset) ? ` OFFSET ${opts.offset}` : "";
+
+  const sql = `SELECT * FROM ${table} ${where} ORDER BY ${order}${lim}${off}`;
+  const params = scoped ? [opts.householdId] : [];
+  return db.select<T[]>(sql, params);
+}
+
+export async function firstActive<T = any>(
+  table: DomainTable,
+  opts: Omit<ListOptions, "limit" | "offset"> = {},
+) {
+  const rows = await listActive<T>(table, { ...opts, limit: 1 });
+  return rows[0];
+}
+
+export { DOMAIN_TABLES };


### PR DESCRIPTION
## Summary
- scope active listing helpers by household and whitelist safe sort orders
- expose `first_active` helper for efficient single-row lookups
- refactor default household lookup to use new helper and document household-scoped usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cargo test --manifest-path src-tauri/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68b6eea2eb78832ab381df9f5e449cf1