### PR TITLE
Persist import ID mapping and wrap import in transaction

### DIFF
--- a/migrations/202509021200_import_id_map.sql
+++ b/migrations/202509021200_import_id_map.sql
@@ -1,0 +1,16 @@
+-- id: 202509021200_import_id_map
+-- checksum: 61d2f4b368e1b7c9ed08ce17f17de6b17ecc119c50c2d0a90e48232d4d535c35
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS import_id_map (
+  entity TEXT NOT NULL,
+  old_id TEXT NOT NULL,
+  new_uuid TEXT NOT NULL,
+  PRIMARY KEY (entity, old_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS import_id_map_new_uuid_idx
+  ON import_id_map(new_uuid);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add `import_id_map` table with unique UUID index
- import tool reads/creates mapping entries before generating new IDs; disables FK checks during insert, validates with `foreign_key_check`, uses `.pluck()` for lookups, and sets a busy timeout
- run entire import process inside a single DB transaction (optional synchronous speed knob)
- skip FK validation on `--dry-run`, drop unknown JSON columns against real table schema, normalize boolean values, summarize reused vs new IDs, assert domain tables before schema introspection, warn with affected row counts, and surface friendlier duplicate-ID errors

## Testing
- `npx tsc -p tsconfig.json && echo 'tsc completed'`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b719706054832ab0124b76cebe7a3c