### PR TITLE
Require explicit household scoping for repository helpers

### DIFF
--- a/docs/integrity-rules.md
+++ b/docs/integrity-rules.md
@@ -61,5 +61,21 @@ All data access must require a `householdId` and include a `household_id`
 filter in SQL. Use `requireHousehold()` at the entry to every repository
 helper to fail fast when the id is missing.
 
+```ts
+import { listActive, firstActive } from "../src/db/repo";
+
+const bills = await listActive("bills", householdId);
+const firstBill = await firstActive("bills", householdId);
+```
+
+```rust
+use crate::repo;
+
+if let Some(row) = repo::first_active(&pool, "bills", &household_id, None).await? {
+    let id: String = row.try_get("id")?;
+    // ...
+}
+```
+
 To obtain a `householdId`, call the `get_default_household_id` command or
 surface a selection flow so the user can choose a household explicitly.

--- a/docs/integrity-rules.md
+++ b/docs/integrity-rules.md
@@ -54,3 +54,12 @@ migrations/202509021300_explicit_fk_actions.sql
 ```
 
 Future schema changes should conform to the guidance above.
+
+## Household Scoping
+
+All data access must require a `householdId` and include a `household_id`
+filter in SQL. Use `requireHousehold()` at the entry to every repository
+helper to fail fast when the id is missing.
+
+To obtain a `householdId`, call the `get_default_household_id` command or
+surface a selection flow so the user can choose a household explicitly.

--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -56,18 +56,18 @@ Repository helpers automatically filter out soft-deleted rows and apply standard
 ```ts
 import { listActive, firstActive } from "../src/db/repo";
 
-// Household-scoped listing (recommended)
-const bills = await listActive("bills", { householdId });
+// Household-scoped listing (required)
+const bills = await listActive("bills", householdId);
 
 // Fetch the first active row
-const firstBill = await firstActive("bills", { householdId });
+const firstBill = await firstActive("bills", householdId);
 ```
 
 ```rust
 use crate::repo;
 
 // Household-scoped and first row
-if let Some(row) = repo::first_active(&pool, "bills", Some(&household_id), None).await? {
+if let Some(row) = repo::first_active(&pool, "bills", &household_id, None).await? {
     let id: String = row.try_get("id")?;
     // ...
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "migrate:checksum": "node --loader ts-node/esm scripts/migrate-checksum.ts",
     "check:migrations": "bash scripts/check-migrations.sh",
     "check:household": "bash scripts/check-household-scope.sh",
-    "test": "node --loader ts-node/esm --test tests/*.ts"
+    "test": "node --loader ts-node/esm --test tests/*.ts",
+    "lint:rs": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "migrate:checksum": "node --loader ts-node/esm scripts/migrate-checksum.ts",
-    "check:migrations": "bash scripts/check-migrations.sh"
+    "check:migrations": "bash scripts/check-migrations.sh",
+    "check:household": "bash scripts/check-household-scope.sh",
+    "test": "node --loader ts-node/esm --test tests/*.ts"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/scripts/check-household-scope.sh
+++ b/scripts/check-household-scope.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+# Tables that must always be scoped by household_id
+pattern='events|bills|policies|property_documents|inventory_items|vehicles|vehicle_maintenance|pets|pet_medical|family_members|budget_categories|expenses'
+# Find files with SQL touching domain tables (excluding migrations)
+files=$(rg -i "(from|update|into)\s+(${pattern})" -l --glob '!migrations/*' || true)
+failed=0
+for f in $files; do
+  if ! rg -i "household_id" "$f" >/dev/null; then
+    echo "Missing household_id in $f"
+    failed=1
+  fi
+done
+exit $failed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
+ "tokio",
  "uuid",
 ]
 
@@ -4722,8 +4723,20 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "socket2",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
 anyhow = "1"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+

--- a/src-tauri/src/household.rs
+++ b/src-tauri/src/household.rs
@@ -1,11 +1,11 @@
 use sqlx::{Row, SqlitePool};
 
 use crate::id::new_uuid_v7;
-use crate::repo;
+use crate::repo::{self, admin};
 use crate::time::now_ms;
 
 pub async fn default_household_id(pool: &SqlitePool) -> anyhow::Result<String> {
-    if let Some(row) = repo::first_active(pool, "household", None, None).await? {
+    if let Some(row) = admin::first_active_for_all_households(pool, "household", None).await? {
         let id: String = row.try_get("id")?;
         return Ok(id);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,6 @@
 use serde::{Deserialize, Serialize};
 use std::{fs, path::PathBuf, sync::{Arc, Mutex}};
 use tauri::{Manager, State};
-use tauri_plugin_sql;
 
 use crate::state::AppState;
 
@@ -214,7 +213,7 @@ pub fn run() {
         .plugin(tauri_plugin_sql::Builder::default().build())
         .setup(|app| {
             let handle = app.handle();
-            let pool = tauri::async_runtime::block_on(crate::migrate::init_db(&handle))?;
+            let pool = tauri::async_runtime::block_on(crate::migrate::init_db(handle))?;
             let hh = tauri::async_runtime::block_on(crate::household::default_household_id(&pool))?;
             app.manage(crate::state::AppState { pool: pool.clone(), default_household_id: Arc::new(Mutex::new(hh)) });
             Ok(())

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -201,8 +201,8 @@ where
     Ok(())
 }
 
-#[allow(dead_code)]
-pub async fn reorder_positions(
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn reorder_positions(
     pool: &SqlitePool,
     table: &str,
     household_id: &str,
@@ -248,7 +248,8 @@ pub mod admin {
     use super::*;
     use sqlx::sqlite::SqliteRow;
 
-    pub async fn list_active_for_all_households(
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) async fn list_active_for_all_households(
         pool: &SqlitePool,
         table: &str,
         order_by: Option<&str>,
@@ -283,7 +284,7 @@ pub mod admin {
         Ok(rows)
     }
 
-    pub async fn first_active_for_all_households(
+    pub(crate) async fn first_active_for_all_households(
         pool: &SqlitePool,
         table: &str,
         order_by: Option<&str>,

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -47,7 +47,10 @@ fn require_household(id: &str) -> anyhow::Result<&str> {
 
 const ALLOWED_ORDERS: &[&str] = &["position, created_at, id", "created_at, id"];
 
-pub async fn list_active(
+// Intentionally kept for test coverage of household scoping.
+// Suppress dead_code in non-test builds.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn list_active(
     pool: &SqlitePool,
     table: &str,
     household_id: &str,
@@ -91,7 +94,10 @@ pub async fn list_active(
     Ok(rows)
 }
 
-pub async fn first_active(
+// Intentionally kept for test coverage of household scoping.
+// Suppress dead_code in non-test builds.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn first_active(
     pool: &SqlitePool,
     table: &str,
     household_id: &str,

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -37,17 +37,26 @@ fn ensure_table(table: &str) -> anyhow::Result<()> {
     }
 }
 
+fn require_household(id: &str) -> anyhow::Result<&str> {
+    if id.is_empty() {
+        Err(anyhow::anyhow!("household_id required"))
+    } else {
+        Ok(id)
+    }
+}
+
 const ALLOWED_ORDERS: &[&str] = &["position, created_at, id", "created_at, id"];
 
 pub async fn list_active(
     pool: &SqlitePool,
     table: &str,
-    household_id: Option<&str>,
+    household_id: &str,
     order_by: Option<&str>,
     limit: Option<i64>,
     offset: Option<i64>,
 ) -> anyhow::Result<Vec<sqlx::sqlite::SqliteRow>> {
     ensure_table(table)?;
+    let household_id = require_household(household_id)?;
     let default_order = if ORDERED_TABLES.contains(&table) {
         "position, created_at, id"
     } else {
@@ -57,15 +66,12 @@ pub async fn list_active(
         .filter(|ob| ALLOWED_ORDERS.contains(ob))
         .unwrap_or(default_order);
 
-    let scoped = table != "household" && household_id.is_some();
-    let mut sql = format!(
-        "SELECT * FROM {table} {} ORDER BY {order}",
-        if scoped {
-            "WHERE deleted_at IS NULL AND household_id = ?"
-        } else {
-            "WHERE deleted_at IS NULL"
-        }
-    );
+    let where_clause = if table == "household" {
+        "WHERE deleted_at IS NULL AND id = ?"
+    } else {
+        "WHERE deleted_at IS NULL AND household_id = ?"
+    };
+    let mut sql = format!("SELECT * FROM {table} {where_clause} ORDER BY {order}");
     if limit.is_some() {
         sql.push_str(" LIMIT ?");
     }
@@ -73,10 +79,7 @@ pub async fn list_active(
         sql.push_str(" OFFSET ?");
     }
 
-    let mut query = sqlx::query(&sql);
-    if scoped {
-        query = query.bind(household_id.unwrap());
-    }
+    let mut query = sqlx::query(&sql).bind(household_id);
     if let Some(l) = limit {
         query = query.bind(l);
     }
@@ -91,9 +94,10 @@ pub async fn list_active(
 pub async fn first_active(
     pool: &SqlitePool,
     table: &str,
-    household_id: Option<&str>,
+    household_id: &str,
     order_by: Option<&str>,
 ) -> anyhow::Result<Option<sqlx::sqlite::SqliteRow>> {
+    let household_id = require_household(household_id)?;
     let mut rows = list_active(pool, table, household_id, order_by, Some(1), None).await?;
     Ok(rows.pop())
 }
@@ -105,6 +109,7 @@ pub async fn set_deleted_at(
     id: &str,
 ) -> anyhow::Result<()> {
     ensure_table(table)?;
+    let household_id = require_household(household_id)?;
     let now = now_ms();
     let res = if table == "household" {
         let sql = format!("UPDATE {table} SET deleted_at = ?, updated_at = ? WHERE id = ?");
@@ -142,6 +147,7 @@ pub async fn clear_deleted_at(
     id: &str,
 ) -> anyhow::Result<()> {
     ensure_table(table)?;
+    let household_id = require_household(household_id)?;
     let now = now_ms();
     let res = if table == "household" {
         let sql = format!("UPDATE {table} SET deleted_at = NULL, updated_at = ? WHERE id = ?");
@@ -175,6 +181,7 @@ where
     E: Executor<'a, Database = sqlx::Sqlite>,
 {
     ensure_table(table)?;
+    let household_id = require_household(household_id)?;
     let sql = format!(
         r#"
         WITH ordered AS (
@@ -202,6 +209,7 @@ pub async fn reorder_positions(
     updates: &[(String, i64)],
 ) -> anyhow::Result<()> {
     ensure_table(table)?;
+    let household_id = require_household(household_id)?;
     let mut tx = pool.begin().await?;
     let now = now_ms();
 
@@ -234,4 +242,104 @@ pub async fn reorder_positions(
     renumber_positions(&mut *tx, table, household_id).await?;
     tx.commit().await?;
     Ok(())
+}
+
+pub mod admin {
+    use super::*;
+    use sqlx::sqlite::SqliteRow;
+
+    pub async fn list_active_for_all_households(
+        pool: &SqlitePool,
+        table: &str,
+        order_by: Option<&str>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> anyhow::Result<Vec<SqliteRow>> {
+        ensure_table(table)?;
+        let default_order = if ORDERED_TABLES.contains(&table) {
+            "position, created_at, id"
+        } else {
+            "created_at, id"
+        };
+        let order = order_by
+            .filter(|ob| ALLOWED_ORDERS.contains(ob))
+            .unwrap_or(default_order);
+        let mut sql =
+            format!("SELECT * FROM {table} WHERE deleted_at IS NULL ORDER BY {order}");
+        if limit.is_some() {
+            sql.push_str(" LIMIT ?");
+        }
+        if offset.is_some() {
+            sql.push_str(" OFFSET ?");
+        }
+        let mut query = sqlx::query(&sql);
+        if let Some(l) = limit {
+            query = query.bind(l);
+        }
+        if let Some(o) = offset {
+            query = query.bind(o);
+        }
+        let rows = query.fetch_all(pool).await?;
+        Ok(rows)
+    }
+
+    pub async fn first_active_for_all_households(
+        pool: &SqlitePool,
+        table: &str,
+        order_by: Option<&str>,
+    ) -> anyhow::Result<Option<SqliteRow>> {
+        let mut rows =
+            list_active_for_all_households(pool, table, order_by, Some(1), None).await?;
+        Ok(rows.pop())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn setup_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE events (id TEXT PRIMARY KEY, household_id TEXT NOT NULL, deleted_at INTEGER, created_at INTEGER, updated_at INTEGER)"
+        ).execute(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn missing_household_id_errors() {
+        let pool = setup_db().await;
+        let err = list_active(&pool, "events", "", None, None, None).await.unwrap_err();
+        assert!(err.to_string().contains("household_id"));
+    }
+
+    #[tokio::test]
+    async fn cross_household_isolation() {
+        let pool = setup_db().await;
+        sqlx::query("INSERT INTO events (id, household_id, created_at, updated_at) VALUES ('a', 'A', 0, 0), ('b', 'B', 0, 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let rows_a = list_active(&pool, "events", "A", None, None, None).await.unwrap();
+        assert_eq!(rows_a.len(), 1);
+        let id_a: String = rows_a[0].try_get("id").unwrap();
+        assert_eq!(id_a, "a");
+
+        let rows_b = list_active(&pool, "events", "B", None, None, None).await.unwrap();
+        assert_eq!(rows_b.len(), 1);
+        let id_b: String = rows_b[0].try_get("id").unwrap();
+        assert_eq!(id_b, "b");
+    }
+
+    #[tokio::test]
+    async fn smoke_with_valid_household() {
+        let pool = setup_db().await;
+        sqlx::query("INSERT INTO events (id, household_id, created_at, updated_at) VALUES ('a', 'A', 0, 0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let rows = list_active(&pool, "events", "A", None, None, None).await.unwrap();
+        assert_eq!(rows.len(), 1);
+    }
 }

--- a/src-tauri/src/time.rs
+++ b/src-tauri/src/time.rs
@@ -5,8 +5,8 @@ pub fn now_ms() -> i64 {
 }
 
 // Keep for parity with TS docs; we don’t call it in Rust paths (yet).
-#[allow(dead_code)]
-pub fn to_date(ms: i64) -> DateTime<Utc> {
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn to_date(ms: i64) -> DateTime<Utc> {
     // from_timestamp_millis returns Option<DateTime<Utc>>
     DateTime::<Utc>::from_timestamp_millis(ms)
         .unwrap_or_else(|| DateTime::<Utc>::from_timestamp_millis(0).unwrap())

--- a/src/db/household.ts
+++ b/src/db/household.ts
@@ -8,3 +8,8 @@ export async function defaultHouseholdId(): Promise<string> {
     return "default";
   }
 }
+
+export function requireHousehold(householdId: string): string {
+  if (!householdId) throw new Error("householdId required");
+  return householdId;
+}

--- a/src/db/position.ts
+++ b/src/db/position.ts
@@ -1,12 +1,14 @@
 import type Database from "@tauri-apps/plugin-sql";
 import { openDb } from "./open";
 import { nowMs } from "./time";
+import { requireHousehold } from "./household";
 
 export async function renumberPositions(
   table: string,
   householdId: string,
   db?: Database,
 ): Promise<void> {
+  const hh = requireHousehold(householdId);
   const conn = db ?? (await openDb());
   await conn.execute(
     `WITH ordered AS (
@@ -17,7 +19,7 @@ export async function renumberPositions(
      UPDATE ${table}
      SET position = (SELECT new_pos FROM ordered WHERE ordered.id = ${table}.id)
      WHERE id IN (SELECT id FROM ordered)`,
-    [householdId]
+    [hh]
   );
 }
 
@@ -26,6 +28,7 @@ export async function reorderPositions(
   householdId: string,
   updates: { id: string; position: number }[],
 ): Promise<void> {
+  const hh = requireHousehold(householdId);
   const db = await openDb();
   await db.execute("BEGIN");
   try {
@@ -33,16 +36,16 @@ export async function reorderPositions(
     await db.execute(
       `UPDATE ${table} SET position = position + 1000000, updated_at = ?
        WHERE household_id = ? AND deleted_at IS NULL`,
-      [now, householdId],
+      [now, hh],
     );
 
     const updateSql = `UPDATE ${table} SET position = ?, updated_at = ?
       WHERE id = ? AND household_id = ?`;
     for (const { id, position } of updates) {
-      await db.execute(updateSql, [position, now, id, householdId]);
+      await db.execute(updateSql, [position, now, id, hh]);
     }
 
-    await renumberPositions(table, householdId, db);
+    await renumberPositions(table, hh, db);
     await db.execute("COMMIT");
   } catch (e) {
     await db.execute("ROLLBACK");

--- a/tests/requireHousehold.test.ts
+++ b/tests/requireHousehold.test.ts
@@ -1,0 +1,13 @@
+import { requireHousehold } from "../src/db/household.ts";
+import assert from "node:assert";
+import test from "node:test";
+
+test("requireHousehold rejects falsy ids", () => {
+  for (const v of [undefined, null, ""] as any[]) {
+    assert.throws(() => requireHousehold(v), /householdId required/);
+  }
+});
+
+test("requireHousehold returns id", () => {
+  assert.equal(requireHousehold("abc"), "abc");
+});


### PR DESCRIPTION
## Summary
- require `householdId` for all repository helpers and add `requireHousehold` guard
- scope every SQL query by `household_id` and provide admin-only helpers
- document household scoping rules and add lint script and tests

## Testing
- `npm test`
- `npm run check:household`
- `npm run check:migrations`
- `cargo test` *(fails: `The system library `libsoup-3.0` required by crate `soup3-sys` was not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68b7f31e2d1c832ab0f13287d994af56