### PR TITLE
Add z-index layering and bring-to-front support for notes

### DIFF
--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -86,7 +86,7 @@ transactions to ensure consistency. To avoid unique-index conflicts during
 reorders, active rows are first shifted out of the way before applying new
 positions. Soft-delete helpers also invoke this compaction to keep active rows
 dense from zero. Queries that return ordered data should sort by `position, created_at`.
-Notes additionally sort by `z, position, created_at` so higher `z` values appear on top.
+Notes additionally sort by `z DESC, position, created_at` so higher `z` values appear on top.
 
 Notes currently persist to local JSON (file-backed). A DB helper (`bring_note_to_front`) exists for the future SQLite migration; it's intentionally unused in runtime builds.
 

--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -88,6 +88,8 @@ positions. Soft-delete helpers also invoke this compaction to keep active rows
 dense from zero. Queries that return ordered data should sort by `position, created_at`.
 Notes additionally sort by `z, position, created_at` so higher `z` values appear on top.
 
+Notes currently persist to local JSON (file-backed). A DB helper (`bring_note_to_front`) exists for the future SQLite migration; it's intentionally unused in runtime builds.
+
 ## Generating IDs
 
 ```ts

--- a/docs/storage-conventions.md
+++ b/docs/storage-conventions.md
@@ -86,6 +86,7 @@ transactions to ensure consistency. To avoid unique-index conflicts during
 reorders, active rows are first shifted out of the way before applying new
 positions. Soft-delete helpers also invoke this compaction to keep active rows
 dense from zero. Queries that return ordered data should sort by `position, created_at`.
+Notes additionally sort by `z, position, created_at` so higher `z` values appear on top.
 
 ## Generating IDs
 

--- a/migrations/202509021410_notes_z_index.sql
+++ b/migrations/202509021410_notes_z_index.sql
@@ -1,0 +1,9 @@
+-- id: 202509021410_notes_z_index
+-- checksum: 4c79b39e4e183abd644cf2008d71eb15d2698bcb35a12c10ea275d970c391c56
+
+BEGIN;
+
+ALTER TABLE notes ADD COLUMN z INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS notes_scope_z_idx ON notes(household_id, deleted_at, z, position);
+
+COMMIT;

--- a/migrations/202509021410_notes_z_index.sql
+++ b/migrations/202509021410_notes_z_index.sql
@@ -1,5 +1,5 @@
 -- id: 202509021410_notes_z_index
--- checksum: 4c79b39e4e183abd644cf2008d71eb15d2698bcb35a12c10ea275d970c391c56
+-- checksum: 37d22b4c1529ebabe3953b2202862effdbd2e13a829f0c337b0adeec71ae2f5a
 
 BEGIN;
 

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -44,6 +44,10 @@ static MIGRATIONS: &[(&str, &str)] = &[
         "202509021400_soft_delete_notes_shopping.sql",
         include_str!("../../migrations/202509021400_soft_delete_notes_shopping.sql"),
     ),
+    (
+        "202509021410_notes_z_index.sql",
+        include_str!("../../migrations/202509021410_notes_z_index.sql"),
+    ),
 ];
 
 pub async fn init_db(app: &AppHandle) -> anyhow::Result<SqlitePool> {

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -260,6 +260,8 @@ pub(crate) async fn reorder_positions(
     Ok(())
 }
 
+// Kept for the future SQLite-backed Notes path; UI is file-based today.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn bring_note_to_front(
     pool: &SqlitePool,
     household_id: &str,

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -1,3 +1,5 @@
+// TODO(backend-notes): when Notes move to SQLite, call the tauri `bring_note_to_front` command
+// instead of local z-bumping, and order by `z DESC, position, created_at` in repo helpers.
 import { readTextFile, writeTextFile, mkdir, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
 import { newUuidV7 } from "./db/id";

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -84,7 +84,7 @@ export async function NotesView(container: HTMLElement) {
     canvas.innerHTML = "";
     notes
       .filter((n) => !n.deleted_at)
-      .sort((a, b) => (a.z || 0) - (b.z || 0))
+      .sort((a, b) => (b.z || 0) - (a.z || 0))
       .forEach((note) => {
         const el = document.createElement("div");
         el.className = "note";

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -8,6 +8,7 @@ interface Note {
   color: string;
   x: number;
   y: number;
+  z?: number;
   deleted_at?: number;
 }
 
@@ -29,6 +30,10 @@ async function loadNotes(): Promise<Note[]> {
       if ("deletedAt" in note) {
         note.deleted_at = (note as any).deletedAt;
         delete (note as any).deletedAt;
+        changed = true;
+      }
+      if (note.z === undefined) {
+        note.z = 0;
         changed = true;
       }
       return note;
@@ -77,57 +82,73 @@ export async function NotesView(container: HTMLElement) {
     canvas.innerHTML = "";
     notes
       .filter((n) => !n.deleted_at)
+      .sort((a, b) => (a.z || 0) - (b.z || 0))
       .forEach((note) => {
-      const el = document.createElement("div");
-      el.className = "note";
-      el.style.backgroundColor = note.color;
-      el.style.left = note.x + "px";
-      el.style.top = note.y + "px";
-      const textarea = document.createElement("textarea");
-      textarea.value = note.text;
-      textarea.addEventListener("input", () => {
-        note.text = textarea.value;
-        saveSoon();
-      });
-      el.appendChild(textarea);
-      const del = document.createElement("button");
-      del.className = "delete";
-      del.textContent = "\u00d7";
+        const el = document.createElement("div");
+        el.className = "note";
+        el.style.backgroundColor = note.color;
+        el.style.left = note.x + "px";
+        el.style.top = note.y + "px";
+        el.style.zIndex = String(note.z || 0);
+        const textarea = document.createElement("textarea");
+        textarea.value = note.text;
+        textarea.addEventListener("input", () => {
+          note.text = textarea.value;
+          saveSoon();
+        });
+        el.appendChild(textarea);
+        const del = document.createElement("button");
+        del.className = "delete";
+        del.textContent = "\u00d7";
         del.addEventListener("click", () => {
           note.deleted_at = Date.now();
           saveNotes(notes).then(render);
         });
-      el.appendChild(del);
+        el.appendChild(del);
 
-      el.addEventListener("pointerdown", (e) => {
-        if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLButtonElement) return;
-        e.preventDefault();
-        const startX = e.clientX;
-        const startY = e.clientY;
-        const origX = note.x;
-        const origY = note.y;
-        el.classList.add("dragging");
-        el.setPointerCapture(e.pointerId);
-        function onMove(ev: PointerEvent) {
-          const maxX = canvas.clientWidth - el.offsetWidth;
-          const maxY = canvas.clientHeight - el.offsetHeight;
-          note.x = Math.max(0, Math.min(maxX, origX + (ev.clientX - startX)));
-          note.y = Math.max(0, Math.min(maxY, origY + (ev.clientY - startY)));
-          el.style.left = note.x + "px";
-          el.style.top = note.y + "px";
-        }
-        function onUp() {
-          el.removeEventListener("pointermove", onMove);
-          el.removeEventListener("pointerup", onUp);
-          el.classList.remove("dragging");
+        const bring = document.createElement("button");
+        bring.className = "bring";
+        bring.textContent = "\u2191";
+        bring.addEventListener("click", () => {
+          const maxZ = Math.max(0, ...notes.filter((n) => !n.deleted_at).map((n) => n.z || 0));
+          note.z = maxZ + 1;
+          saveNotes(notes).then(render);
+        });
+        el.appendChild(bring);
+
+        el.addEventListener("pointerdown", (e) => {
+          if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLButtonElement) return;
+          e.preventDefault();
+          const startX = e.clientX;
+          const startY = e.clientY;
+          const origX = note.x;
+          const origY = note.y;
+          const maxZ = Math.max(0, ...notes.filter((n) => !n.deleted_at).map((n) => n.z || 0));
+          note.z = maxZ + 1;
+          el.style.zIndex = String(note.z);
           saveSoon();
-        }
-        el.addEventListener("pointermove", onMove);
-        el.addEventListener("pointerup", onUp);
-      });
+          el.classList.add("dragging");
+          el.setPointerCapture(e.pointerId);
+          function onMove(ev: PointerEvent) {
+            const maxX = canvas.clientWidth - el.offsetWidth;
+            const maxY = canvas.clientHeight - el.offsetHeight;
+            note.x = Math.max(0, Math.min(maxX, origX + (ev.clientX - startX)));
+            note.y = Math.max(0, Math.min(maxY, origY + (ev.clientY - startY)));
+            el.style.left = note.x + "px";
+            el.style.top = note.y + "px";
+          }
+          function onUp() {
+            el.removeEventListener("pointermove", onMove);
+            el.removeEventListener("pointerup", onUp);
+            el.classList.remove("dragging");
+            saveSoon();
+          }
+          el.addEventListener("pointermove", onMove);
+          el.addEventListener("pointerup", onUp);
+        });
 
-      canvas.appendChild(el);
-    });
+        canvas.appendChild(el);
+      });
   }
 
   render();
@@ -135,12 +156,14 @@ export async function NotesView(container: HTMLElement) {
   form?.addEventListener("submit", (e) => {
     e.preventDefault();
     if (!textInput || !colorInput) return;
+    const maxZ = Math.max(0, ...notes.filter((n) => !n.deleted_at).map((n) => n.z || 0));
     const note: Note = {
       id: newUuidV7(),
       text: textInput.value,
       color: colorInput.value,
       x: 10,
       y: 10,
+      z: maxZ + 1,
     };
     notes.push(note);
     saveNotes(notes).then(render);

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -32,7 +32,7 @@ const ORDER_MAP: Record<DomainTable, string> = {
   family_members: "position, created_at, id",
   budget_categories: "position, created_at, id",
   expenses: "created_at, id",
-  notes: "position, created_at, id",
+  notes: "z DESC, position, created_at, id",
   shopping_items: "position, created_at, id",
 };
 


### PR DESCRIPTION
## Summary
- add `z` column and index for notes
- support z-aware ordering and bring-to-front in repo and frontend
- document notes ordering and include migration

## Testing
- `npm run build`
- `npm run lint:rs` *(fails: libsoup-3.0 not found)*
- `npm run check:migrations`
- `npm run check:household`
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: libsoup-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b833accf3c832a9c93a9a671fab5fe