### PR TITLE
feat: add repo scaffolding and JSON write guard

### DIFF
--- a/scripts/ci/no-json-writes.sh
+++ b/scripts/ci/no-json-writes.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+if git diff -U0 | grep -E "writeFileSync|fs\.writeFile|events\.json|bills\.json"; then
+  echo "❌ JSON write detected"; exit 1; fi

--- a/src/BillsView.ts
+++ b/src/BillsView.ts
@@ -17,6 +17,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import { assertJsonWritable } from "./storage";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -102,6 +103,7 @@ async function loadBills(): Promise<Bill[]> {
   }
 }
 async function saveBills(bills: Bill[]): Promise<void> {
+  assertJsonWritable("bills");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(bills, null, 2), { baseDir: BaseDirectory.AppLocalData });

--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -5,6 +5,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import storage from "./storage";
 import type { Bill, Policy, Vehicle } from "./models";
 
 const STORE_DIR = "Arklowdun";
@@ -93,7 +94,10 @@ async function loadJson<T>(file: string): Promise<T[]> {
     arr = arr.filter((i: any) => (i as any).deleted_at == null);
     arr.sort((a: any, b: any) => (a as any).position - (b as any).position || (a as any).created_at - (b as any).created_at);
     if (changed) {
-      await writeTextFile(p, JSON.stringify(arr), { baseDir: BaseDirectory.AppLocalData });
+      const key = file.replace(/\.json$/, "") as keyof typeof storage;
+      if (!(key in storage) || storage[key] === "json") {
+        await writeTextFile(p, JSON.stringify(arr), { baseDir: BaseDirectory.AppLocalData });
+      }
     }
     return arr as T[];
   } catch {

--- a/src/FamilyView.ts
+++ b/src/FamilyView.ts
@@ -6,6 +6,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { toMs } from "./db/normalize";
 import { defaultHouseholdId } from "./db/household";
+import { assertJsonWritable } from "./storage";
 
 // ----- storage -----
 const STORE_DIR = "Arklowdun";
@@ -71,6 +72,7 @@ async function loadMembers(): Promise<FamilyMember[]> {
   }
 }
 async function saveMembers(members: FamilyMember[]): Promise<void> {
+  assertJsonWritable("family_members");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(members, null, 2), {

--- a/src/InsuranceView.ts
+++ b/src/InsuranceView.ts
@@ -17,6 +17,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import { assertJsonWritable } from "./storage";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -102,6 +103,7 @@ async function loadPolicies(): Promise<Policy[]> {
   }
 }
 async function savePolicies(policies: Policy[]): Promise<void> {
+  assertJsonWritable("policies");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(policies, null, 2), { baseDir: BaseDirectory.AppLocalData });

--- a/src/InventoryView.ts
+++ b/src/InventoryView.ts
@@ -17,6 +17,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import { assertJsonWritable } from "./storage";
 
 const MAX_TIMEOUT = 2_147_483_647;
 function scheduleAt(ts: number, cb: () => void) {
@@ -104,6 +105,7 @@ async function loadItems(): Promise<InventoryItem[]> {
   }
 }
 async function saveItems(items: InventoryItem[]): Promise<void> {
+  assertJsonWritable("inventory_items");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(items, null, 2), {

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -3,6 +3,7 @@
 import { readTextFile, writeTextFile, mkdir, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
 import { newUuidV7 } from "./db/id";
+import { assertJsonWritable } from "./storage";
 
 interface Note {
   id: string;
@@ -48,6 +49,7 @@ async function loadNotes(): Promise<Note[]> {
 }
 
 async function saveNotes(notes: Note[]): Promise<void> {
+  assertJsonWritable("notes");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(notes, null, 2), { baseDir: BaseDirectory.AppLocalData });

--- a/src/PetsView.ts
+++ b/src/PetsView.ts
@@ -13,6 +13,7 @@ import { nowMs } from "./db/time";
 import { toMs } from "./db/normalize";
 import { defaultHouseholdId } from "./db/household";
 import { sanitizeRelativePath } from "./files/path";
+import { assertJsonWritable } from "./storage";
 
 const MAX_TIMEOUT = 2_147_483_647; // ~24.8 days
 function scheduleAt(ts: number, cb: () => void) {
@@ -117,6 +118,7 @@ async function loadPets(): Promise<Pet[]> {
   }
 }
 async function savePets(pets: Pet[]): Promise<void> {
+  assertJsonWritable("pets");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(pets, null, 2), {

--- a/src/PropertyView.ts
+++ b/src/PropertyView.ts
@@ -18,6 +18,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import { assertJsonWritable } from "./storage";
 
 const MAX_TIMEOUT = 2_147_483_647;
 function scheduleAt(ts: number, cb: () => void) {
@@ -98,6 +99,7 @@ async function loadDocuments(): Promise<PropertyDocument[]> {
   }
 }
 async function saveDocuments(docs: PropertyDocument[]): Promise<void> {
+  assertJsonWritable("property_documents");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(docs, null, 2), {

--- a/src/ShoppingListView.ts
+++ b/src/ShoppingListView.ts
@@ -1,5 +1,6 @@
 import { readTextFile, writeTextFile, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { newUuidV7 } from "./db/id";
+import { assertJsonWritable } from "./storage";
 
 interface ShoppingItem {
   id: string;
@@ -38,6 +39,7 @@ async function loadItems(): Promise<ShoppingItem[]> {
 }
 
 async function saveItems(items: ShoppingItem[]): Promise<void> {
+  assertJsonWritable("shopping_items");
   await writeTextFile(FILE, JSON.stringify(items), {
     baseDir: BaseDirectory.AppLocalData,
   });

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -17,6 +17,7 @@ import { newUuidV7 } from "./db/id";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { toMs } from "./db/normalize";
+import { assertJsonWritable } from "./storage";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -163,6 +164,7 @@ async function loadVehicles(): Promise<Vehicle[]> {
   }
 }
 async function saveVehicles(vehicles: Vehicle[]): Promise<void> {
+  assertJsonWritable("vehicles");
   await mkdir(STORE_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
   const p = await join(STORE_DIR, FILE_NAME);
   await writeTextFile(p, JSON.stringify(vehicles, null, 2), {

--- a/src/db/crudRepo.ts
+++ b/src/db/crudRepo.ts
@@ -1,0 +1,140 @@
+import { openDb } from "./open";
+import { requireHousehold } from "./household";
+import { newUuidV7 } from "./id";
+import { nowMs } from "./time";
+import type { DomainTable } from "./repo";
+import { ORDER_MAP } from "./repo";
+
+export type RepoErrorCode =
+  | "Constraint"
+  | "NotFound"
+  | "Tx"
+  | "Parse"
+  | "Io";
+
+export class RepoError extends Error {
+  constructor(public code: RepoErrorCode, message: string) {
+    super(message);
+  }
+}
+
+export interface CrudRepo<T, NewT, PatchT> {
+  list(opts: {
+    householdId: string;
+    includeDeleted?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<T[]>;
+  get(householdId: string, id: string): Promise<T | null>;
+  create(householdId: string, input: NewT): Promise<T>;
+  update(householdId: string, id: string, patch: PatchT): Promise<T>;
+  delete(householdId: string, id: string): Promise<void>;
+  restore(householdId: string, id: string): Promise<T>;
+}
+
+export type NewRow<T> = Omit<T, "id" | "created_at" | "updated_at" | "deleted_at">;
+export type PatchRow<T> = Partial<NewRow<T>>;
+
+export function createCrudRepo<
+  T,
+  NewT extends Record<string, any>,
+  PatchT extends Record<string, any>,
+>(table: DomainTable): CrudRepo<T, NewT, PatchT> {
+  return {
+    async list({ householdId, includeDeleted, limit, offset }) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      const order = ORDER_MAP[table];
+      const where = includeDeleted
+        ? "household_id = ?"
+        : "deleted_at IS NULL AND household_id = ?";
+      const lim = Number.isFinite(limit) ? ` LIMIT ${limit}` : "";
+      const off = Number.isFinite(offset) ? ` OFFSET ${offset}` : "";
+      const sql = `SELECT * FROM ${table} WHERE ${where} ORDER BY ${order}${lim}${off}`;
+      return db.select<T[]>(sql, [hh]);
+    },
+    async get(householdId, id) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      const rows = await db.select<T[]>(
+        `SELECT * FROM ${table} WHERE id = ? AND household_id = ?`,
+        [id, hh],
+      );
+      return rows[0] ?? null;
+    },
+    async create(householdId, input) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      const now = nowMs();
+      const id = newUuidV7();
+      const row: any = { id, household_id: hh, created_at: now, updated_at: now, ...input };
+      const keys = Object.keys(row);
+      const placeholders = keys.map(() => "?").join(",");
+      const sql = `INSERT INTO ${table} (${keys.join(",")}) VALUES (${placeholders})`;
+      try {
+        await db.execute(sql, Object.values(row));
+      } catch (e: any) {
+        if (/UNIQUE constraint failed/.test(String(e))) {
+          throw new RepoError("Constraint", String(e));
+        }
+        throw new RepoError("Io", String(e));
+      }
+      return row as T;
+    },
+    async update(householdId, id, patch) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      const fields = { ...patch, updated_at: nowMs() } as Record<string, any>;
+      const keys = Object.keys(fields);
+      if (!keys.length) {
+        const rows = await db.select<T[]>(
+          `SELECT * FROM ${table} WHERE id = ? AND household_id = ?`,
+          [id, hh],
+        );
+        const row = rows[0];
+        if (!row) throw new RepoError("NotFound", "row not found");
+        return row;
+      }
+      const set = keys.map((k) => `${k} = ?`).join(", ");
+      const sql = `UPDATE ${table} SET ${set} WHERE id = ? AND household_id = ?`;
+      try {
+        await db.execute(sql, [...keys.map((k) => fields[k]), id, hh]);
+      } catch (e: any) {
+        if (/UNIQUE constraint failed/.test(String(e))) {
+          throw new RepoError("Constraint", String(e));
+        }
+        throw new RepoError("Io", String(e));
+      }
+      const rows = await db.select<T[]>(
+        `SELECT * FROM ${table} WHERE id = ? AND household_id = ?`,
+        [id, hh],
+      );
+      const row = rows[0];
+      if (!row) throw new RepoError("NotFound", "row not found");
+      return row;
+    },
+    async delete(householdId, id) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      await db.execute(
+        `UPDATE ${table} SET deleted_at = ? WHERE id = ? AND household_id = ?`,
+        [nowMs(), id, hh],
+      );
+    },
+    async restore(householdId, id) {
+      const hh = requireHousehold(householdId);
+      const db = await openDb();
+      await db.execute(
+        `UPDATE ${table} SET deleted_at = NULL WHERE id = ? AND household_id = ?`,
+        [id, hh],
+      );
+      const rows = await db.select<T[]>(
+        `SELECT * FROM ${table} WHERE id = ? AND household_id = ?`,
+        [id, hh],
+      );
+      const row = rows[0];
+      if (!row) throw new RepoError("NotFound", "row not found");
+      return row;
+    },
+  };
+}

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -16,9 +16,9 @@ const DOMAIN_TABLES = [
   "shopping_items",
 ] as const;
 
-type DomainTable = (typeof DOMAIN_TABLES)[number];
+export type DomainTable = (typeof DOMAIN_TABLES)[number];
 
-const ORDER_MAP: Record<DomainTable, string> = {
+export const ORDER_MAP: Record<DomainTable, string> = {
   household: "created_at, id",
   events: "created_at, id",
   bills: "position, created_at, id",

--- a/src/models.ts
+++ b/src/models.ts
@@ -146,5 +146,30 @@ export interface Expense {
   deleted_at?: number;
 }
 
+export interface Note {
+  id: string;
+  text: string;
+  color: string;
+  x: number;
+  y: number;
+  z?: number;
+  household_id?: string;
+  position: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at?: number;
+}
+
+export interface ShoppingItem {
+  id: string;
+  text: string;
+  completed: boolean;
+  household_id?: string;
+  position: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at?: number;
+}
+
 export type { Event } from "./bindings/Event";
 

--- a/src/repos/index.ts
+++ b/src/repos/index.ts
@@ -1,0 +1,40 @@
+import { createCrudRepo, type NewRow, type PatchRow } from "../db/crudRepo";
+import type {
+  Bill,
+  Policy,
+  PropertyDocument,
+  Vehicle,
+  Pet,
+  FamilyMember,
+  InventoryItem,
+  Note,
+  ShoppingItem,
+} from "../models";
+import type { Event } from "../bindings/Event";
+
+export const billsRepo = createCrudRepo<Bill, NewRow<Bill>, PatchRow<Bill>>("bills");
+export const policiesRepo = createCrudRepo<Policy, NewRow<Policy>, PatchRow<Policy>>("policies");
+export const propertyDocumentsRepo = createCrudRepo<
+  PropertyDocument,
+  NewRow<PropertyDocument>,
+  PatchRow<PropertyDocument>
+>("property_documents");
+export const vehiclesRepo = createCrudRepo<Vehicle, NewRow<Vehicle>, PatchRow<Vehicle>>("vehicles");
+export const petsRepo = createCrudRepo<Pet, NewRow<Pet>, PatchRow<Pet>>("pets");
+export const familyMembersRepo = createCrudRepo<
+  FamilyMember,
+  NewRow<FamilyMember>,
+  PatchRow<FamilyMember>
+>("family_members");
+export const inventoryItemsRepo = createCrudRepo<
+  InventoryItem,
+  NewRow<InventoryItem>,
+  PatchRow<InventoryItem>
+>("inventory_items");
+export const notesRepo = createCrudRepo<Note, NewRow<Note>, PatchRow<Note>>("notes");
+export const shoppingItemsRepo = createCrudRepo<
+  ShoppingItem,
+  NewRow<ShoppingItem>,
+  PatchRow<ShoppingItem>
+>("shopping_items");
+export const eventsRepo = createCrudRepo<Event, NewRow<Event>, PatchRow<Event>>("events");

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,35 @@
+export type StorageBackend = "sqlite" | "json";
+
+export interface StorageFlags {
+  bills: StorageBackend;
+  policies: StorageBackend;
+  property_documents: StorageBackend;
+  vehicles: StorageBackend;
+  pets: StorageBackend;
+  family_members: StorageBackend;
+  inventory_items: StorageBackend;
+  notes: StorageBackend;
+  shopping_items: StorageBackend;
+  events: StorageBackend;
+}
+
+export const storage: StorageFlags = {
+  bills: "json",
+  policies: "json",
+  property_documents: "json",
+  vehicles: "json",
+  pets: "json",
+  family_members: "json",
+  inventory_items: "json",
+  notes: "json",
+  shopping_items: "json",
+  events: "json",
+};
+
+export function assertJsonWritable(domain: keyof StorageFlags): void {
+  if (storage[domain] !== "json") {
+    throw new Error(`JSON write disabled for ${domain}`);
+  }
+}
+
+export default storage;


### PR DESCRIPTION
## Summary
- add RepoError, CrudRepo, and generic CRUD helpers
- wire feature flags and guard JSON writes in UI views
- add CI script to block new JSON write patterns

## Testing
- `npm test`
- `scripts/ci/no-json-writes.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b888daec14832a8bd18705e5202969