### PR TITLE
feat: add theme tokens and base styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script type="module" src="/src/main.ts" defer></script>
   </head>
 
-  <body>
+  <body class="theme-v1">
     <aside class="sidebar">
       <h1>Arklowdun</h1>
       <p class="tagline">Home management</p>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 
 // Ensure SCSS is compiled by Vite:
 import "./debug";
+import "./theme.scss";
 import "./styles.scss";
 import { CalendarView } from "./CalendarView";
 import { FilesView } from "./FilesView";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -136,8 +136,33 @@ button {
   margin-top: var(--space-3);
   flex: 1;
 }
-.nav a.active {
+
+.nav a {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-base);
   color: var(--color-text);
+}
+
+.nav a:hover,
+.nav a:focus-visible {
+  background-color: var(--color-border);
+}
+
+.nav a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.nav a.active {
+  font-weight: 700;
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+}
+
+.nav a.active:hover,
+.nav a.active:focus-visible {
+  background-color: var(--color-accent);
 }
 
 #nav-settings {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,35 +1,9 @@
-@use "sass:color";
-
-$color-burgundy: #f05411;
-$color-green: #34783d;
-$color-burgundy_pastel: color.adjust($color-burgundy, $lightness: 50%);
-$color-green_pastel: color.adjust($color-green, $lightness: 50%);
-$color-green_shade_hi: #5ab867; // 20% lighter than $color-green
-$color-green_shade_lo: #153119; // 20% darker than $color-green
-$color-white: #ffffff;
-
 .logo.vite:hover {
-  filter: drop-shadow(0 0 2em $color-burgundy);
+  filter: drop-shadow(0 0 2em var(--color-accent));
 }
 
 .logo.typescript:hover {
-  filter: drop-shadow(0 0 2em $color-green);
-}
-
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color: $color-green;
-  background-color: $color-white;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+  filter: drop-shadow(0 0 2em var(--color-success));
 }
 /* 1) Make the document able to match the viewport */
 html,
@@ -66,11 +40,11 @@ main {
 .container {
   flex: 1;
   margin: 0;
-  padding: 2rem 1rem 4rem;
+  padding: var(--space-4) var(--space-3) var(--space-5);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  background-color: $color-green_pastel;
+  gap: var(--space-3);
+  background-color: var(--color-panel);
 }
 
 .logo {
@@ -81,7 +55,7 @@ main {
 }
 
 .logo.tauri:hover {
-  filter: drop-shadow(0 0 2em $color-burgundy);
+  filter: drop-shadow(0 0 2em var(--color-accent));
 }
 
 .row {
@@ -91,12 +65,12 @@ main {
 
 a {
   font-weight: 500;
-  color: $color-burgundy;
+  color: var(--color-accent);
   text-decoration: inherit;
 }
 
 a:hover {
-  color: $color-green;
+  color: var(--color-text);
 }
 
 h1 {
@@ -106,16 +80,16 @@ h1 {
 
 input,
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--color-border);
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  color: $color-green;
-  background-color: $color-white;
+  color: var(--color-text);
+  background-color: var(--color-panel);
   transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-base);
 }
 
 button {
@@ -123,12 +97,12 @@ button {
 }
 
 button:hover {
-  border-color: $color-burgundy;
+  border-color: var(--color-accent);
 }
 button:active {
-  border-color: $color-burgundy;
-  background-color: $color-green;
-  color: $color-white;
+  border-color: var(--color-accent);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 input,
@@ -143,13 +117,13 @@ button {
 /* App shell */
 .sidebar {
   width: 200px;
-  padding: 1rem;
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  background-color: $color-white;
-  color: $color-burgundy;
+  gap: var(--space-2);
+  background-color: var(--color-panel);
+  color: var(--color-text);
 }
 .tagline {
   opacity: 0.8;
@@ -158,12 +132,12 @@ button {
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
   flex: 1;
 }
 .nav a.active {
-  color: $color-green;
+  color: var(--color-text);
 }
 
 #nav-settings {
@@ -172,30 +146,9 @@ button {
 
 .list.empty, .calendar-empty {
   opacity: 0.7;
-  padding: 1rem;
-  border: 1px dashed $color-green;
-  border-radius: 8px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: $color-white;
-    background-color: $color-green;
-  }
-
-  a:hover {
-    color: $color-burgundy;
-  }
-
-  input,
-  button {
-    color: $color-green;
-    background-color: $color-white;
-  }
-  button:active {
-    background-color: $color-burgundy;
-    color: $color-white;
-  }
+  padding: var(--space-4);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-base);
 }
 
 .notes-canvas {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1,0 +1,49 @@
+/* Theme tokens and base styles scoped to theme-v1 */
+.theme-v1 {
+  /* Colors */
+  --color-background: #f7f8fb;
+  --color-panel: #ffffff;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-border: #e2e8f0;
+  --color-accent: #d35400;
+  --color-accent-text: #ffffff;
+  --color-success: #166534;
+  --color-danger: #b91c1c;
+
+  /* Typography */
+  --font-family-base: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-size-base: 16px;
+
+  /* Spacing */
+  --space-1: 6px;
+  --space-2: 10px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 36px;
+
+  /* Shape */
+  --radius-base: 10px;
+  --shadow-base: 0 1px 2px rgba(15, 23, 42, 0.05);
+
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
+}
+
+.theme-v1 a {
+  color: var(--color-accent);
+}
+
+.theme-v1 a:hover {
+  color: var(--color-text);
+}
+
+.theme-v1 .sidebar,
+.theme-v1 .container {
+  background-color: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-base);
+}


### PR DESCRIPTION
## Summary
- add theme token file and scoped base styles
- apply `theme-v1` class to app shell and import theme in main
- replace ad-hoc colors with token references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f6541d9c832aaad30a79b89dad96