### PR TITLE
feat: card-based dashboard layout

### DIFF
--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -69,14 +69,27 @@ async function loadJson<T>(file: string): Promise<T[]> {
 
 export async function DashboardView(container: HTMLElement) {
   const section = document.createElement("section");
+  section.className = "dashboard";
   section.innerHTML = `
-    <h2>Dashboard</h2>
-    <ul id="dash-list"></ul>
+    <header class="dashboard__header">
+      <div>
+        <h2>Dashboard</h2>
+        <p class="kicker">What needs your attention</p>
+      </div>
+      <div class="dashboard__actions">
+        <button class="btn">+ Event</button>
+        <button class="btn">+ Note</button>
+      </div>
+    </header>
+    <div class="card">
+      <h3>Attention</h3>
+      <div class="list" id="dash-list"></div>
+    </div>
   `;
   container.innerHTML = "";
   container.appendChild(section);
 
-  const listEl = section.querySelector<HTMLUListElement>("#dash-list");
+  const listEl = section.querySelector<HTMLDivElement>("#dash-list");
   const items: { date: number; text: string }[] = [];
   const now = nowMs();
   const hh = await defaultHouseholdId();
@@ -126,9 +139,15 @@ export async function DashboardView(container: HTMLElement) {
     if (listEl) listEl.textContent = "No upcoming items";
   } else {
     for (const i of items) {
-      const li = document.createElement("li");
-      li.textContent = i.text;
-      listEl?.appendChild(li);
+      const row = document.createElement("div");
+      row.className = "item";
+      const title = document.createElement("span");
+      title.textContent = i.text;
+      const badge = document.createElement("span");
+      badge.className = "badge badge--muted";
+      badge.textContent = "Item";
+      row.append(title, badge);
+      listEl?.appendChild(row);
     }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -114,6 +114,98 @@ button {
   margin-right: 5px;
 }
 
+/* Utility classes */
+.card {
+  background-color: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-base);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.kicker {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-base);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-base);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.badge--muted {
+  background-color: var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.badge--accent {
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+}
+
+.btn {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-panel);
+  color: var(--color-text);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.btn:hover {
+  background-color: var(--color-border);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.btn--accent {
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+}
+
+/* Dashboard layout */
+.dashboard {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.dashboard__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
 /* App shell */
 .sidebar {
   width: 200px;
@@ -156,13 +248,13 @@ button {
 
 .nav a.active {
   font-weight: 700;
-  background-color: var(--color-accent);
-  color: var(--color-accent-text);
+  background-color: rgba(211, 84, 0, 0.15);
+  color: var(--color-accent);
 }
 
 .nav a.active:hover,
 .nav a.active:focus-visible {
-  background-color: var(--color-accent);
+  background-color: rgba(211, 84, 0, 0.15);
 }
 
 #nav-settings {


### PR DESCRIPTION
## Summary
- restyle dashboard with card layout, attention list and quick add buttons
- add token-based utility classes and updated nav active state

## Testing
- `npm test`

## Screenshots
- Dashboard
- Sidebar states
- Legacy view


------
https://chatgpt.com/codex/tasks/task_e_68b9fa724960832ab15bc10d1b3804f4