### PR TITLE
style: refine settings layout

### DIFF
--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -1,10 +1,44 @@
 export function SettingsView(container: HTMLElement) {
   const section = document.createElement("section");
+  section.className = "settings";
   section.innerHTML = `
-    <h2>Settings</h2>
-    <p>Manage application preferences.</p>
+    <a href="#" class="settings__back">Back to dashboard</a>
+    <h2 class="settings__title">Settings</h2>
+
+    <section class="card settings__section" aria-labelledby="settings-general">
+      <h3 id="settings-general">General</h3>
+      <p class="settings__empty">No settings yet.</p>
+    </section>
+
+    <section class="card settings__section" aria-labelledby="settings-storage">
+      <h3 id="settings-storage">Storage and permissions</h3>
+      <p class="settings__empty">No settings yet.</p>
+    </section>
+
+    <section class="card settings__section" aria-labelledby="settings-notifications">
+      <h3 id="settings-notifications">Notifications</h3>
+      <p class="settings__empty">No settings yet.</p>
+    </section>
+
+    <section class="card settings__section" aria-labelledby="settings-appearance">
+      <h3 id="settings-appearance">Appearance</h3>
+      <p class="settings__empty">No settings yet.</p>
+    </section>
+
+    <section class="card settings__section" aria-labelledby="settings-about">
+      <h3 id="settings-about">About and diagnostics</h3>
+      <p class="settings__empty">No settings yet.</p>
+    </section>
   `;
+
   container.innerHTML = "";
   container.appendChild(section);
+
+  section
+    .querySelector<HTMLAnchorElement>(".settings__back")
+    ?.addEventListener("click", (e) => {
+      e.preventDefault();
+      document.querySelector<HTMLAnchorElement>("#nav-dashboard")?.click();
+    });
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -110,6 +110,13 @@ button {
   outline: none;
 }
 
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 #greet-input {
   margin-right: 5px;
 }
@@ -193,6 +200,48 @@ button {
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+}
+
+/* Settings layout */
+.settings {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings__back {
+  align-self: flex-start;
+}
+
+.settings__back:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.settings__row {
+  display: grid;
+  grid-template-columns: 35% 65%;
+  column-gap: var(--space-3);
+  row-gap: var(--space-2);
+  align-items: center;
+}
+
+.settings__help {
+  grid-column: 2;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.settings__empty {
+  color: var(--color-text-muted);
 }
 
 .dashboard__header {


### PR DESCRIPTION
## Summary
- group settings into cards with placeholder sections and a back-to-dashboard link
- add layout and focus styles for settings and form controls

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc481840832aaf7d49b0902b7c90