### PR TITLE
style: facelift files view

### DIFF
--- a/src/FilesView.ts
+++ b/src/FilesView.ts
@@ -8,28 +8,70 @@ import {
 import { join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
+function renderBreadcrumb(path: string, el: HTMLElement) {
+  el.innerHTML = "";
+  const parts = path.split(/[/\\]/).filter(Boolean);
+  for (let i = 0; i < parts.length; i++) {
+    const span = document.createElement("span");
+    span.textContent = parts[i];
+    span.className = "breadcrumb__segment" + (i === parts.length - 1 ? " current" : "");
+    span.tabIndex = 0;
+    el.appendChild(span);
+  }
+}
+
 async function listDirectory(
   dir: string,
-  listEl: HTMLUListElement,
+  listEl: HTMLTableSectionElement,
   previewEl: HTMLElement,
   pathEl: HTMLElement,
   setDir: (d: string) => void,
 ) {
   const entries = await readDir(dir); // entries expose isDirectory/isFile
+  renderBreadcrumb(dir, pathEl);
   listEl.innerHTML = "";
   if (entries.length === 0) {
-    const empty = document.createElement("li");
-    empty.className = "list empty";
-    empty.textContent = "No files";
-    listEl.appendChild(empty);
+    const emptyRow = document.createElement("tr");
+    const emptyCell = document.createElement("td");
+    emptyCell.colSpan = 5;
+    const msg = document.createElement("div");
+    msg.className = "files__empty";
+    msg.textContent = "No files here yet";
+    const ghostBtn = document.createElement("button");
+    ghostBtn.className = "btn btn--ghost";
+    ghostBtn.textContent = "New File";
+    msg.appendChild(ghostBtn);
+    emptyCell.appendChild(msg);
+    emptyRow.appendChild(emptyCell);
+    listEl.appendChild(emptyRow);
     return;
   }
   for (const entry of entries) {
     const path = (entry as any).path as string;
-    const li = document.createElement("li");
-    li.textContent = entry.name;
+    const row = document.createElement("tr");
+    row.tabIndex = 0;
+
+    const nameTd = document.createElement("td");
+    const icon = document.createElement("span");
+    icon.textContent = entry.isDirectory ? "📁" : "📄";
+    icon.className = "files__icon";
+    const nameSpan = document.createElement("span");
+    nameSpan.textContent = entry.name;
+    nameSpan.className = "files__name";
+    nameSpan.title = entry.name;
+    nameTd.append(icon, nameSpan);
+
+    const typeTd = document.createElement("td");
+    typeTd.textContent = entry.isDirectory ? "Folder" : "File";
+
+    const sizeTd = document.createElement("td");
+    const modTd = document.createElement("td");
+
+    const actionsTd = document.createElement("td");
+    actionsTd.className = "files__actions-cell";
     const del = document.createElement("button");
     del.textContent = "Delete";
+    del.className = "files__action";
     del.addEventListener("click", async (e) => {
       e.stopPropagation();
       try {
@@ -39,11 +81,11 @@ async function listDirectory(
         console.error("Failed to delete", err);
       }
     });
-    li.appendChild(del);
-    li.addEventListener("click", async () => {
+    actionsTd.appendChild(del);
+
+    row.addEventListener("click", async () => {
       if (entry.isDirectory) {
         setDir(path);
-        pathEl.textContent = path;
         await listDirectory(path, listEl, previewEl, pathEl, setDir);
       } else {
         previewEl.innerHTML = "";
@@ -69,16 +111,41 @@ async function listDirectory(
         }
       }
     });
-    listEl.appendChild(li);
+
+    row.append(nameTd, typeTd, sizeTd, modTd, actionsTd);
+    listEl.appendChild(row);
   }
 }
 
 export async function FilesView(container: HTMLElement) {
   const section = document.createElement("section");
+  section.className = "files";
   section.innerHTML = `
-    <h2>Files</h2>
-    <button id="select-dir">Select Directory</button>
-    <div id="current-path"></div>
+    <header class="files__header">
+      <div>
+        <h2>Files</h2>
+        <nav id="current-path" class="breadcrumb"></nav>
+      </div>
+      <div class="files__actions">
+        <button id="select-dir" class="btn">Select Directory</button>
+        <button class="btn">New Folder</button>
+        <button class="btn">New File</button>
+      </div>
+    </header>
+    <div class="card files__panel">
+      <table class="files__table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Size</th>
+            <th>Modified</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="file-list"></tbody>
+      </table>
+    </div>
     <form id="new-file-form" style="display:none">
       <input id="new-file-name" type="text" placeholder="New file name" required />
       <button type="submit">Create File</button>
@@ -87,14 +154,13 @@ export async function FilesView(container: HTMLElement) {
       <input id="new-folder-name" type="text" placeholder="New folder name" required />
       <button type="submit">Create Folder</button>
     </form>
-    <ul id="file-list"></ul>
     <div id="preview"></div>
   `;
   container.innerHTML = "";
   container.appendChild(section);
 
   const selectBtn = section.querySelector<HTMLButtonElement>("#select-dir");
-  const listEl = section.querySelector<HTMLUListElement>("#file-list");
+  const listEl = section.querySelector<HTMLTableSectionElement>("#file-list");
   const previewEl = section.querySelector<HTMLElement>("#preview");
   const pathEl = section.querySelector<HTMLElement>("#current-path");
   const fileForm = section.querySelector<HTMLFormElement>("#new-file-form");
@@ -116,7 +182,7 @@ export async function FilesView(container: HTMLElement) {
     const dir = await open({ directory: true });
     if (typeof dir === "string") {
       setDir(dir);
-      if (pathEl) pathEl.textContent = dir;
+      if (pathEl) renderBreadcrumb(dir, pathEl);
       if (fileForm) fileForm.style.display = "block";
       if (folderForm) folderForm.style.display = "block";
       if (listEl && previewEl && pathEl)

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -354,3 +354,128 @@ textarea:focus-visible {
   background: transparent;
   cursor: pointer;
 }
+
+/* Files view */
+.files {
+  max-width: 1024px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.files__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.files__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.breadcrumb {
+  display: flex;
+  gap: var(--space-1);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  flex-wrap: nowrap;
+}
+
+.breadcrumb__segment {
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-base);
+}
+
+.breadcrumb__segment.current {
+  font-weight: 600;
+  background-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.breadcrumb__segment:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.files__panel {
+  overflow-x: auto;
+}
+
+.files__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.files__table th,
+.files__table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  white-space: nowrap;
+}
+
+.files__table th:last-child,
+.files__actions-cell {
+  text-align: right;
+}
+
+.files__table tbody tr:nth-child(even) {
+  background-color: var(--color-border);
+}
+
+.files__table tbody tr:hover {
+  background-color: rgba(211, 84, 0, 0.15);
+}
+
+.files__table tbody tr:focus-within {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  background-color: rgba(211, 84, 0, 0.1);
+}
+
+.files__icon {
+  margin-right: var(--space-2);
+}
+
+.files__name {
+  display: inline-block;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.files__action {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.files__action:hover {
+  color: var(--color-danger);
+}
+
+.files__action:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.files__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+}
+
+.btn--ghost {
+  background-color: transparent;
+  border: 1px dashed var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.btn--ghost:hover {
+  background-color: var(--color-border);
+}


### PR DESCRIPTION
## Summary
- add breadcrumb header and action buttons to Files view
- wrap file listing in carded table with row icons and hover/focus states
- introduce empty state styling with ghost button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9fdb16da8832a8877477b4ffa448b