### PR TITLE
chore: polish sticky notes styling

### DIFF
--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -17,6 +17,16 @@ type Note = {
   deleted_at?: number | null;
 };
 
+const NOTE_PALETTE: Record<string, { base: string; text: string }> = {
+  "#FFFF88": { base: "#FFF4B8", text: "#2b2b2b" },
+  "#FFF4B8": { base: "#FFF4B8", text: "#2b2b2b" },
+  "#CFF7E3": { base: "#CFF7E3", text: "#1f2937" },
+  "#DDEBFF": { base: "#DDEBFF", text: "#0f172a" },
+  "#FFD9D3": { base: "#FFD9D3", text: "#1f2937" },
+  "#EADCF9": { base: "#EADCF9", text: "#1f2937" },
+  "#F6EBDC": { base: "#F6EBDC", text: "#1f2937" },
+};
+
 async function openDb() {
   // Uses the same DB the rest of the app uses (tauri config maps this to your app.sqlite)
   // Do NOT put an absolute path here.
@@ -132,7 +142,7 @@ export async function NotesView(container: HTMLElement) {
     <h2>Notes</h2>
     <form id="note-form">
       <input id="note-text" type="text" placeholder="Note" required />
-      <input id="note-color" type="color" value="#ffff88" />
+      <input id="note-color" type="color" value="#FFF4B8" />
       <button type="submit">Add</button>
     </form>
     <div id="notes-canvas" class="notes-canvas"></div>
@@ -164,7 +174,11 @@ export async function NotesView(container: HTMLElement) {
       .forEach((note) => {
         const el = document.createElement("div");
         el.className = "note";
-        el.style.backgroundColor = note.color;
+        const palette = NOTE_PALETTE[note.color.toUpperCase()];
+        const baseColor = palette?.base ?? note.color;
+        const textColor = palette?.text ?? "#1f2937";
+        el.style.setProperty("--note-color", baseColor);
+        el.style.setProperty("--note-text-color", textColor);
         el.style.left = note.x + "px";
         el.style.top = note.y + "px";
         el.style.zIndex = String(note.z ?? 0);
@@ -262,7 +276,7 @@ export async function NotesView(container: HTMLElement) {
       notes.push(created);
       render();
       form.reset();
-      colorInput.value = "#ffff88";
+      colorInput.value = "#FFF4B8";
     } catch (err: any) {
       alert(`Failed to add note:\n${err?.message ?? String(err)}`);
     }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -320,20 +320,61 @@ textarea:focus-visible {
 .notes-canvas {
   position: relative;
   min-height: 300px;
+  padding: 24px;
+  background-color: #f7f8fb;
+  background-image: radial-gradient(rgba(0, 0, 0, 0.1) 1px, transparent 1px);
+  background-size: 10px 10px;
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.05);
 }
 
 .note {
   position: absolute;
-  padding: 0.5rem;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  padding-top: 24px;
+  border-radius: 10px;
+  box-shadow: var(--shadow-base);
   cursor: grab;
   user-select: none;
   touch-action: none;
+  background-color: color-mix(in srgb, var(--note-color, #FFF4B8) 85%, white);
+  color: var(--note-text-color, #1f2937);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.note::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 10px;
+  background-color: var(--note-color, #FFF4B8);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+
+.note::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 8px;
+  width: 16px;
+  height: 4px;
+  background-image: radial-gradient(currentColor 1px, transparent 1px);
+  background-size: 4px 4px;
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 .note.dragging {
   cursor: grabbing;
+  transform: scale(1.02);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.note:focus-within {
+  outline: 2px solid rgba(211, 84, 0, 0.7);
+  outline-offset: 2px;
 }
 
 .note textarea {
@@ -343,16 +384,45 @@ textarea:focus-visible {
   width: 100px;
   height: 100px;
   font: inherit;
+  font-size: 14px;
+  line-height: 1.4;
   outline: none;
+  color: inherit;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
-.note button.delete {
+.note button.delete,
+.note button.bring {
   position: absolute;
-  top: 2px;
-  right: 2px;
+  top: 4px;
   border: none;
   background: transparent;
   cursor: pointer;
+  color: inherit;
+}
+
+.note button.delete {
+  right: 4px;
+}
+
+.note button.bring {
+  right: 24px;
+}
+
+.note--sm {
+  min-width: 160px;
+  min-height: 120px;
+}
+
+.note--md {
+  min-width: 220px;
+  min-height: 160px;
+}
+
+.note--lg {
+  min-width: 300px;
+  min-height: 220px;
 }
 
 /* Files view */


### PR DESCRIPTION
## Summary
- refine sticky note palette and default color
- add dotted canvas background and improved card styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0219b830832a915a62e42f610791