### PR TITLE
style: refresh calendar view layout

### DIFF
--- a/src/CalendarView.ts
+++ b/src/CalendarView.ts
@@ -34,7 +34,16 @@ function renderMonth(root: HTMLElement, events: Event[]) {
   const firstDay = new Date(year, month, 1).getDay();
   const lastDate = new Date(year, month + 1, 0).getDate();
 
+  const monthLabel = document.createElement("div");
+  monthLabel.className = "calendar__month-label";
+  monthLabel.textContent = now.toLocaleString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+  root.appendChild(monthLabel);
+
   const table = document.createElement("table");
+  table.className = "calendar__table";
   const headerRow = document.createElement("tr");
   ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].forEach((d) => {
     const th = document.createElement("th");
@@ -51,8 +60,20 @@ function renderMonth(root: HTMLElement, events: Event[]) {
       row = document.createElement("tr");
     }
     const cell = document.createElement("td");
-    cell.innerHTML = `<div class="date">${day}</div>`;
+    cell.tabIndex = 0;
     const cellDate = new Date(year, month, day);
+    const dateDiv = document.createElement("div");
+    dateDiv.className = "calendar__date";
+    dateDiv.textContent = String(day);
+    const today = new Date();
+    if (
+      cellDate.getFullYear() === today.getFullYear() &&
+      cellDate.getMonth() === today.getMonth() &&
+      cellDate.getDate() === today.getDate()
+    ) {
+      dateDiv.classList.add("calendar__date--today");
+    }
+    cell.appendChild(dateDiv);
     const dayEvents = events.filter((e) => {
       const a = toDate(e.starts_at);
       return (
@@ -63,7 +84,7 @@ function renderMonth(root: HTMLElement, events: Event[]) {
     });
     dayEvents.forEach((ev) => {
       const div = document.createElement("div");
-      div.className = "event";
+      div.className = "calendar__event";
       div.textContent = ev.title;
       cell.appendChild(div);
     });
@@ -94,10 +115,18 @@ async function scheduleNotifications(events: Event[]) {
 
 export async function CalendarView(container: HTMLElement) {
   const section = document.createElement("section");
+  section.className = "calendar";
   section.innerHTML = `
-    <h2>Calendar</h2>
-    <div id="calendar"></div>
-    <form id="event-form">
+    <header class="calendar__header">
+      <div>
+        <h2>Calendar</h2>
+        <p class="kicker">All times local</p>
+      </div>
+    </header>
+    <div class="card calendar__panel">
+      <div id="calendar"></div>
+    </div>
+    <form id="event-form" class="calendar__form">
       <input id="event-title" type="text" placeholder="Title" required />
       <input id="event-start" type="datetime-local" required />
       <button type="submit">Add Event</button>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -549,3 +549,86 @@ textarea:focus-visible {
 .btn--ghost:hover {
   background-color: var(--color-border);
 }
+
+/* Calendar view */
+.calendar {
+  max-width: 1024px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.calendar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.calendar__month-label {
+  font-weight: 600;
+  text-align: center;
+}
+
+.calendar__panel {
+  padding: var(--space-4);
+}
+
+.calendar__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.calendar__table th {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: var(--space-2);
+}
+
+.calendar__table td {
+  vertical-align: top;
+  width: calc(100% / 7);
+  height: 100px;
+  padding: var(--space-1);
+}
+
+.calendar__table td:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.calendar__date {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  text-align: center;
+  border-radius: var(--radius-base);
+}
+
+.calendar__date--today {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.calendar__event {
+  margin-top: var(--space-1);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-base);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.calendar__form {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.calendar__form input {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- add header and panel structure to calendar view
- render month label and highlight current day with event pills
- style calendar grid, dates, and event form using theme tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba043253e0832a8b34ccb2031cdc81