### PR TITLE
feat: compact sidebar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,18 @@
 
   <body class="theme-v1">
     <aside class="sidebar">
-      <h1>Arklowdun</h1>
-      <p class="tagline">Home management</p>
-      <nav class="nav">
-        <a id="nav-dashboard" class="active" href="#" aria-current="page">Dashboard</a>
-        <a id="nav-files" href="#">Files</a>
-        <a id="nav-calendar" href="#">Calendar</a>
-        <a id="nav-notes" href="#">Notes</a>
-        <a id="nav-legacy" href="#">Legacy</a>
-        <a id="nav-settings" href="#">Settings</a>
-      </nav>
+      <div class="sidebar__top">
+        <h1>Arklowdun</h1>
+        <p class="tagline">Home management</p>
+        <nav class="nav">
+          <a id="nav-dashboard" class="active" href="#" aria-current="page">Dashboard</a>
+          <a id="nav-files" href="#">Files</a>
+          <a id="nav-calendar" href="#">Calendar</a>
+          <a id="nav-notes" href="#">Notes</a>
+          <a id="nav-legacy" href="#">Legacy</a>
+        </nav>
+      </div>
+      <a id="nav-settings" href="#">Settings</a>
     </aside>
     <main id="view" class="container"></main>
   </body>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,7 +16,8 @@ body {
 
 /* 4) Optional: avoid micro scrollbars during rapid resize */
 body {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(160px, max-content) 1fr;
   margin: 0;
   overflow: hidden; // switch to 'auto' if you need full-page scroll
 }
@@ -257,57 +258,71 @@ textarea:focus-visible {
 
 /* App shell */
 .sidebar {
-  width: 200px;
-  padding: var(--space-4);
+  inline-size: max-content;
+  padding: var(--space-4) var(--space-3);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
+  justify-content: space-between;
+  align-items: flex-start;
   background-color: var(--color-panel);
   color: var(--color-text);
 }
+
+.sidebar__top {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.sidebar h1 {
+  white-space: nowrap;
+}
+
 .tagline {
   opacity: 0.8;
   margin: 0;
 }
+
 .nav {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  margin-top: var(--space-3);
-  flex: 1;
 }
 
-.nav a {
+.sidebar a {
   display: block;
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-2);
   border-radius: var(--radius-base);
   color: var(--color-text);
+  white-space: nowrap;
 }
 
-.nav a:hover,
-.nav a:focus-visible {
+.sidebar a:hover,
+.sidebar a:focus-visible {
   background-color: var(--color-border);
 }
 
-.nav a:focus-visible {
+.sidebar a:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-.nav a.active {
+.sidebar a.active {
   font-weight: 700;
   background-color: rgba(211, 84, 0, 0.15);
   color: var(--color-accent);
 }
 
-.nav a.active:hover,
-.nav a.active:focus-visible {
+.sidebar a.active:hover,
+.sidebar a.active:focus-visible {
   background-color: rgba(211, 84, 0, 0.15);
 }
 
-#nav-settings {
-  margin-top: auto;
+@media (max-width: 1100px) {
+  .sidebar {
+    padding-inline: var(--space-2);
+  }
 }
 
 .list.empty, .calendar-empty {


### PR DESCRIPTION
## Summary
- shrink sidebar to auto width with flex column layout and pinned settings link
- switch app shell to grid layout with auto-sizing sidebar column
- add responsive padding and prevent nav label wrapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba07316af4832aa029b35a592a7958