### PR TITLE
feat: tint sidebar with pale green background

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -264,7 +264,8 @@ textarea:focus-visible {
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
-  background-color: var(--color-panel);
+  background-color: var(--color-sidebar-bg);
+  border-inline-end: 1px solid var(--color-sidebar-border);
   color: var(--color-text);
 }
 

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -10,6 +10,8 @@
   --color-accent-text: #ffffff;
   --color-success: #166534;
   --color-danger: #b91c1c;
+  --color-sidebar-bg: #f6fbf8;
+  --color-sidebar-border: #e4f2ea;
 
   /* Typography */
   --font-family-base: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -40,7 +42,6 @@
   color: var(--color-text);
 }
 
-.theme-v1 .sidebar,
 .theme-v1 .container {
   background-color: var(--color-panel);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- add theme tokens for sidebar background and border
- apply pale green tint and soft divider to sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b65f8f0832a9a37a623d7f1307e