### PR TITLE
refactor: anchor settings in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
           title="Diagnostics / Logs"
           aria-label="Diagnostics and logs"
         >
-          <i class="fa-solid fa-bug" aria-hidden="true"></i>
+          <i class="fa-regular fa-bug" aria-hidden="true"></i>
         </button>
         <button
           type="button"

--- a/index.html
+++ b/index.html
@@ -54,15 +54,17 @@
     </aside>
     <main id="view" class="container"></main>
     <footer role="contentinfo" class="footer">
-      <div class="footer__icons">
-        <a
-          id="footer-settings"
-          href="#"
-          title="Settings"
-          aria-label="Settings"
-        >
-          <i class="fa-solid fa-gear" aria-hidden="true"></i>
-        </a>
+      <a
+        id="footer-settings"
+        href="#"
+        class="footer__settings"
+        title="Settings"
+        aria-label="Settings"
+      >
+        <i class="fa-solid fa-gear" aria-hidden="true"></i>
+        <span>Settings</span>
+      </a>
+      <div class="footer__utilities">
         <button
           type="button"
           id="footer-notifications"
@@ -78,7 +80,11 @@
         >
           <i class="fa-solid fa-bug" aria-hidden="true"></i>
         </button>
-        <button type="button" title="Help" aria-label="Help">
+        <button
+          type="button"
+          title="Help"
+          aria-label="Help"
+        >
           <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
         </button>
       </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -484,9 +484,8 @@ textarea:focus-visible {
 footer {
   grid-column: 1 / -1;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
-  gap: var(--space-2);
   padding: 0 var(--space-1);
   block-size: 44px;
   background-color: var(--color-panel);
@@ -495,16 +494,47 @@ footer {
   z-index: 1;
 }
 
-.footer__icons {
+.footer__settings {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  block-size: 32px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.footer__settings i {
+  font-size: 18px;
+  color: currentColor;
+}
+
+.footer__settings:hover,
+.footer__settings:focus-visible,
+.footer__settings:active {
+  color: var(--color-accent);
+  background-color: var(--color-accent-soft);
+  border-color: var(--color-accent);
+}
+
+.footer__settings:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.footer__utilities {
   display: flex;
   flex-wrap: nowrap;
   gap: var(--space-2);
 }
 
-.footer__icons a,
-.footer__icons button {
-  inline-size: 44px;
-  block-size: 44px;
+.footer__utilities a,
+.footer__utilities button {
+  inline-size: 32px;
+  block-size: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -517,24 +547,25 @@ footer {
   transition: color 0.15s, background-color 0.15s, filter 0.15s;
 }
 
-.footer__icons a:hover,
-.footer__icons button:hover {
+.footer__utilities a:hover,
+.footer__utilities button:hover {
   background-color: var(--color-border);
 }
 
-.footer__icons a:focus-visible,
-.footer__icons button:focus-visible {
+.footer__utilities a:focus-visible,
+.footer__utilities button:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-.footer__icons a:active,
-.footer__icons button:active {
+.footer__utilities a:active,
+.footer__utilities button:active {
   background-color: rgba(211, 84, 0, 0.15);
 }
 
-.footer__icons i {
+.footer__utilities i {
   font-size: 18px;
+  color: currentColor;
 }
 
 .list.empty, .calendar-empty {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -486,38 +486,40 @@ footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 var(--space-1);
+  padding: 0 var(--space-3);
   block-size: 44px;
   background-color: var(--color-panel);
-  border-block-start: 1px solid var(--color-border);
-  box-shadow: var(--shadow-base);
-  z-index: 1;
+  border-block-start: 1px solid var(--color-sidebar-rule);
 }
 
-.footer__settings {
+footer a {
+  color: inherit;
+}
+
+footer a.footer__settings {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  padding: 0 var(--space-2);
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
   block-size: 32px;
   color: var(--color-text-muted);
   text-decoration: none;
-  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+  font-weight: 600;
+  line-height: 1;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .footer__settings i {
-  font-size: 18px;
   color: currentColor;
 }
 
 .footer__settings:hover,
 .footer__settings:focus-visible,
-.footer__settings:active {
-  color: var(--color-accent);
+.footer__settings.is-current {
   background-color: var(--color-accent-soft);
-  border-color: var(--color-accent);
+  color: var(--color-accent);
+  outline: none;
 }
 
 .footer__settings:focus-visible {
@@ -527,14 +529,13 @@ footer {
 
 .footer__utilities {
   display: flex;
-  flex-wrap: nowrap;
   gap: var(--space-2);
 }
 
 .footer__utilities a,
 .footer__utilities button {
-  inline-size: 32px;
-  block-size: 32px;
+  inline-size: 44px;
+  block-size: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -543,8 +544,7 @@ footer {
   border-radius: var(--radius-base);
   color: var(--color-text);
   cursor: pointer;
-  padding: 0;
-  transition: color 0.15s, background-color 0.15s, filter 0.15s;
+  transition: background-color 0.15s, color 0.15s, filter 0.15s;
 }
 
 .footer__utilities a:hover,
@@ -558,13 +558,7 @@ footer {
   outline-offset: 2px;
 }
 
-.footer__utilities a:active,
-.footer__utilities button:active {
-  background-color: rgba(211, 84, 0, 0.15);
-}
-
 .footer__utilities i {
-  font-size: 18px;
   color: currentColor;
 }
 


### PR DESCRIPTION
## Summary
- anchor Settings with label on left
- group Notifications, Logs, and Help as right-aligned utilities
- style Settings as pill and utilities as icon buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab578b020832ab545048655c0ffb6