### PR TITLE
feat: widen dashboard with two-column layout

### DIFF
--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -111,6 +111,10 @@ export async function DashboardView(container: HTMLElement) {
         <h3><i class="card__icon fa-solid fa-triangle-exclamation" aria-hidden="true"></i>Attention</h3>
         <div class="list" id="dash-list" role="list"></div>
       </div>
+      <div class="card">
+        <h3><i class="card__icon fa-regular fa-clock" aria-hidden="true"></i>Upcoming</h3>
+        <p>Coming soon</p>
+      </div>
     `;
   container.innerHTML = "";
   container.appendChild(section);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 .logo.vite:hover {
   filter: drop-shadow(0 0 2em var(--color-accent));
 }
@@ -264,51 +268,25 @@ textarea:focus-visible {
   color: var(--color-text);
 }
 
-/* Dashboard grid — robust two-column */
+/* Dashboard grid — responsive, no-overlap */
 .dashboard {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);  /* tracks shrink safely */
-  column-gap: var(--space-5);          /* a bit more than var(--space-4) */
-  row-gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); /* self-healing tracks */
+  gap: var(--space-4);                                         /* both axes */
   max-width: 1280px;
   margin: 0 auto;
-  align-items: start;                   /* cards hug the top of their tracks */
+  padding-inline: var(--space-4);
+  align-items: start;
 }
 
-/* Belt-and-braces: ensure grid children can shrink */
+/* Ensure grid children can shrink within their tracks */
 .dashboard > * {
-  min-width: 0;                         /* header + cards */
-}
-.dashboard > .card {
-  min-width: 0;                         /* explicit for cards */
+  min-width: 0;
 }
 
-/* Breakpoints tuned for single column comfort */
-@media (max-width: 1100px) {
-  .dashboard {
-    max-width: none;                 /* remove artificial cap */
-    padding-inline: var(--space-3);  /* 16px-ish sides */
-  }
-}
-
-@media (max-width: 900px) {
-  .dashboard {
-    grid-template-columns: 1fr;      /* single column */
-    max-width: none;                 /* full width of container */
-    padding-inline: var(--space-2);  /* ~10px sides; tighter gutters */
-    row-gap: var(--space-3);
-  }
-
-  /* Make the container feel "edge-to-edge" on small screens */
-  .theme-v1 .container {
-    border-left: 0;
-    border-right: 0;
-    border-radius: 0;
-    box-shadow: none;                /* optional: keeps it flat and roomy */
-  }
-
-  /* Header spans full width already; ensure no extra inset */
-  .dashboard__header { margin-inline: 0; }
+/* Give extra breathing room on very wide viewports */
+@media (min-width: 1400px) {
+  .dashboard { gap: var(--space-5); }
 }
 
 /* Settings layout */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -141,7 +141,7 @@ textarea:focus-visible {
 
 .card {
   background-color: var(--color-panel);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-sidebar-border); /* a touch darker than --color-border */
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-base);
   padding: var(--space-4);
@@ -261,25 +261,27 @@ textarea:focus-visible {
   color: var(--color-text);
 }
 
-/* Dashboard layout */
+/* Dashboard grid — robust two-column */
 .dashboard {
-  margin: 0 auto;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-4);
+  column-gap: var(--space-5);          /* a bit more than var(--space-4) */
+  row-gap: var(--space-4);
   max-width: 1280px;
+  margin: 0 auto;
+  align-items: start;                   /* cards hug the top of their tracks */
 }
 
-@media (max-width: 1280px) {
-  .dashboard {
-    max-width: 100%;
-    padding: 0 var(--space-4);
-  }
+/* Critical: allow grid items to shrink within their track */
+.dashboard > .card {
+  min-width: 0;                         /* prevents overflow “bleed” into gap */
 }
 
+/* Responsive collapse */
 @media (max-width: 900px) {
   .dashboard {
     grid-template-columns: 1fr;
+    padding: 0 var(--space-4);
   }
 }
 
@@ -325,6 +327,7 @@ textarea:focus-visible {
   color: var(--color-text-muted);
 }
 
+/* Header should own the full row */
 .dashboard__header {
   grid-column: 1 / -1;
   display: flex;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -148,6 +148,7 @@ textarea:focus-visible {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  inline-size: 100%;
 }
 
 .card h3 {
@@ -262,11 +263,24 @@ textarea:focus-visible {
 
 /* Dashboard layout */
 .dashboard {
-  max-width: 960px;
   margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-5);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  max-width: 1280px;
+}
+
+@media (max-width: 1280px) {
+  .dashboard {
+    max-width: 100%;
+    padding: 0 var(--space-4);
+  }
+}
+
+@media (max-width: 900px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Settings layout */
@@ -312,6 +326,7 @@ textarea:focus-visible {
 }
 
 .dashboard__header {
+  grid-column: 1 / -1;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -149,6 +149,7 @@ textarea:focus-visible {
   flex-direction: column;
   gap: var(--space-3);
   inline-size: 100%;
+  overflow: hidden; /* clip row highlights within radius */
 }
 
 .card h3 {
@@ -172,6 +173,7 @@ textarea:focus-visible {
   display: grid;
   gap: 0;
   font-variant-numeric: tabular-nums;
+  min-width: 0;
 }
 
 .item {
@@ -182,6 +184,7 @@ textarea:focus-visible {
   border-bottom: 1px solid var(--color-border);
   transition: background-color 0.15s;
   font-variant-numeric: tabular-nums;
+  min-width: 0;
 }
 
 .item:nth-child(even) {
@@ -264,7 +267,7 @@ textarea:focus-visible {
 /* Dashboard grid — robust two-column */
 .dashboard {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);  /* tracks shrink safely */
   column-gap: var(--space-5);          /* a bit more than var(--space-4) */
   row-gap: var(--space-4);
   max-width: 1280px;
@@ -272,17 +275,40 @@ textarea:focus-visible {
   align-items: start;                   /* cards hug the top of their tracks */
 }
 
-/* Critical: allow grid items to shrink within their track */
+/* Belt-and-braces: ensure grid children can shrink */
+.dashboard > * {
+  min-width: 0;                         /* header + cards */
+}
 .dashboard > .card {
-  min-width: 0;                         /* prevents overflow “bleed” into gap */
+  min-width: 0;                         /* explicit for cards */
 }
 
-/* Responsive collapse */
+/* Breakpoints tuned for single column comfort */
+@media (max-width: 1100px) {
+  .dashboard {
+    max-width: none;                 /* remove artificial cap */
+    padding-inline: var(--space-3);  /* 16px-ish sides */
+  }
+}
+
 @media (max-width: 900px) {
   .dashboard {
-    grid-template-columns: 1fr;
-    padding: 0 var(--space-4);
+    grid-template-columns: 1fr;      /* single column */
+    max-width: none;                 /* full width of container */
+    padding-inline: var(--space-2);  /* ~10px sides; tighter gutters */
+    row-gap: var(--space-3);
   }
+
+  /* Make the container feel "edge-to-edge" on small screens */
+  .theme-v1 .container {
+    border-left: 0;
+    border-right: 0;
+    border-radius: 0;
+    box-shadow: none;                /* optional: keeps it flat and roomy */
+  }
+
+  /* Header spans full width already; ensure no extra inset */
+  .dashboard__header { margin-inline: 0; }
 }
 
 /* Settings layout */


### PR DESCRIPTION
## Summary
- widen dashboard container to 1280px and switch to responsive two-column grid
- add placeholder card to second column
- ensure cards span full column width and stack on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac5b18610832aab0c3315b97f44f9