### PR TITLE
refactor: streamline dashboard grid

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -271,22 +271,17 @@ textarea:focus-visible {
 /* Dashboard grid — responsive, no-overlap */
 .dashboard {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); /* self-healing tracks */
-  gap: var(--space-4);                                         /* both axes */
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-4);
   max-width: 1280px;
   margin: 0 auto;
-  padding-inline: var(--space-4);
   align-items: start;
+  padding-inline: var(--space-4);
 }
 
 /* Ensure grid children can shrink within their tracks */
 .dashboard > * {
   min-width: 0;
-}
-
-/* Give extra breathing room on very wide viewports */
-@media (min-width: 1400px) {
-  .dashboard { gap: var(--space-5); }
 }
 
 /* Settings layout */


### PR DESCRIPTION
## Summary
- Replace dashboard grid layout with auto-fitting CSS grid using 320px card minimums
- Drop redundant dashboard grid overrides

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bacf1ac18c832aaae8b35c802ec284