### PR TITLE
Refine dashboard card layout and status indicators

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -180,15 +180,21 @@ textarea:focus-visible {
   min-width: 0;
 }
 
+/* Ensure lists inside cards don't overflow */
+.card .list {
+  min-width: 0;
+}
+
 .item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-2) var(--space-3);
+  gap: var(--space-2);
+  min-width: 0;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--color-border);
   transition: background-color 0.15s;
   font-variant-numeric: tabular-nums;
-  min-width: 0;
 }
 
 .item:nth-child(even) {
@@ -200,13 +206,28 @@ textarea:focus-visible {
 }
 
 .item:hover {
-  background-color: var(--color-accent-soft);
+  background: var(--color-accent-soft);
 }
 
-.item__left {
+.item__left,
+.item__right {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.item__left span,
+.item__left time {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 /* Status dots */
@@ -215,24 +236,35 @@ textarea:focus-visible {
   block-size: 8px;
   border-radius: 999px;
 }
-.status-dot--soon {
-  background: var(--color-text-muted);
+.status--soon {
+  background: #fbbf24;
 }
-.status-dot--today {
-  background: #ffb020;
+.status--today {
+  background: #fb923c;
 }
-.status-dot--overdue {
-  background: #e5484d;
+.status--overdue {
+  background: #ef4444;
 }
 
-/* Right-side "View" pill */
-.pill.pill--ghost {
-  background: var(--color-background);
+/* Action pill */
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: var(--radius-pill);
+  font-size: 0.9rem;
+  text-decoration: none;
   border: 1px solid var(--color-border);
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: 12px;
+  color: var(--color-text);
+  background: transparent;
+}
+
+.pill--view:hover {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .btn {
@@ -354,6 +386,12 @@ textarea:focus-visible {
 .dashboard .card {
   grid-column: span 6;
   min-width: 0;
+}
+
+/* Equal-height siblings inside the grid row */
+.dashboard > .card {
+  align-self: stretch;
+  height: 100%;
 }
 
 /* Prevent long labels from blowing out the header on tight widths */


### PR DESCRIPTION
## Summary
- Equalize dashboard card heights for consistent two-column layout
- Improve dashboard list items with truncation, hover and focus styles
- Render upcoming items with status-aware dots and view pill

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf38d97f8832a9b235e599ada62e5