### PR TITLE
Rename tertiary manage page to tasks

### DIFF
--- a/src/ManageView.ts
+++ b/src/ManageView.ts
@@ -9,7 +9,7 @@ export function ManageView(container: HTMLElement) {
     <nav class="manage" aria-label="Manage categories">
       <a id="nav-primary" href="#">Primary</a>
       <a id="nav-secondary" href="#">Secondary</a>
-      <a id="nav-tertiary" href="#">Tertiary</a>
+      <a id="nav-tasks" href="#">Tasks</a>
       <a id="nav-bills" href="#">Bills</a>
       <a id="nav-insurance" href="#">Insurance</a>
       <a id="nav-property" href="#">Property</a>

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ type View =
   | "dashboard"
   | "primary"
   | "secondary"
-  | "tertiary"
+  | "tasks"
   | "calendar"
   | "files"
   | "shopping"
@@ -51,7 +51,7 @@ const linkPrimary = () =>
 const linkSecondary = () =>
   document.querySelector<HTMLAnchorElement>("#nav-secondary");
 const linkTasks = () =>
-  document.querySelector<HTMLAnchorElement>("#nav-tertiary");
+  document.querySelector<HTMLAnchorElement>("#nav-tasks");
 const linkCalendar = () =>
   document.querySelector<HTMLAnchorElement>("#nav-calendar");
 const linkFiles = () =>
@@ -178,7 +178,7 @@ function setActive(tab: View) {
     manage: linkManage(),
     primary: linkPrimary(),
     secondary: linkSecondary(),
-    tertiary: linkTasks(),
+    tasks: linkTasks(),
     calendar: linkCalendar(),
     files: linkFiles(),
     shopping: linkShopping(),
@@ -294,7 +294,7 @@ function setupManageLinks() {
   const pairs: [() => HTMLAnchorElement | null, View][] = [
     [linkPrimary, "primary"],
     [linkSecondary, "secondary"],
-    [linkTasks, "tertiary"],
+    [linkTasks, "tasks"],
     [linkBills, "bills"],
     [linkInsurance, "insurance"],
     [linkProperty, "property"],


### PR DESCRIPTION
## Summary
- Replace Manage page "Tertiary" link with "Tasks"
- Update navigation types and mappings from `tertiary` to `tasks`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4187fd54832a8a754118a3889aa2