### PR TITLE
Fix hash routing default redirect

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,10 @@ function routeFromHashOrDefault(): View {
     "settings",
     "manage",
   ];
-  return valid.includes(fragment as View) ? (fragment as View) : "dashboard";
+  if (valid.includes(fragment as View)) return fragment as View;
+
+  location.replace("#dashboard");
+  return "dashboard";
 }
 
 


### PR DESCRIPTION
## Summary
- ensure invalid hashes update the location to `#dashboard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4e87cf4c832abda570cdfa009c95