### PR TITLE
Remove manage link setup in main

### DIFF
--- a/src/ManageView.ts
+++ b/src/ManageView.ts
@@ -7,18 +7,18 @@ export function ManageView(container: HTMLElement) {
   section.innerHTML = `
     <h2>Manage</h2>
     <nav class="manage" aria-label="Manage categories">
-      <a id="nav-primary" href="#">Primary</a>
-      <a id="nav-secondary" href="#">Secondary</a>
-      <a id="nav-tasks" href="#">Tasks</a>
-      <a id="nav-bills" href="#">Bills</a>
-      <a id="nav-insurance" href="#">Insurance</a>
-      <a id="nav-property" href="#">Property</a>
-      <a id="nav-vehicles" href="#">Vehicles</a>
-      <a id="nav-pets" href="#">Pets</a>
-      <a id="nav-family" href="#">Family</a>
-      <a id="nav-inventory" href="#">Inventory</a>
-      <a id="nav-budget" href="#">Budget</a>
-      <a id="nav-shopping" href="#">Shopping List</a>
+      <a id="nav-primary" href="#primary">Primary</a>
+      <a id="nav-secondary" href="#secondary">Secondary</a>
+      <a id="nav-tasks" href="#tasks">Tasks</a>
+      <a id="nav-bills" href="#bills">Bills</a>
+      <a id="nav-insurance" href="#insurance">Insurance</a>
+      <a id="nav-property" href="#property">Property</a>
+      <a id="nav-vehicles" href="#vehicles">Vehicles</a>
+      <a id="nav-pets" href="#pets">Pets</a>
+      <a id="nav-family" href="#family">Family</a>
+      <a id="nav-inventory" href="#inventory">Inventory</a>
+      <a id="nav-budget" href="#budget">Budget</a>
+      <a id="nav-shopping" href="#shopping">Shopping List</a>
     </nav>
   `;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,37 +315,10 @@ function navigate(to: View) {
   }
   if (to === "manage") {
     ManageView(el);
-    setupManageLinks();
     return;
   }
   const title = to.charAt(0).toUpperCase() + to.slice(1);
   renderBlank(title);
-}
-
-function setupManageLinks() {
-  const pairs: [() => HTMLAnchorElement | null, View][] = [
-    [linkPrimary, "primary"],
-    [linkSecondary, "secondary"],
-    [linkTasks, "tasks"],
-    [linkBills, "bills"],
-    [linkInsurance, "insurance"],
-    [linkProperty, "property"],
-    [linkVehicles, "vehicles"],
-    [linkPets, "pets"],
-    [linkFamily, "family"],
-    [linkInventory, "inventory"],
-    [linkBudget, "budget"],
-    [linkShopping, "shopping"],
-  ];
-  for (const [getter, view] of pairs) {
-    const el = getter();
-    if (el) {
-      el.onclick = (e) => {
-        e.preventDefault();
-        navigate(view);
-      };
-    }
-  }
 }
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -379,6 +352,9 @@ window.addEventListener("DOMContentLoaded", () => {
     });
   // Load the route from the URL fragment or fall back to the dashboard view.
   navigate(routeFromHashOrDefault());
+  window.addEventListener("hashchange", () =>
+    navigate(routeFromHashOrDefault())
+  );
   requestAnimationFrame(() => {
     console.log("Runtime window label:", appWindow.label);
     setupDynamicMinSize();


### PR DESCRIPTION
## Summary
- Remove obsolete manage link setup utility
- Render manage page links with hashes and listen for hash changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4fe57ad0832a9ea8b0b3f2ea715c