### PR TITLE
PR-03: Log-level overrides (dev/prod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ See the [Arklowdun Master Plan](docs/master-plan.md) for the high-level strategi
 
 Recommended IDE: VS Code with Tauri and rust-analyzer extensions.
 
+## Logging & Verbosity
+
+- Backend (Rust):
+  `TAURI_ARKLOWDUN_LOG="arklowdun=debug,sqlx=info" npm run tauri dev`
+  (default: `arklowdun=info,sqlx=warn`)
+  `TAURI_ARKLOWDUN_LOG="arklowdun=info,sqlx=warn" npm run tauri build` # Example production run with quieter SQLx
+- Frontend (TS):
+  `VITE_LOG_LEVEL=debug npm run tauri dev`
+  (allowed: `debug|info|warn|error`)
+
 ## Database integrity
 
 Schema constraint guidelines live in [docs/integrity-rules.md](docs/integrity-rules.md).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,19 +20,19 @@ mod events_tz_backfill;
 
 use commands::DbErrorPayload;
 use events_tz_backfill::events_backfill_timezone;
-use tracing_subscriber::{prelude::*, EnvFilter};
+use tracing_subscriber::{fmt, EnvFilter};
 
 pub fn init_logging() {
-    let fmt_layer = tracing_subscriber::fmt::layer()
+    let filter = std::env::var("TAURI_ARKLOWDUN_LOG")
+        .unwrap_or_else(|_| "arklowdun=info,sqlx=warn".to_string());
+
+    let _ = fmt()
+        .with_env_filter(EnvFilter::new(filter))
         .json()
         .with_target(true)
-        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339());
-
-    let filter = EnvFilter::new("arklowdun=info,sqlx=warn");
-
-    let _ = tracing_subscriber::registry()
-        .with(filter)
-        .with(fmt_layer)
+        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+        .with_current_span(false)
+        .with_span_list(false)
         .try_init();
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,5 +3,6 @@
 
 fn main() {
     arklowdun_lib::init_logging();
+    tracing::debug!(target = "arklowdun", "app booted");
     arklowdun_lib::run()
 }

--- a/src/db/household.ts
+++ b/src/db/household.ts
@@ -1,10 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
+import { log } from "../utils/logger";
 
 export async function defaultHouseholdId(): Promise<string> {
   try {
     return await invoke<string>("get_default_household_id");
   } catch (e) {
-    console.warn("Household id lookup failed; using fallback", e);
+    log.warn("Household id lookup failed; using fallback", e);
     return "default";
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { DashboardView } from "./DashboardView";
 import { ManageView } from "./ManageView";
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import { defaultHouseholdId } from "./db/household";
+import { log } from "./utils/logger";
 const appWindow = getCurrentWindow();
 
 type View =
@@ -175,7 +176,7 @@ async function enforceMinNow(growOnly = true) {
       );
     }
   } catch (e) {
-    console.warn("enforceMinNow failed", e);
+    log.warn("enforceMinNow failed", e);
   }
 }
 
@@ -323,6 +324,7 @@ function navigate(to: View) {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  log.debug("app booted");
   defaultHouseholdId().catch((e) => console.error("DB init failed:", e));
 
   linkDashboard()?.addEventListener("click", (e) => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,23 @@
+type Level = "debug" | "info" | "warn" | "error";
+
+const ORDER: Level[] = ["debug", "info", "warn", "error"];
+const configured = (import.meta.env.VITE_LOG_LEVEL as Level) || "info";
+
+function shouldLog(level: Level) {
+  return ORDER.indexOf(level) >= ORDER.indexOf(configured);
+}
+
+export const log = {
+  debug: (...args: unknown[]) => {
+    if (shouldLog("debug")) console.debug(...args);
+  },
+  info: (...args: unknown[]) => {
+    if (shouldLog("info")) console.info(...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (shouldLog("warn")) console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    if (shouldLog("error")) console.error(...args);
+  },
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+interface ImportMetaEnv {
+  readonly VITE_LOG_LEVEL?: "debug" | "info" | "warn" | "error";
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- configure Rust logging via `TAURI_ARKLOWDUN_LOG` with JSON output and defaults
- add tiny TypeScript logger honoring `VITE_LOG_LEVEL`
- document runtime logging options in README

## Acceptance Criteria
* **A1 (Rust default):** With no `TAURI_ARKLOWDUN_LOG` set, only `arklowdun=info` and `sqlx=warn` events are emitted.
* **A2 (Rust override):** With `TAURI_ARKLOWDUN_LOG="arklowdun=debug,sqlx=info"`, debug messages from our code and info from `sqlx` appear.
* **A3 (No double-init):** Running tests followed by dev does not panic on logging init (`try_init()` used).
* **A4 (TS default):** With no `VITE_LOG_LEVEL`, `log.debug` messages are suppressed; `log.info` shows.
* **A5 (TS override):** `VITE_LOG_LEVEL=warn` suppresses `debug` and `info` in the dev console, but `warn` and `error` remain.
* **A6 (Docs):** README contains the “Logging & Verbosity” section with both env examples.
* **A7 (Non-intrusive):** No unrelated files changed; no schema migrations added.

## Testing
```bash
npm run typecheck
# npm error Missing script: "typecheck"

cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
# Checking arklowdun v0.1.0 (/workspace/Arklowdun/src-tauri)
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.57s

git grep -n '@tauri-apps/plugin-fs' -- src | grep -v 'FilesView' || true
# (no output)

cargo test --manifest-path src-tauri/Cargo.toml
# test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

npm run tauri dev
# Failed to initialize gtk backend!: BoolError { message: "Failed to initialize GTK" }

TAURI_ARKLOWDUN_LOG="arklowdun=debug,sqlx=info" VITE_LOG_LEVEL=warn npm run tauri dev
# {"timestamp":"...","level":"DEBUG","fields":{"message":"app booted","target":"arklowdun"},"target":"arklowdun"}
# Failed to initialize gtk backend!: BoolError { message: "Failed to initialize GTK" }
```

------
https://chatgpt.com/codex/tasks/task_e_68be8de2c864832abe7826582c4e0813