### PR TITLE
PR-04: unify invoke wrapper and error handling

### DIFF
--- a/docs/architecture/1-overview.md
+++ b/docs/architecture/1-overview.md
@@ -1,0 +1,21 @@
+# Overview
+
+## Calling backend commands
+
+Use the `call` helper to invoke Tauri backend commands:
+
+```ts
+import { call } from "../db/call";
+
+const rows = await call<MyRow[]>("vehicles_list", { householdId });
+```
+
+Policy: **No direct `invoke()` outside `src/db/call.ts`.** All errors are normalised into the shared `ArkError` shape:
+
+```ts
+export type ArkError = {
+  code: string;         // machine-usable e.g. "DB/NOT_FOUND", "IO/ENOENT", "VALIDATION"
+  message: string;      // user-facing, safe to display
+  details?: unknown;    // optional structured debug payload
+};
+```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "test": "node --loader ts-node/esm --test tests/*.ts tests/*.js",
     "lint:rs": "cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings",
     "gen:models": "cargo test --no-default-features --manifest-path src-tauri/Cargo.toml",
-    "check:models": "npm run gen:models && git diff --exit-code -- src/bindings"
+    "check:models": "npm run gen:models && git diff --exit-code -- src/bindings",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "guard:invoke": "bash scripts/guards/no-direct-invoke.sh",
+    "check": "npm run typecheck && echo TS OK"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",

--- a/scripts/guards/no-direct-invoke.sh
+++ b/scripts/guards/no-direct-invoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+hits=$(git grep -n -F "invoke(" -- src | grep -v "src/db/call.ts" || true)
+if [[ -n "$hits" ]]; then
+  echo "❌ Direct invoke() calls found:"
+  echo "$hits"
+  exit 1
+fi
+echo "✅ No direct invoke() calls."

--- a/src/BillsView.ts
+++ b/src/BillsView.ts
@@ -9,6 +9,7 @@ import type { Bill } from "./models";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { billsRepo } from "./repos";
+import { showError } from "./ui/errors";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -34,7 +35,7 @@ function renderBills(listEl: HTMLUListElement, bills: Bill[]) {
       try {
         await openPath(await resolvePath(b.root_key, b.relative_path));
       } catch {
-        alert(`File location unavailable (root: ${b.root_key})`);
+        showError(`File location unavailable (root: ${b.root_key})`);
       }
     });
     li.appendChild(btn);

--- a/src/BudgetView.ts
+++ b/src/BudgetView.ts
@@ -3,6 +3,7 @@ import type { BudgetCategory, Expense } from "./models";
 import { defaultHouseholdId } from "./db/household";
 import { toDate, nowMs } from "./db/time";
 import { budgetCategoriesRepo, expensesRepo } from "./repos";
+import { showError } from "./ui/errors";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -142,7 +143,7 @@ export async function BudgetView(container: HTMLElement) {
   expForm.addEventListener("submit", async (e) => {
     e.preventDefault();
     if (!expCategory.value) {
-      alert("Please add a category first.");
+      showError("Please add a category first.");
       return;
     }
     const amt = Number(expAmount.value);

--- a/src/CalendarView.ts
+++ b/src/CalendarView.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { call } from "./db/call";
 import {
   isPermissionGranted,
   requestPermission,
@@ -10,7 +10,7 @@ import type { Event } from "./models";
 
 async function fetchEvents(): Promise<Event[]> {
   const hh = await defaultHouseholdId();
-  return await invoke<Event[]>("events_list_range", {
+  return await call<Event[]>("events_list_range", {
     householdId: hh,
     start: 0,
     end: Number.MAX_SAFE_INTEGER,
@@ -21,7 +21,7 @@ async function saveEvent(
   event: Omit<Event, "id" | "created_at" | "updated_at" | "household_id" | "deleted_at">,
 ): Promise<Event> {
   const hh = await defaultHouseholdId();
-  return await invoke<Event>("event_create", {
+  return await call<Event>("event_create", {
     data: { ...event, household_id: hh },
   });
 }

--- a/src/InsuranceView.ts
+++ b/src/InsuranceView.ts
@@ -9,6 +9,7 @@ import type { Policy } from "./models";
 import { nowMs, toDate } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
 import { policiesRepo } from "./repos";
+import { showError } from "./ui/errors";
 
 const money = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -34,7 +35,7 @@ function renderPolicies(listEl: HTMLUListElement, policies: Policy[]) {
       try {
         await openPath(await resolvePath(p.root_key, p.relative_path));
       } catch {
-        alert(`File location unavailable (root: ${p.root_key})`);
+        showError(`File location unavailable (root: ${p.root_key})`);
       }
     });
     li.appendChild(btn);

--- a/src/InventoryView.ts
+++ b/src/InventoryView.ts
@@ -6,6 +6,7 @@ import type { InventoryItem } from "./models";
 import { defaultHouseholdId } from "./db/household";
 import { nowMs, toDate } from "./db/time";
 import { inventoryRepo } from "./repos";
+import { showError } from "./ui/errors";
 
 const MAX_TIMEOUT = 2_147_483_647; // ~24.8 days
 function scheduleAt(ts: number, cb: () => void) {
@@ -29,7 +30,7 @@ function renderInventory(listEl: HTMLUListElement, items: InventoryItem[]) {
         try {
           await openPath(await resolvePath(it.root_key, it.relative_path));
         } catch {
-          alert(`File location unavailable (root: ${it.root_key})`);
+          showError(`File location unavailable (root: ${it.root_key})`);
         }
       });
       li.appendChild(btn);

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -2,6 +2,7 @@
 import { openDb } from "./db/open";
 import { newUuidV7 } from "./db/id";
 import { defaultHouseholdId } from "./db/household";
+import { showError } from "./ui/errors";
 
 type Note = {
   id: string;
@@ -197,7 +198,7 @@ export async function NotesView(container: HTMLElement) {
             notes = notes.filter((n) => n.id !== note.id);
             render();
           } catch (err: any) {
-            alert(`Failed to delete note:\n${err?.message ?? String(err)}`);
+            showError(err);
           }
         });
         el.appendChild(del);
@@ -212,7 +213,7 @@ export async function NotesView(container: HTMLElement) {
             await updateNote(householdId, note.id, { z: note.z });
             render();
           } catch (err: any) {
-            alert(`Failed to bring note to front:\n${err?.message ?? String(err)}`);
+            showError(err);
           }
         });
         el.appendChild(bring);
@@ -272,7 +273,7 @@ export async function NotesView(container: HTMLElement) {
       form.reset();
       colorInput.value = "#FFF4B8";
     } catch (err: any) {
-      alert(`Failed to add note:\n${err?.message ?? String(err)}`);
+      showError(err);
     }
   });
 }

--- a/src/PetDetailView.ts
+++ b/src/PetDetailView.ts
@@ -3,6 +3,7 @@ import { sanitizeRelativePath } from "./files/path";
 import type { Pet, PetMedicalRecord } from "./models";
 import { petMedicalRepo, petsRepo } from "./repos";
 import { defaultHouseholdId } from "./db/household";
+import { showError } from "./ui/errors";
 
 export async function PetDetailView(
   container: HTMLElement,
@@ -74,7 +75,7 @@ export async function PetDetailView(
           const { resolvePath } = await import("./files/path");
           await openPath(await resolvePath(m.root_key, m.relative_path));
         } catch {
-          alert("File location unavailable");
+          showError("File location unavailable");
         }
       });
     });
@@ -91,7 +92,7 @@ export async function PetDetailView(
           await render();
         } catch (err) {
           console.error("pet_medical delete failed:", err);
-          alert(`Could not delete medical record: ${String(err)}`);
+          showError(err);
         }
       });
     });
@@ -138,7 +139,7 @@ export async function PetDetailView(
         await render();
       } catch (err) {
         console.error("pet_medical create failed:", err);
-        alert(`Could not save medical record: ${String(err)}`);
+        showError(err);
       }
     });
   }

--- a/src/PropertyView.ts
+++ b/src/PropertyView.ts
@@ -7,6 +7,7 @@ import type { PropertyDocument } from "./models";
 import { propertyDocsRepo } from "./repos";
 import { defaultHouseholdId } from "./db/household";
 import { nowMs, toDate } from "./db/time";
+import { showError } from "./ui/errors";
 
 const MAX_TIMEOUT = 2_147_483_647; // ~24.8 days
 function scheduleAt(ts: number, cb: () => void) {
@@ -28,7 +29,7 @@ function renderDocs(listEl: HTMLUListElement, docs: PropertyDocument[]) {
         try {
           await openPath(await resolvePath(d.root_key, d.relative_path));
         } catch {
-          alert(`File location unavailable (root: ${d.root_key})`);
+          showError(`File location unavailable (root: ${d.root_key})`);
         }
       });
       li.appendChild(btn);

--- a/src/ShoppingListView.ts
+++ b/src/ShoppingListView.ts
@@ -2,6 +2,7 @@
 import { defaultHouseholdId } from "./db/household";
 import { shoppingRepo } from "./repos";
 import type { ShoppingItem } from "./models";
+import { showError } from "./ui/errors";
 
 export async function ShoppingListView(container: HTMLElement) {
   const section = document.createElement("section");
@@ -47,8 +48,8 @@ export async function ShoppingListView(container: HTMLElement) {
           item.completed = cb.checked;
           await shoppingRepo.update(hh, item.id, { completed: item.completed } as Partial<ShoppingItem>);
           render();
-        } catch {
-          alert("Failed to update item.");
+        } catch (err) {
+          showError(err);
           cb.checked = !cb.checked;
         }
       });
@@ -64,8 +65,8 @@ export async function ShoppingListView(container: HTMLElement) {
           await shoppingRepo.delete(hh, item.id);
           items = items.filter((i) => i.id !== item.id);
           render();
-        } catch {
-          alert("Failed to delete item.");
+        } catch (err) {
+          showError(err);
         }
       });
 
@@ -91,8 +92,8 @@ export async function ShoppingListView(container: HTMLElement) {
       items.push(created);
       input.value = "";
       render();
-    } catch {
-      alert("Failed to add item.");
+    } catch (err) {
+      showError(err);
     }
   });
 }

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -11,35 +11,39 @@ export async function VehiclesView(container: HTMLElement) {
   container.appendChild(section);
 
   async function renderList() {
-    const vehicles = await vehiclesRepo.list(hh);
-    section.innerHTML = `<h2>Vehicles</h2><ul id="veh-list"></ul>`;
-    const listEl = section.querySelector<HTMLUListElement>("#veh-list");
-    vehicles.forEach((v) => {
-      const li = document.createElement("li");
-      li.innerHTML = `
+    try {
+      const vehicles = await vehiclesRepo.list(hh);
+      section.innerHTML = `<h2>Vehicles</h2><ul id="veh-list"></ul>`;
+      const listEl = section.querySelector<HTMLUListElement>("#veh-list");
+      vehicles.forEach((v) => {
+        const li = document.createElement("li");
+        li.innerHTML = `
         <span class="veh-name">${v.name}</span>
         <span class="badge">MOT: ${fmt(v.next_mot_due)}</span>
         <span class="badge">Service: ${fmt(v.next_service_due)}</span>
         <button data-id="${v.id}">Open</button>`;
-      listEl?.appendChild(li);
-    });
+        listEl?.appendChild(li);
+      });
 
-    listEl?.addEventListener("click", async (e) => {
-      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>("button[data-id]");
-      if (!btn) return;
-      try {
-        const vehicle = await vehiclesRepo.get(btn.dataset.id!, hh);
-        if (!vehicle) {
-          alert("Vehicle not found");
-          return;
+      listEl?.addEventListener("click", async (e) => {
+        const btn = (e.target as HTMLElement).closest<HTMLButtonElement>("button[data-id]");
+        if (!btn) return;
+        try {
+          const vehicle = await vehiclesRepo.get(btn.dataset.id!, hh);
+          if (!vehicle) {
+            showError("Vehicle not found");
+            return;
+          }
+          VehicleDetailView(section, vehicle, () => {
+            renderList();
+          });
+        } catch (err) {
+          showError(err);
         }
-        VehicleDetailView(section, vehicle, () => {
-          renderList();
-        });
-      } catch (err) {
-        showError(err, "Opening vehicle failed");
-      }
-    });
+      });
+    } catch (err) {
+      showError(err);
+    }
   }
 
   await renderList();

--- a/src/db/call.ts
+++ b/src/db/call.ts
@@ -1,0 +1,24 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ArkError = { code: string; message: string; details?: unknown };
+
+export function toArkError(e: unknown): ArkError {
+  // Tauri error shapes are inconsistent: strings, { message }, { code, message, data }, etc.
+  if (typeof e === "string") return { code: "UNKNOWN", message: e };
+  if (e && typeof e === "object") {
+    const any = e as any;
+    const code = any.code || any.name || "UNKNOWN";
+    const message = any.message || String(e);
+    const details = any.data ?? any.details ?? any.stack ?? undefined;
+    return { code: String(code), message: String(message), details };
+  }
+  return { code: "UNKNOWN", message: String(e) };
+}
+
+export async function call<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  try {
+    return await invoke<T>(cmd, args);
+  } catch (e) {
+    throw toArkError(e);
+  }
+}

--- a/src/db/household.ts
+++ b/src/db/household.ts
@@ -1,9 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
+import { call } from "./call";
 import { log } from "../utils/logger";
 
 export async function defaultHouseholdId(): Promise<string> {
   try {
-    return await invoke<string>("get_default_household_id");
+    return await call<string>("get_default_household_id");
   } catch (e) {
     log.warn("Household id lookup failed; using fallback", e);
     return "default";

--- a/src/db/softDelete.ts
+++ b/src/db/softDelete.ts
@@ -1,9 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
+import { call } from "./call";
 
 export async function deleteHousehold(id: string): Promise<void> {
-  await invoke("household_delete", { householdId: id, id });
+  await call("household_delete", { householdId: id, id });
 }
 
 export async function restoreHousehold(id: string): Promise<void> {
-  await invoke("household_restore", { householdId: id, id });
+  await call("household_restore", { householdId: id, id });
 }

--- a/src/db/vehiclesRepo.ts
+++ b/src/db/vehiclesRepo.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { call } from "./call";
 import type { Vehicle } from "../bindings/Vehicle";
 
 function normalize(v: Vehicle): Vehicle {
@@ -11,32 +11,32 @@ function normalize(v: Vehicle): Vehicle {
 
 export const vehiclesRepo = {
   async list(householdId: string): Promise<Vehicle[]> {
-    const rows = await invoke<Vehicle[]>("vehicles_list", { householdId });
+    const rows = await call<Vehicle[]>("vehicles_list", { householdId });
     return rows.map(normalize);
   },
 
     async get(id: string, householdId: string): Promise<Vehicle | null> {
-      const row = await invoke<Vehicle | null>("vehicles_get", { id, householdId });
+      const row = await call<Vehicle | null>("vehicles_get", { id, householdId });
       return row ? normalize(row) : null;
     },
 
   async create(householdId: string, data: Partial<Vehicle>): Promise<Vehicle> {
-    const row = await invoke<Vehicle>("vehicles_create", {
+    const row = await call<Vehicle>("vehicles_create", {
       data: { ...data, household_id: householdId },
     });
     return normalize(row);
   },
 
   async update(householdId: string, id: string, data: Partial<Vehicle>): Promise<void> {
-    await invoke("vehicles_update", { id, data, householdId });
+    await call("vehicles_update", { id, data, householdId });
   },
 
   async delete(householdId: string, id: string): Promise<void> {
-    await invoke("vehicles_delete", { householdId, id });
+    await call("vehicles_delete", { householdId, id });
   },
 
   async restore(householdId: string, id: string): Promise<void> {
-    await invoke("vehicles_restore", { householdId, id });
+    await call("vehicles_restore", { householdId, id });
   },
 };
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,11 +1,9 @@
 // src/debug.ts
-import { invoke as realInvoke } from "@tauri-apps/api/core";
 
 // Loud global JS errors
 window.addEventListener("error", (e) => {
   const msg = `JS Error: ${e.message}\n${e.error?.stack ?? ""}`;
   console.error(msg);
-  alert(msg); // make it impossible to miss
 });
 
 window.addEventListener("unhandledrejection", (e: PromiseRejectionEvent) => {
@@ -14,19 +12,5 @@ window.addEventListener("unhandledrejection", (e: PromiseRejectionEvent) => {
     typeof reason === "object" ? JSON.stringify(reason, null, 2) : String(reason)
   }`;
   console.error(msg);
-  alert(msg);
 });
 
-// Wrap tauri invoke so backend failures are visible
-export async function invoke<T = unknown>(cmd: string, args?: Record<string, any>): Promise<T> {
-  try {
-    return await realInvoke<T>(cmd, args);
-  } catch (err: any) {
-    const detail =
-      typeof err === "object" ? JSON.stringify(err, null, 2) : String(err);
-    const msg = `invoke("${cmd}") failed:\n${detail}\nargs: ${JSON.stringify(args ?? {}, null, 2)}`;
-    console.error(msg);
-    alert(msg);
-    throw err; // keep normal behavior after shouting
-  }
-}

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -1,12 +1,10 @@
 // src/repos.ts
-// Use our debug invoke so failures show args + stack.
-import { invoke } from "./debug";
+import { call } from "./db/call";
 
 import type {
   Bill,
   Policy,
   PropertyDocument,
-  Vehicle,
   Pet,
   PetMedicalRecord,
   FamilyMember,
@@ -34,7 +32,7 @@ function domainRepo<T extends object>(table: string, defaultOrderBy: string) {
           'Do not use domainRepo("events"). Use eventsApi.listRange(...) (events_list_range) instead.'
         );
       }
-      return await invoke<T[]>(`${table}_list`, {
+      return await call<T[]>(`${table}_list`, {
         householdId: opts.householdId,
         orderBy: opts.orderBy ?? defaultOrderBy,
         limit: opts.limit,
@@ -46,7 +44,7 @@ function domainRepo<T extends object>(table: string, defaultOrderBy: string) {
       if (table === "events") {
         throw new Error('Do not use domainRepo("events"). Use eventsApi.* helpers.');
       }
-      return await invoke<T>(`${table}_create`, {
+      return await call<T>(`${table}_create`, {
         data: { ...data, household_id: householdId },
       });
     },
@@ -55,21 +53,21 @@ function domainRepo<T extends object>(table: string, defaultOrderBy: string) {
       if (table === "events") {
         throw new Error('Do not use domainRepo("events"). Use eventsApi.* helpers.');
       }
-      await invoke(`${table}_update`, { id, data, householdId });
+      await call(`${table}_update`, { id, data, householdId });
     },
 
     async delete(householdId: string, id: string): Promise<void> {
       if (table === "events") {
         throw new Error('Do not use domainRepo("events"). Use eventsApi.* helpers.');
       }
-      await invoke(`${table}_delete`, { householdId, id });
+      await call(`${table}_delete`, { householdId, id });
     },
 
     async restore(householdId: string, id: string): Promise<void> {
       if (table === "events") {
         throw new Error('Do not use domainRepo("events"). Use eventsApi.* helpers.');
       }
-      await invoke(`${table}_restore`, { householdId, id });
+      await call(`${table}_restore`, { householdId, id });
     },
   };
 }
@@ -92,18 +90,18 @@ export const expensesRepo         = domainRepo<Expense>("expenses", "date DESC, 
 // ---- Events: dedicated API (uses events_list_range and singular CRUD) ----
 export const eventsApi = {
   async listRange(householdId: string, start = 0, end = Number.MAX_SAFE_INTEGER): Promise<Event[]> {
-    return await invoke<Event[]>("events_list_range", { householdId, start, end });
+    return await call<Event[]>("events_list_range", { householdId, start, end });
   },
   async create(householdId: string, data: Partial<Event>): Promise<Event> {
-    return await invoke<Event>("event_create", { data: { ...data, household_id: householdId } });
+    return await call<Event>("event_create", { data: { ...data, household_id: householdId } });
   },
   async update(householdId: string, id: string, data: Partial<Event>): Promise<void> {
-    await invoke("event_update", { id, data, householdId });
+    await call("event_update", { id, data, householdId });
   },
   async delete(householdId: string, id: string): Promise<void> {
-    await invoke("event_delete", { householdId, id });
+    await call("event_delete", { householdId, id });
   },
   async restore(householdId: string, id: string): Promise<void> {
-    await invoke("event_restore", { householdId, id });
+    await call("event_restore", { householdId, id });
   },
 };

--- a/src/ui/errors.ts
+++ b/src/ui/errors.ts
@@ -1,15 +1,21 @@
-export function showError(err: unknown, context?: string) {
-  const msg = err instanceof Error
-    ? `${context ?? "Error"}: ${err.message}`
-    : typeof err === "string"
-    ? `${context ?? "Error"}: ${err}`
-    : `${context ?? "Error"}: ${JSON.stringify(err)}`;
-  console.error(err);
-  alert(msg);
+import type { ArkError } from "../db/call";
+import { toArkError } from "../db/call";
+import { log } from "../utils/logger";
+
+export function showError(err: unknown) {
+  const e: ArkError =
+    typeof err === "object" && err && "code" in (err as any) && "message" in (err as any)
+      ? (err as ArkError)
+      : toArkError(err);
+
+  const container = document.querySelector("#errors");
+  if (container) {
+    container.textContent = `${e.message} (${e.code})`;
+  }
+  log.error("error", e);
 }
 
 window.addEventListener("unhandledrejection", (e) => {
   console.error("Unhandled promise rejection", e.reason);
-  showError(e.reason, "Unhandled Promise Rejection");
+  showError(e.reason);
 });
-


### PR DESCRIPTION
## Summary
- Add `call` wrapper normalising Tauri errors into a shared `ArkError` shape.
- Centralise error rendering via `showError` and remove `alert()`s from UI paths.
- Replace all direct `invoke()` calls with the new wrapper and add a guard script.

## Testing
- `git grep -n -F 'invoke(' -- src | grep -v 'src/db/call.ts' || true`
- `git grep -n -F 'alert(' -- src | grep -v 'dev' || true`
- `npm run typecheck`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` *(fails: missing glib-2.0)*
- `npm run guard:invoke`


------
https://chatgpt.com/codex/tasks/task_e_68be9aaf11d4832aa72577e8526582fa