### PR TITLE
[PR-05] Consistent empty states

### DIFF
--- a/docs/architecture/1-overview.md
+++ b/docs/architecture/1-overview.md
@@ -19,3 +19,7 @@ export type ArkError = {
   details?: unknown;    // optional structured debug payload
 };
 ```
+
+## Empty State
+Use `createEmptyState({ title, description?, actionLabel?, onAction?, icon? })` for any list view with zero items.
+Policy: avoid ad-hoc "No X yet" strings; render a consistent component for clarity and polish.

--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -4,6 +4,7 @@ import { defaultHouseholdId } from "./db/household";
 import { billsRepo, policiesRepo, eventsApi } from "./repos";
 import { vehiclesRepo } from "./db/vehiclesRepo";
 import type { Event } from "./models";
+import { STR } from "./ui/strings";
 const money = new Intl.NumberFormat(undefined, { style: "currency", currency: "GBP" });
 
 function statusFor(dueMs: number, now: number): "soon" | "today" | "overdue" {
@@ -103,7 +104,15 @@ export async function DashboardView(container: HTMLElement) {
   // Render
   items.sort((a, b) => a.date - b.date);
   if (!items.length) {
-    if (listEl) listEl.textContent = "No upcoming items";
+    if (listEl) {
+      const { createEmptyState } = await import("./ui/emptyState");
+      listEl.appendChild(
+        createEmptyState({
+          title: STR.empty.dashboardTitle,
+          description: "You're all caught up.",
+        }),
+      );
+    }
   } else {
     items.forEach(({ date, text }) => {
       const li = document.createElement("div");

--- a/src/FilesView.ts
+++ b/src/FilesView.ts
@@ -7,6 +7,7 @@ import {
 } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { STR } from "./ui/strings";
 
 function renderBreadcrumb(path: string, el: HTMLElement) {
   el.innerHTML = "";
@@ -31,19 +32,19 @@ async function listDirectory(
   renderBreadcrumb(dir, pathEl);
   listEl.innerHTML = "";
   if (entries.length === 0) {
-    const emptyRow = document.createElement("tr");
-    const emptyCell = document.createElement("td");
-    emptyCell.colSpan = 5;
-    const msg = document.createElement("div");
-    msg.className = "files__empty";
-    msg.textContent = "No files here yet";
-    const ghostBtn = document.createElement("button");
-    ghostBtn.className = "btn btn--ghost";
-    ghostBtn.textContent = "New File";
-    msg.appendChild(ghostBtn);
-    emptyCell.appendChild(msg);
-    emptyRow.appendChild(emptyCell);
-    listEl.appendChild(emptyRow);
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    const { createEmptyState } = await import("./ui/emptyState");
+    cell.appendChild(
+      createEmptyState({
+        title: STR.empty.filesTitle,
+        actionLabel: "New file",
+        onAction: () => setDir(dir),
+      }),
+    );
+    row.appendChild(cell);
+    listEl.appendChild(row);
     return;
   }
   for (const entry of entries) {

--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -1,3 +1,6 @@
+import { createEmptyState } from "./ui/emptyState";
+import { STR } from "./ui/strings";
+
 export function SettingsView(container: HTMLElement) {
   const section = document.createElement("section");
   section.className = "settings";
@@ -7,32 +10,36 @@ export function SettingsView(container: HTMLElement) {
 
     <section class="card settings__section" aria-labelledby="settings-general">
       <h3 id="settings-general">General</h3>
-      <p class="settings__empty">No settings yet.</p>
+      <div class="settings__empty"></div>
     </section>
 
     <section class="card settings__section" aria-labelledby="settings-storage">
       <h3 id="settings-storage">Storage and permissions</h3>
-      <p class="settings__empty">No settings yet.</p>
+      <div class="settings__empty"></div>
     </section>
 
     <section class="card settings__section" aria-labelledby="settings-notifications">
       <h3 id="settings-notifications">Notifications</h3>
-      <p class="settings__empty">No settings yet.</p>
+      <div class="settings__empty"></div>
     </section>
 
     <section class="card settings__section" aria-labelledby="settings-appearance">
       <h3 id="settings-appearance">Appearance</h3>
-      <p class="settings__empty">No settings yet.</p>
+      <div class="settings__empty"></div>
     </section>
 
     <section class="card settings__section" aria-labelledby="settings-about">
       <h3 id="settings-about">About and diagnostics</h3>
-      <p class="settings__empty">No settings yet.</p>
+      <div class="settings__empty"></div>
     </section>
   `;
 
   container.innerHTML = "";
   container.appendChild(section);
+
+  section
+    .querySelectorAll<HTMLElement>(".settings__empty")
+    .forEach((el) => el.appendChild(createEmptyState({ title: STR.empty.settingsTitle })));
 
   section
     .querySelector<HTMLAnchorElement>(".settings__back")

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -3,6 +3,7 @@ import { defaultHouseholdId } from "./db/household";
 import { fmt } from "./ui/fmt";
 import { showError } from "./ui/errors";
 import { VehicleDetailView } from "./VehicleDetail";
+import { STR } from "./ui/strings";
 
 export async function VehiclesView(container: HTMLElement) {
   const hh = await defaultHouseholdId();
@@ -11,21 +12,33 @@ export async function VehiclesView(container: HTMLElement) {
   container.appendChild(section);
 
   async function renderList() {
-    try {
-      const vehicles = await vehiclesRepo.list(hh);
-      section.innerHTML = `<h2>Vehicles</h2><ul id="veh-list"></ul>`;
-      const listEl = section.querySelector<HTMLUListElement>("#veh-list");
-      vehicles.forEach((v) => {
-        const li = document.createElement("li");
-        li.innerHTML = `
+      try {
+        const vehicles = await vehiclesRepo.list(hh);
+        section.innerHTML = `<h2>Vehicles</h2><ul id="veh-list"></ul>`;
+        const listEl = section.querySelector<HTMLUListElement>("#veh-list");
+        if (!vehicles.length) {
+          const li = document.createElement("li");
+          const { createEmptyState } = await import("./ui/emptyState");
+          li.appendChild(
+            createEmptyState({
+              title: STR.empty.vehiclesTitle,
+              description: STR.empty.vehiclesDesc,
+            }),
+          );
+          listEl?.appendChild(li);
+          return;
+        }
+        vehicles.forEach((v) => {
+          const li = document.createElement("li");
+          li.innerHTML = `
         <span class="veh-name">${v.name}</span>
         <span class="badge">MOT: ${fmt(v.next_mot_due)}</span>
         <span class="badge">Service: ${fmt(v.next_service_due)}</span>
         <button data-id="${v.id}">Open</button>`;
-        listEl?.appendChild(li);
-      });
+          listEl?.appendChild(li);
+        });
 
-      listEl?.addEventListener("click", async (e) => {
+        listEl?.addEventListener("click", async (e) => {
         const btn = (e.target as HTMLElement).closest<HTMLButtonElement>("button[data-id]");
         if (!btn) return;
         try {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -891,6 +891,38 @@ footer a.footer__settings {
 .calendar__form { display: flex; gap: var(--space-2); }
 .calendar__form input { flex: 1; }
 
+/* Empty state component */
+.empty-state {
+  --es-bg: var(--surface-muted, #f6f7f9);
+  --es-fg: var(--text-muted, #6b7280);
+  --es-title: var(--text, #111827);
+  --es-border: var(--border, rgba(0,0,0,0.08));
+
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 2rem;
+  border: 1px dashed var(--es-border);
+  border-radius: 12px;
+  background: var(--es-bg);
+  color: var(--es-fg);
+  gap: .5rem;
+  min-height: 140px;
+}
+
+.empty-state__icon { font-size: 1.8rem; opacity: .8; }
+.empty-state__title { margin: 0; color: var(--es-title); font-size: 1.1rem; }
+.empty-state__desc { margin: 0; max-width: 34ch; }
+.empty-state__action {
+  margin-top: .5rem;
+  padding: .5rem .8rem;
+  border-radius: 8px;
+  border: 1px solid var(--es-border);
+  background: white;
+  cursor: pointer;
+}
+.empty-state__action:hover { filter: brightness(0.98); }
+
 /* ========================================================================== */
 /* END                                                                        */
 /* ========================================================================== */

--- a/src/ui/emptyState.ts
+++ b/src/ui/emptyState.ts
@@ -1,0 +1,48 @@
+export type EmptyStateOpts = {
+  title: string;              // e.g., "No bills"
+  description?: string;       // e.g., "New bills will appear here."
+  actionLabel?: string;       // e.g., "Add bill"
+  onAction?: () => void;      // handler for the CTA
+  icon?: string;              // optional emoji or icon class
+  id?: string;                // optional identifier for tests/greps
+};
+
+export function createEmptyState(opts: EmptyStateOpts): HTMLElement {
+  const root = document.createElement("div");
+  root.className = "empty-state";
+  if (opts.id) root.id = opts.id;
+  root.setAttribute("role", "status");       // non-blocking, minimal a11y
+  root.setAttribute("aria-live", "polite");
+
+  if (opts.icon) {
+    const i = document.createElement("div");
+    i.className = "empty-state__icon";
+    i.textContent = opts.icon;               // keep simple; no external assets
+    root.appendChild(i);
+  }
+
+  const h = document.createElement("h3");
+  h.className = "empty-state__title";
+  h.textContent = opts.title;
+  root.appendChild(h);
+
+  if (opts.description) {
+    const p = document.createElement("p");
+    p.className = "empty-state__desc";
+    p.textContent = opts.description;
+    root.appendChild(p);
+  }
+
+  if (opts.actionLabel && opts.onAction) {
+    const btn = document.createElement("button");
+    btn.className = "empty-state__action";
+    btn.textContent = opts.actionLabel;
+    btn.addEventListener("click", (e) => {
+      e.preventDefault();
+      opts.onAction?.();
+    });
+    root.appendChild(btn);
+  }
+
+  return root;
+}

--- a/src/ui/strings.ts
+++ b/src/ui/strings.ts
@@ -1,0 +1,21 @@
+export const STR = {
+  empty: {
+    shoppingTitle: "No shopping items",
+    shoppingDesc: "New items will appear here.",
+    billsTitle: "No bills",
+    billsDesc: "New bills will appear here.",
+    inventoryTitle: "No inventory items",
+    inventoryDesc: "Add your appliances, electronics, and more.",
+    policiesTitle: "No policies",
+    policiesDesc: "New policies will appear here.",
+    propertyTitle: "No property documents",
+    propertyDesc: "Add your property documents here.",
+    vehiclesTitle: "No vehicles",
+    vehiclesDesc: "Add your vehicles to track maintenance.",
+    budgetTitle: "No budget categories",
+    budgetDesc: "Create a category to start budgeting.",
+    filesTitle: "No files here",
+    settingsTitle: "No settings",
+    dashboardTitle: "No upcoming items",
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add createEmptyState DOM helper and token-driven styles
- replace ad-hoc empty messages in list-style views
- document empty-state usage for future consistency

## Testing
- `git grep -n 'No .* yet' -- src || true`
- `git grep -n -F 'No items' -- src || true`
- `npm run typecheck`
- `cargo clippy -- -D warnings` *(fails: could not find `Cargo.toml`)*
- `npm run guard:invoke`
- `git grep -n -F 'alert(' -- src | grep -v 'dev' || true`


------
https://chatgpt.com/codex/tasks/task_e_68bea12c81b0832ab2747da728cfbbd2