### PR TITLE
docs: add architecture overview and fs guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See the [Arklowdun Master Plan](docs/master-plan.md) for the high-level strategi
 
 - `npm run dev` — run Vite dev server (Tauri will attach).
 - `npm run tauri` — run Tauri CLI (build/dev/bundle).
+- `npm run check-all` — run local guard checks.
 
 Recommended IDE: VS Code with Tauri and rust-analyzer extensions.
 
@@ -34,3 +35,7 @@ Recommended IDE: VS Code with Tauri and rust-analyzer extensions.
 Schema constraint guidelines live in [docs/integrity-rules.md](docs/integrity-rules.md).
 The first migration to apply them will be
 `migrations/202509021200_add_integrity_constraints.sql`.
+
+## Documentation
+
+- [Architecture Overview](docs/architecture/1-overview.md)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "dev:profile": "VITE_ENV=development node --loader ts-node/esm scripts/dev/seed.ts --profile",
     "test:coverage": "vitest run --coverage",
     "cov:rs": "node scripts/cov-rs.mjs",
-    "cov:all": "npm run test:coverage && npm run cov:rs"
+    "cov:all": "npm run test:coverage && npm run cov:rs",
+    "check:plugin-fs": "node scripts/guards/check-plugin-fs-usage.mjs",
+    "check-all": "npm run check:plugin-fs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",

--- a/scripts/guards/check-plugin-fs-usage.mjs
+++ b/scripts/guards/check-plugin-fs-usage.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SRC_DIR = path.join(REPO_ROOT, 'src');
+
+// Resolve all allowlists to absolute paths
+const allowedDirs = [
+  path.join(SRC_DIR, 'fs'),
+  path.join(SRC_DIR, 'files'),
+].map((p) => path.resolve(p));
+
+const allowedFiles = [path.join(SRC_DIR, 'storage.ts')].map((p) => path.resolve(p));
+
+const CODE_EXT_RE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/i;
+const TARGET = '@tauri-apps/plugin-fs';
+
+async function walk(dir, files = []) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fullPath, files);
+    } else if (entry.isFile() && CODE_EXT_RE.test(entry.name)) {
+      files.push(path.resolve(fullPath));
+    }
+  }
+  return files;
+}
+
+function isAllowed(file) {
+  const f = path.resolve(file);
+  if (allowedFiles.includes(f)) return true;
+  return allowedDirs.some((d) => f.startsWith(d + path.sep));
+}
+
+(async () => {
+  const files = await walk(SRC_DIR).catch((e) => {
+    console.error(`Failed to scan src/: ${e?.message || e}`);
+    process.exit(2);
+  });
+  const violations = [];
+  for (const file of files) {
+    const content = await readFile(file, 'utf8').catch(() => '');
+    if (content.includes(TARGET) && !isAllowed(file)) {
+      violations.push(path.relative(REPO_ROOT, file));
+    }
+  }
+  if (violations.length) {
+    console.error('Forbidden @tauri-apps/plugin-fs usage in:');
+    for (const v of violations) {
+      console.error(' - ' + v);
+    }
+    process.exit(1);
+  } else {
+    console.log('check-plugin-fs-usage: OK');
+  }
+})();

--- a/src/FilesView.ts
+++ b/src/FilesView.ts
@@ -1,10 +1,5 @@
 import { open } from "@tauri-apps/plugin-dialog";
-import {
-  readDir,
-  writeTextFile,
-  remove,
-  mkdir,
-} from "@tauri-apps/plugin-fs";
+import { readDir, writeTextFile, remove, mkdir } from "./files/fs";
 import { join } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { STR } from "./ui/strings";

--- a/src/files/fs.ts
+++ b/src/files/fs.ts
@@ -1,0 +1,17 @@
+import {
+  readDir,
+  readTextFile,
+  readFile,
+  writeTextFile,
+  remove,
+  mkdir,
+} from "@tauri-apps/plugin-fs";
+
+export {
+  readDir,
+  readTextFile,
+  readFile,
+  writeTextFile,
+  remove,
+  mkdir,
+};


### PR DESCRIPTION
## Summary
- document runtime architecture, storage rules and boundaries for Arklowdun
- add guard script preventing `@tauri-apps/plugin-fs` usage outside `src/files`/`src/fs`
- expose guard via `npm run check-all` and link architecture overview from README

## Testing
- `npm test`
- `npm run typecheck`
- `npm run check-all`
- `npm run check-all` (with intentional violation, fails)

------
https://chatgpt.com/codex/tasks/task_e_68c02f111e40832a89fb021bff25d7fc