### PR TITLE
Fix search union with household scope and UI sanitization

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,14 +53,16 @@
       </div>
     </aside>
     <header class="topbar">
-      <input
-        id="omnibox"
-        type="search"
-        placeholder="Search..."
-        aria-label="Search"
-        autocomplete="off"
-      />
-      <div id="omnibox-results" class="omnibox__results" hidden></div>
+      <div class="omnibox">
+        <input
+          id="omnibox"
+          type="search"
+          placeholder="Search..."
+          aria-label="Search"
+          autocomplete="off"
+        />
+        <div id="omnibox-results" class="omnibox__results" hidden></div>
+      </div>
     </header>
     <main id="view" class="container"></main>
     <footer role="contentinfo" class="footer">

--- a/migrations/202509101200_search_indexes.sql
+++ b/migrations/202509101200_search_indexes.sql
@@ -1,0 +1,4 @@
+-- Prefix search indexes for files and events
+CREATE INDEX IF NOT EXISTS idx_files_household_filename ON files(household_id, filename);
+CREATE INDEX IF NOT EXISTS idx_events_household_title ON events(household_id, title);
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,111 +452,108 @@ pub struct SearchErrorPayload {
 #[tauri::command]
 async fn search_entities(
     state: State<'_, AppState>,
+    household_id: String,
     query: String,
     limit: i64,
     offset: i64,
 ) -> Result<Vec<SearchResult>, SearchErrorPayload> {
     use sqlx::Row;
     let pool = &state.pool;
-    let q_lower = query.to_lowercase();
-    let mut results: Vec<(i32, usize, SearchResult)> = Vec::new();
-    let mut ord: usize = 0;
 
-    // Files prefix match
-    let file_rows = sqlx::query(
-        "SELECT id, filename, updated_at FROM files WHERE filename LIKE ?1 || '%' ORDER BY filename ASC LIMIT ?2 OFFSET ?3",
-    )
-    .bind(&query)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| SearchErrorPayload {
-        code: "DB/QUERY_FAILED".into(),
-        message: "Search failed".into(),
-        details: serde_json::json!({ "error": e.to_string() }),
-    })?;
-    for row in file_rows {
-        let filename: String = row.try_get("filename").unwrap_or_default();
-        let score = if filename.eq_ignore_ascii_case(&query) {
-            2
-        } else if filename.to_lowercase().contains(&q_lower) {
-            1
-        } else {
-            0
-        };
-        let id: String = row.try_get("id").unwrap_or_default();
-        let updated_at: i64 = row.try_get("updated_at").unwrap_or_default();
-        results.push((score, ord, SearchResult::File { id, filename, updated_at }));
-        ord += 1;
+    let file_prefix = format!("{}%", query);
+    let sub = format!("%{}%", query);
+
+    // SQL parameters:
+    // ?1 household_id
+    // ?2 file prefix (query%)
+    // ?3 exact query
+    // ?4 substring (%query%)
+    // ?5 limit
+    // ?6 offset
+    let sql = r#"
+      SELECT 'File' AS kind, id, filename AS a1, NULL AS a2, NULL AS a3, updated_at AS ts,
+             CASE
+               WHEN filename = ?3 COLLATE NOCASE THEN 2
+               WHEN filename LIKE ?2 COLLATE NOCASE THEN 1
+               ELSE 0
+             END AS score
+      FROM files
+      WHERE household_id = ?1 AND filename LIKE ?2 COLLATE NOCASE
+
+      UNION ALL
+
+      SELECT 'Event' AS kind, id, title AS a1, CAST(start_at_utc AS TEXT) AS a2, tz AS a3, start_at_utc AS ts,
+             CASE
+               WHEN title = ?3 COLLATE NOCASE THEN 2
+               WHEN title LIKE ?4 COLLATE NOCASE THEN 1
+               ELSE 0
+             END AS score
+      FROM events
+      WHERE household_id = ?1 AND title LIKE ?4 COLLATE NOCASE
+
+      UNION ALL
+
+      SELECT 'Note' AS kind, id, SUBSTR(text, 1, 80) AS a1, color AS a2, NULL AS a3, updated_at AS ts,
+             CASE
+               WHEN text = ?3 COLLATE NOCASE THEN 2
+               WHEN text LIKE ?4 COLLATE NOCASE THEN 1
+               ELSE 0
+             END AS score
+      FROM notes
+      WHERE household_id = ?1 AND text LIKE ?4 COLLATE NOCASE
+
+      ORDER BY score DESC, ts DESC
+      LIMIT ?5 OFFSET ?6;
+    "#;
+
+    let rows = sqlx::query(sql)
+        .bind(&household_id) // ?1
+        .bind(&file_prefix) // ?2
+        .bind(&query) // ?3
+        .bind(&sub) // ?4
+        .bind(limit) // ?5
+        .bind(offset) // ?6
+        .fetch_all(pool)
+        .await
+        .map_err(|e| SearchErrorPayload {
+            code: "DB/QUERY_FAILED".into(),
+            message: "Search failed".into(),
+            details: serde_json::json!({ "error": e.to_string() }),
+        })?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for r in rows {
+        let kind: String = r.try_get("kind").unwrap_or_default();
+        let id: String = r.try_get("id").unwrap_or_default();
+        match kind.as_str() {
+            "File" => {
+                let filename: String = r.try_get("a1").unwrap_or_default();
+                let updated_at: i64 = r.try_get("ts").unwrap_or_default();
+                out.push(SearchResult::File { id, filename, updated_at });
+            }
+            "Event" => {
+                let title: String = r.try_get("a1").unwrap_or_default();
+                let start_at_txt: String = r.try_get("a2").unwrap_or_default();
+                let tz: String = r.try_get("a3").unwrap_or_default();
+                let start_at_utc: i64 = start_at_txt.parse().unwrap_or_default();
+                out.push(SearchResult::Event { id, title, start_at_utc, tz });
+            }
+            "Note" => {
+                let snippet: String = r.try_get("a1").unwrap_or_default();
+                let color: String = r.try_get("a2").unwrap_or_default();
+                let updated_at: i64 = r.try_get("ts").unwrap_or_default();
+                out.push(SearchResult::Note {
+                    id,
+                    snippet,
+                    updated_at,
+                    color,
+                });
+            }
+            _ => {}
+        }
     }
 
-    // Events substring match
-    let event_rows = sqlx::query(
-        "SELECT id, title, start_at_utc, tz FROM events WHERE title LIKE '%' || ?1 || '%' ORDER BY title ASC LIMIT ?2 OFFSET ?3",
-    )
-    .bind(&query)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| SearchErrorPayload {
-        code: "DB/QUERY_FAILED".into(),
-        message: "Search failed".into(),
-        details: serde_json::json!({ "error": e.to_string() }),
-    })?;
-    for row in event_rows {
-        let title: String = row.try_get("title").unwrap_or_default();
-        let score = if title.eq_ignore_ascii_case(&query) {
-            2
-        } else if title.to_lowercase().contains(&q_lower) {
-            1
-        } else {
-            0
-        };
-        let id: String = row.try_get("id").unwrap_or_default();
-        let start_at_utc: i64 = row.try_get("start_at_utc").unwrap_or_default();
-        let tz: String = row.try_get("tz").unwrap_or_default();
-        results.push((score, ord, SearchResult::Event { id, title, start_at_utc, tz }));
-        ord += 1;
-    }
-
-    // Notes substring match
-    let note_rows = sqlx::query(
-        "SELECT id, text, updated_at, color FROM notes WHERE text LIKE '%' || ?1 || '%' ORDER BY updated_at DESC LIMIT ?2 OFFSET ?3",
-    )
-    .bind(&query)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| SearchErrorPayload {
-        code: "DB/QUERY_FAILED".into(),
-        message: "Search failed".into(),
-        details: serde_json::json!({ "error": e.to_string() }),
-    })?;
-    for row in note_rows {
-        let text: String = row.try_get("text").unwrap_or_default();
-        let score = if text.eq_ignore_ascii_case(&query) {
-            2
-        } else if text.to_lowercase().contains(&q_lower) {
-            1
-        } else {
-            0
-        };
-        let snippet: String = text.chars().take(80).collect();
-        let id: String = row.try_get("id").unwrap_or_default();
-        let updated_at: i64 = row.try_get("updated_at").unwrap_or_default();
-        let color: String = row.try_get("color").unwrap_or_default();
-        results.push((score, ord, SearchResult::Note { id, snippet, updated_at, color }));
-        ord += 1;
-    }
-
-    results.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
-    if results.len() > 100 {
-        results.truncate(100);
-    }
-    Ok(results.into_iter().map(|(_, _, r)| r).collect())
+    Ok(out)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -482,7 +482,7 @@ async fn search_entities(
 
       UNION ALL
 
-      SELECT 'Event' AS kind, id, title AS a1, CAST(start_at_utc AS TEXT) AS a2, tz AS a3, start_at_utc AS ts,
+      SELECT 'Event' AS kind, id, title AS a1, CAST(start_at_utc AS TEXT) AS a2, COALESCE(tz, 'Europe/London') AS a3, start_at_utc AS ts,
              CASE
                WHEN title = ?3 COLLATE NOCASE THEN 2
                WHEN title LIKE ?4 COLLATE NOCASE THEN 1

--- a/src/services/searchRepo.ts
+++ b/src/services/searchRepo.ts
@@ -1,27 +1,19 @@
-import { call } from "@tauri-apps/api/core";
-
-export type SearchResult =
-  | { kind: "File"; id: string; filename: string; updated_at: number }
-  | {
-      kind: "Event";
-      id: string;
-      title: string;
-      start_at_utc: number;
-      tz: string;
-    }
-  | {
-      kind: "Note";
-      id: string;
-      snippet: string;
-      updated_at: number;
-      color: string;
-    };
+import { call } from "../db/call";
+import { defaultHouseholdId } from "../db/household";
+import type { SearchResult } from "../bindings/SearchResult";
 
 export async function search(
   query: string,
   limit = 100,
   offset = 0,
 ): Promise<SearchResult[]> {
-  return call<SearchResult[]>("search_entities", { query, limit, offset });
+  const householdId = await defaultHouseholdId();
+  return call<SearchResult[]>("search_entities", {
+    householdId,
+    query,
+    limit,
+    offset,
+  });
 }
 
+export type { SearchResult } from "../bindings/SearchResult";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -956,23 +956,44 @@ footer a.footer__settings {
 
 /* Omnibox search */
 .topbar {
-  position: relative;
+  /* fixed header above content area (not full screen) */
+  position: fixed;
+  top: 0;
+  /* keep in sync with sidebar width (extract to var later if you like) */
+  left: 200px;
+  right: 0;
+  height: 48px;
   display: flex;
-  padding: var(--space-2);
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
   background: var(--color-bg);
   border-bottom: 1px solid var(--color-border);
+  z-index: 100; /* above content; below modals */
 }
 
 .topbar input[type="search"] {
   width: 100%;
+  max-width: 520px;
   padding: var(--space-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
 
+.container {
+  /* room for the fixed header so it doesn’t cover content */
+  padding-top: 48px;
+}
+
+.omnibox {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+}
+
 .omnibox__results {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 6px); /* small gap under input */
   left: 0;
   right: 0;
   background: var(--color-bg);
@@ -980,7 +1001,8 @@ footer a.footer__settings {
   border-top: none;
   max-height: 400px;
   overflow-y: auto;
-  z-index: 1000;
+  z-index: 200; /* above header, below modals */
+  box-shadow: var(--shadow-base);
 }
 
 .omnibox__results ul {


### PR DESCRIPTION
## Summary
- Standardize search matching and scoring as case-insensitive and reuse query params
- Add prefix indexes for files and events to support household-scoped lookups
- Prevent multiple "Load more" buttons from stacking in omnibox results

## Testing
- `npm run check-all`
- `npm run guard:invoke`
- `npm run check`
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-run` *(fails: The system library `glib-2.0` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c060b2f62c832a9c309dab2aaedacf