### PR TITLE
fix: anchor omnibox results panel

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -517,13 +517,14 @@ window.addEventListener("DOMContentLoaded", () => {
       });
 
       if (items.length === 100) {
-        const load = document.createElement('div');
+        const load = document.createElement('button');
+        load.type = 'button';
         load.className = 'omnibox__load-more';
         load.textContent = 'Load more';
-        load.onclick = () => {
+        load.addEventListener('click', () => {
           offset += 100;
           run(current, true);
-        };
+        });
         panel.appendChild(load);
       }
 
@@ -636,6 +637,11 @@ window.addEventListener("DOMContentLoaded", () => {
       if (!panel.hidden) positionResults();
     });
     window.addEventListener('scroll', () => {
+      if (!panel.hidden) positionResults();
+    }, { passive: true });
+    // If the sidebar is its own scroll container, keep the panel aligned.
+    const sidebar = document.querySelector<HTMLElement>('.sidebar');
+    sidebar?.addEventListener('scroll', () => {
       if (!panel.hidden) positionResults();
     }, { passive: true });
   linkDashboard()?.addEventListener("click", (e) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -372,6 +372,7 @@ window.addEventListener("DOMContentLoaded", () => {
     let current = '';
     let reqId = 0;
     let activeIndex = -1;
+    let suppressBlurFocus = false;
 
     let announceTimer: number | undefined;
     function announce(text: string) {
@@ -386,14 +387,18 @@ window.addEventListener("DOMContentLoaded", () => {
 
     function positionResults() {
       const r = input.getBoundingClientRect();
-      const GAP = 8;
-      const top = Math.round(r.bottom + 6);
-      const left = Math.round(r.right + GAP);
-      const rightPadding = 16;
-      const maxWidth = Math.min(520, window.innerWidth - left - rightPadding);
+      const MARGIN = 8;
+      const panelWidth = Math.min(520, window.innerWidth - MARGIN * 2);
+      let left = r.right + MARGIN;
+      if (left + panelWidth > window.innerWidth - MARGIN) {
+        left = Math.max(MARGIN, r.left - panelWidth - MARGIN);
+      }
+      const top = Math.round(r.bottom + 4);
+      const maxHeight = Math.min(420, window.innerHeight - top - MARGIN);
       panel.style.top = `${top}px`;
       panel.style.left = `${left}px`;
-      panel.style.width = `${Math.max(260, maxWidth)}px`;
+      panel.style.width = `${panelWidth}px`;
+      panel.style.maxHeight = `${maxHeight}px`;
     }
 
     function hideResults() {
@@ -444,9 +449,9 @@ window.addEventListener("DOMContentLoaded", () => {
         empty.className = 'omnibox__empty';
         empty.textContent = `No results found for ${q}`;
         panel.appendChild(empty);
+        positionResults();
         panel.hidden = false;
         input.setAttribute('aria-expanded', 'true');
-        positionResults();
         announce(`No results for ${q}`);
         return;
       }
@@ -463,6 +468,7 @@ window.addEventListener("DOMContentLoaded", () => {
           li.innerHTML = `<i class="fa-regular fa-file"></i><span>${it.filename}</span><span>${date}</span>`;
           li.addEventListener('click', () => {
             location.hash = '#files';
+            suppressBlurFocus = true;
             hideResults();
             setTimeout(() => input.blur(), 0);
           });
@@ -471,6 +477,7 @@ window.addEventListener("DOMContentLoaded", () => {
           li.innerHTML = `<i class="fa-regular fa-calendar"></i><span>${it.title}</span><span>${date}</span>`;
           li.addEventListener('click', () => {
             location.hash = '#calendar';
+            suppressBlurFocus = true;
             hideResults();
             setTimeout(() => input.blur(), 0);
           });
@@ -479,6 +486,7 @@ window.addEventListener("DOMContentLoaded", () => {
           li.innerHTML = `<i class="fa-regular fa-note-sticky" style="color:${it.color}"></i><span>${it.snippet}</span><span>${date}</span>`;
           li.addEventListener('click', () => {
             location.hash = '#notes';
+            suppressBlurFocus = true;
             hideResults();
             setTimeout(() => input.blur(), 0);
           });
@@ -490,6 +498,7 @@ window.addEventListener("DOMContentLoaded", () => {
           li.innerHTML = `<i class="fa-solid fa-car"></i><span>${title}${reg}${nick}</span><span>${date}</span>`;
           li.addEventListener('click', () => {
             location.hash = '#vehicles';
+            suppressBlurFocus = true;
             hideResults();
             setTimeout(() => input.blur(), 0);
           });
@@ -499,6 +508,7 @@ window.addEventListener("DOMContentLoaded", () => {
           li.innerHTML = `<i class="fa-solid fa-paw"></i><span>${it.name}${species}</span><span>${date}</span>`;
           li.addEventListener('click', () => {
             location.hash = '#pets';
+            suppressBlurFocus = true;
             hideResults();
             setTimeout(() => input.blur(), 0);
           });
@@ -517,9 +527,9 @@ window.addEventListener("DOMContentLoaded", () => {
         panel.appendChild(load);
       }
 
+      positionResults();
       panel.hidden = false;
       input.setAttribute('aria-expanded', 'true');
-      positionResults();
       if (!append) {
         const msg = items.length === 0
           ? `No results for ${q}`
@@ -531,6 +541,10 @@ window.addEventListener("DOMContentLoaded", () => {
       const took = Math.round(performance.now() - start);
       log.debug('search:render', { count: items.length, append, offset, took_ms: took });
     }
+
+    input.addEventListener('focus', () => {
+      positionResults();
+    });
 
     input.addEventListener('input', () => {
       const MINLEN = Number(import.meta.env.VITE_SEARCH_MINLEN ?? '2');
@@ -561,7 +575,6 @@ window.addEventListener("DOMContentLoaded", () => {
         activeIndex = e.key === 'ArrowDown' ? Math.min(activeIndex + 1, options.length - 1) : Math.max(activeIndex - 1, 0);
         options.forEach((el, i) => {
           const active = i === activeIndex;
-          el.classList.toggle('is-active', active);
           el.setAttribute('aria-selected', active ? 'true' : 'false');
         });
         if (activeIndex >= 0) {
@@ -595,6 +608,7 @@ window.addEventListener("DOMContentLoaded", () => {
       } else if (e.key === 'Escape') {
         input.value = '';
         hideResults();
+        input.focus();
       }
     });
 
@@ -608,7 +622,12 @@ window.addEventListener("DOMContentLoaded", () => {
     input.addEventListener('blur', () => {
       setTimeout(() => {
         if (document.activeElement !== input && !panel.contains(document.activeElement)) {
-          hideResults();
+          if (!suppressBlurFocus) {
+            hideResults();
+            input.focus();
+          } else {
+            suppressBlurFocus = false;
+          }
         }
       }, 100);
     });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,7 +5,8 @@
   --z-index-dropdown: 200;
 
   /* Surfaces for the omnibox */
-  --surface: var(--color-accent-soft);           /* pale orange (base) */
+  /* Use sidebar pale orange; if token isn't in scope, fall back to hex */
+  --surface: var(--color-accent-soft, #ffe4d5);
   --surface-hover: var(--color-accent-soft-hover, #fcd9a8);
 }
 
@@ -1000,7 +1001,7 @@ footer a.footer__settings {
   width: 520px;
   max-height: 420px;
   overflow-y: auto;
-  background-color: var(--surface); /* pale orange from --color-accent-soft */
+  background-color: var(--surface, #ffe4d5); /* pale orange from --color-accent-soft */
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 6px);
   box-shadow: var(--shadow-base);
@@ -1025,7 +1026,7 @@ footer a.footer__settings {
   gap: var(--space-2);
   padding: var(--space-2);
   cursor: pointer;
-  background-color: var(--surface); /* pale orange by default */
+  background-color: var(--surface, #ffe4d5); /* pale orange by default */
 }
 
 .omnibox__results li[role="option"]:hover,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1000,7 +1000,7 @@ footer a.footer__settings {
   width: 520px;
   max-height: 420px;
   overflow-y: auto;
-  background: var(--color-bg);
+  background-color: var(--surface); /* pale orange from --color-accent-soft */
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 6px);
   box-shadow: var(--shadow-base);
@@ -1045,8 +1045,12 @@ footer a.footer__settings {
 }
 
 .omnibox__load-more {
-  text-align: center;
+  display: block;
+  width: 100%;
   padding: var(--space-2);
+  text-align: center;
+  background: none;
+  border: 0;
   cursor: pointer;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,10 @@
 :root {
   --radius-sm: 6px;
   --z-index-dropdown: 200;
+
+  /* Surfaces for the omnibox */
+  --surface: var(--color-accent-soft);           /* pale orange (base) */
+  --surface-hover: var(--color-accent-soft-hover, #fcd9a8);
 }
 
 [hidden] {
@@ -1021,14 +1025,12 @@ footer a.footer__settings {
   gap: var(--space-2);
   padding: var(--space-2);
   cursor: pointer;
+  background-color: var(--surface); /* pale orange by default */
 }
 
-.omnibox__results li[role="option"]:hover {
-  background: var(--color-border);
-}
-
+.omnibox__results li[role="option"]:hover,
 .omnibox__results li[role="option"][aria-selected="true"] {
-  background: var(--color-border);
+  background-color: var(--surface-hover); /* deeper orange */
   font-weight: 600;
   outline: 2px solid var(--color-accent, #4a90e2);
   outline-offset: -2px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,11 @@
 
 :root {
   --radius-sm: 6px;
+  --z-index-dropdown: 200;
+}
+
+[hidden] {
+  display: none !important;
 }
 
 /* ========================================================================== */
@@ -989,18 +994,20 @@ footer a.footer__settings {
 .omnibox__results {
   position: fixed;
   width: 520px;
-  max-width: min(90vw, 520px);
-  max-height: 400px;
+  max-height: 420px;
   overflow-y: auto;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 6px);
   box-shadow: var(--shadow-base);
-  z-index: 200;
+  z-index: var(--z-index-dropdown, 200);
+  transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
-.omnibox__results[hidden] {
-  display: none;
+@media (prefers-reduced-motion: reduce) {
+  .omnibox__results {
+    transition: none;
+  }
 }
 
 .omnibox__results ul {
@@ -1020,14 +1027,15 @@ footer a.footer__settings {
   background: var(--color-border);
 }
 
-.omnibox__results li[role="option"].is-active {
+.omnibox__results li[role="option"][aria-selected="true"] {
   background: var(--color-border);
+  font-weight: 600;
   outline: 2px solid var(--color-accent, #4a90e2);
   outline-offset: -2px;
 }
 
 @media (forced-colors: active) {
-  .omnibox__results li[role="option"].is-active {
+  .omnibox__results li[role="option"][aria-selected="true"] {
     outline: 2px solid CanvasText;
     background: Highlight;
     color: HighlightText;

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -40,6 +40,7 @@ h1, h2, h3 { letter-spacing: -0.01em; }
   --color-accent: #ff7e36;
   --color-accent-text: #ffffff;
   --color-accent-soft: #ffe4d5;
+  --color-accent-soft-hover: #fcd9a8;
   --color-success: #166534;
   --color-danger: #b91c1c;
   --color-sidebar-bg: #e9edf2;
@@ -115,6 +116,7 @@ h1, h2, h3 { letter-spacing: -0.01em; }
     --color-accent: #ff7e36;
     --color-accent-text: #ffffff;
     --color-accent-soft: rgba(255, 126, 54, 0.2);
+    --color-accent-soft-hover: rgba(255, 126, 54, 0.3);
     --color-sidebar-bg: #1e293b;
     --color-sidebar-border: #334155;
     --shadow-base: 0 1px 2px rgba(0, 0, 0, 0.4);

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -115,9 +115,9 @@ h1, h2, h3 { letter-spacing: -0.01em; }
     --color-border: #374151;
     --color-accent: #ff7e36;
     --color-accent-text: #ffffff;
-    /* Opaque “pale orange” surfaces for dark UI */
-    --color-accent-soft: #3b2a21;        /* base surface */
-    --color-accent-soft-hover: #4c372b;  /* hover/active surface */
+    /* Opaque "pale orange" surfaces for dark UI */
+    --color-accent-soft: #3b2a21; /* base surface */
+    --color-accent-soft-hover: #4c372b; /* hover/active surface */
     --color-sidebar-bg: #1e293b;
     --color-sidebar-border: #334155;
     --shadow-base: 0 1px 2px rgba(0, 0, 0, 0.4);

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -115,8 +115,9 @@ h1, h2, h3 { letter-spacing: -0.01em; }
     --color-border: #374151;
     --color-accent: #ff7e36;
     --color-accent-text: #ffffff;
-    --color-accent-soft: rgba(255, 126, 54, 0.2);
-    --color-accent-soft-hover: rgba(255, 126, 54, 0.3);
+    /* Opaque “pale orange” surfaces for dark UI */
+    --color-accent-soft: #3b2a21;        /* base surface */
+    --color-accent-soft-hover: #4c372b;  /* hover/active surface */
     --color-sidebar-bg: #1e293b;
     --color-sidebar-border: #334155;
     --shadow-base: 0 1px 2px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Summary
- clamp omnibox dropdown to viewport and flip when sidebar runs out of space
- add chrome tokens and accessible active-row styling

## Testing
- `npm run check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c170cfc264832aaef10c734b57fd09