### PR TITLE
feat: add search micro-cache and capabilities

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -18,6 +18,13 @@ One-character queries are ignored **except** prefix filename searches when a
 `files_index` table is present. Developers can override the front-end rule with
 `VITE_SEARCH_MINLEN`.
 
+## Engine Hygiene
+
+- A 30 s in-memory micro-cache serves duplicate searches keyed by `{q, offset, limit, householdId}` (includes a version field; bump `CACHE_VERSION` to invalidate keys after semantic changes).
+  - Entries expire after 30 s.
+  - Explicit busts on `householdChanged` or `searchInvalidated` events.
+- Capability checks live in `src/shared/capabilities.ts`; features like `files_index` are gated by these probes. Never sort results on the client—preserve backend order.
+
 ## Troubleshooting
 
 - Files missing? Ensure the `files_index` table is present; otherwise Events,

--- a/src/db/household.ts
+++ b/src/db/household.ts
@@ -1,5 +1,6 @@
-import { call } from "./call.ts";
-import { log } from "../utils/logger.ts";
+import { call } from "./call";
+import { log } from "../utils/logger";
+import { emit } from "../shared/events";
 
 export async function defaultHouseholdId(): Promise<string> {
   try {
@@ -13,4 +14,9 @@ export async function defaultHouseholdId(): Promise<string> {
 export function requireHousehold(householdId: string): string {
   if (!householdId) throw new Error("householdId required");
   return householdId;
+}
+
+export async function setDefaultHouseholdId(id: string): Promise<void> {
+  await call("set_default_household_id", { id });
+  emit("householdChanged");
 }

--- a/src/services/searchRepo.ts
+++ b/src/services/searchRepo.ts
@@ -2,6 +2,38 @@ import { call } from "../db/call";
 import { defaultHouseholdId } from "../db/household";
 import type { SearchResult } from "../bindings/SearchResult";
 import { log } from "../utils/logger";
+import { on } from "../shared/events";
+import { probeCaps } from "../shared/capabilities";
+
+probeCaps().catch(() => {});
+
+const CACHE_TTL_MS = 30_000;
+const CACHE_VERSION = 1;
+
+type CacheEntry =
+  | { promise: Promise<SearchResult[]>; tsStart: number }
+  | { results: SearchResult[]; ts: number };
+
+const cache = new Map<string, CacheEntry>();
+const loggedHits = new Set<string>();
+const loggedMisses = new Set<string>();
+
+function stableKey(obj: Record<string, unknown>): string {
+  return JSON.stringify(
+    Object.keys(obj)
+      .sort()
+      .map((k) => [k, (obj as any)[k]])
+  );
+}
+
+function bust() {
+  cache.clear();
+  loggedHits.clear();
+  loggedMisses.clear();
+}
+
+on("householdChanged", bust);
+on("searchInvalidated", bust);
 
 export async function search(
   query: string,
@@ -9,17 +41,63 @@ export async function search(
   offset = 0,
 ): Promise<SearchResult[]> {
   const householdId = await defaultHouseholdId();
-  const payload = await call<unknown>("search_entities", {
+  const key = stableKey({ v: CACHE_VERSION, q: query, offset, limit, householdId });
+  const now = Date.now();
+  const existing = cache.get(key);
+  if (existing) {
+    if ("promise" in existing) {
+      if (!loggedHits.has(key)) {
+        log.debug("search:cache", { key, hit: true, age_ms: 0 });
+        loggedHits.add(key);
+      }
+      return existing.promise;
+    }
+    const age = now - existing.ts;
+    if (age < CACHE_TTL_MS) {
+      if (!loggedHits.has(key)) {
+        log.debug("search:cache", { key, hit: true, age_ms: age });
+        loggedHits.add(key);
+      }
+      return existing.results;
+    }
+    cache.delete(key);
+    loggedHits.delete(key);
+    loggedMisses.delete(key);
+  }
+
+  const promise = call<unknown>("search_entities", {
     householdId,
     query,
     limit,
     offset,
+  }).then((payload) => {
+    if (!Array.isArray(payload)) {
+      log.debug("[search] IPC non-array", payload);
+      return [] as SearchResult[];
+    }
+    return payload as SearchResult[];
   });
-  if (!Array.isArray(payload)) {
-    log.debug("[search] IPC non-array", payload);
-    return [];
+
+  cache.set(key, { promise, tsStart: now });
+
+  try {
+    const results = await promise;
+    cache.set(key, { results, ts: Date.now() });
+    if (!loggedMisses.has(key)) {
+      log.debug("search:cache", { key, hit: false });
+      loggedMisses.add(key);
+    }
+    return results;
+  } catch (err) {
+    cache.delete(key);
+    loggedHits.delete(key);
+    loggedMisses.delete(key);
+    throw err;
   }
-  return payload as SearchResult[];
+}
+
+export function clearSearchCache() {
+  bust();
 }
 
 export type { SearchResult } from "../bindings/SearchResult";

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -1,0 +1,65 @@
+import { call } from "../db/call";
+import { log } from "../utils/logger";
+
+let caps: {
+  files_index: boolean;
+  vehicles_cols: boolean;
+  pets_cols: boolean;
+} | null = null;
+let capsPromise: Promise<void> | null = null;
+let capsTs = 0;
+let capsLogged = false;
+
+async function probe(): Promise<void> {
+  const [files_index, vehicles_cols, pets_cols] = await Promise.all([
+    call<boolean>("db_has_files_index"),
+    call<boolean>("db_has_vehicle_columns"),
+    call<boolean>("db_has_pet_columns"),
+  ]);
+  caps = { files_index, vehicles_cols, pets_cols };
+  capsTs = Date.now();
+  if (!capsLogged) {
+    log.debug("caps:probe", { files_index, vehicles_cols, pets_cols });
+    capsLogged = true;
+  }
+}
+
+async function ensure(): Promise<void> {
+  const stale = !caps || Date.now() - capsTs > 5 * 60_000;
+  if (stale) {
+    if (!capsPromise) {
+      capsPromise = probe().finally(() => {
+        capsPromise = null;
+      });
+    }
+    await capsPromise;
+  }
+}
+
+export async function probeCaps(): Promise<void> {
+  await ensure();
+}
+
+export async function hasFilesIndex(): Promise<boolean> {
+  await ensure();
+  return caps!.files_index;
+}
+
+export async function hasVehicleColumns(): Promise<boolean> {
+  await ensure();
+  return caps!.vehicles_cols;
+}
+
+export async function hasPetColumns(): Promise<boolean> {
+  await ensure();
+  return caps!.pets_cols;
+}
+
+const tableCache = new Map<string, boolean>();
+
+export async function tableExists(name: string): Promise<boolean> {
+  if (tableCache.has(name)) return tableCache.get(name)!;
+  const exists = await call<boolean>("db_table_exists", { name });
+  tableCache.set(name, exists);
+  return exists;
+}

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -1,0 +1,22 @@
+export type AppEvent = 'householdChanged' | 'searchInvalidated';
+
+const listeners = new Map<AppEvent, Set<() => void>>();
+
+export function on(event: AppEvent, fn: () => void): void {
+  if (!listeners.has(event)) listeners.set(event, new Set());
+  listeners.get(event)!.add(fn);
+}
+
+export function off(event: AppEvent, fn: () => void): void {
+  listeners.get(event)?.delete(fn);
+}
+
+export function emit(event: AppEvent): void {
+  listeners.get(event)?.forEach((fn) => {
+    try {
+      fn();
+    } catch (err) {
+      console.error(err);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add 30s micro-cache in searchRepo with logging and event-driven busts
- centralize DB capability probing with new Tauri commands and TS wrappers
- emit searchInvalidated after data writes; document engine hygiene
- wire householdChanged emission and memoize capability probes
- document cache key version and clarify searchInvalidated emit timing

## Testing
- `npm run build`
- `npm run check-all`
- `cargo build --manifest-path src-tauri/Cargo.toml` *(fails: system library `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a587e9e4832a99d04400733f1615