### PR TITLE
PR-13h.1: highlight hardening

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1067,6 +1067,19 @@ footer a.footer__settings {
 .command-palette__results li.cmd-error {
   color: var(--color-danger);
 }
+mark.search-hit {
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  padding: 0 2px;
+  border-radius: var(--radius-sm);
+}
+
+@media (prefers-contrast: more) {
+  mark.search-hit {
+    outline: 2px solid currentColor;
+    text-shadow: 0 0 0 currentColor;
+  }
+}
 
 
 /* ========================================================================== */

--- a/src/ui/CommandPalette.ts
+++ b/src/ui/CommandPalette.ts
@@ -1,6 +1,7 @@
 import { search } from "../services/searchRepo";
 import type { SearchResult } from "../bindings/SearchResult";
 import { showError } from "./errors";
+import { highlight } from "../utils/highlight";
 
 interface PaletteItem {
   kind: string;
@@ -156,7 +157,7 @@ export function initCommandPalette() {
         return;
       }
       const items = results.map(mapResult);
-      render(items);
+      render(items, q);
       announce(`${results.length} results for ${q}`);
     } catch (err) {
       if (my !== reqId) return;
@@ -173,14 +174,16 @@ export function initCommandPalette() {
     list.innerHTML = `<li role="presentation" class="cmd-${kind}">${msg}</li>`;
   }
 
-  function render(items: PaletteItem[]) {
+  function render(items: PaletteItem[], q: string) {
     list.innerHTML = "";
     items.forEach((item, i) => {
       const li = document.createElement("li");
       li.setAttribute("role", "option");
       li.setAttribute("tabindex", "-1");
       li.setAttribute("aria-selected", "false");
-      li.innerHTML = `<i class="${item.icon}"></i><span>${item.title}</span>${item.subtitle ? `<span>${item.subtitle}</span>` : ""}`;
+      const title = highlight(item.title, q);
+      const subtitle = highlight(item.subtitle ?? "", q);
+      li.innerHTML = `<i class="${item.icon}"></i><span>${title}</span>${item.subtitle ? `<span>${subtitle}</span>` : ""}`;
       li.addEventListener("click", () => {
         item.action();
         close();

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -1,0 +1,70 @@
+const ENTITY_MAP: Record<string, string> = {
+  '<': '&lt;',
+  '>': '&gt;',
+  '&': '&amp;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(input: string): string {
+  // TODO: this scans forward with indexOf for every '&'. If profiling ever
+  // shows it hot, replace with a small state machine to avoid potential
+  // quadratic behaviour on pathological strings.
+  let out = '';
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (ch === '&') {
+      const semi = input.indexOf(';', i + 1);
+      if (semi > -1) {
+        const entity = input.slice(i + 1, semi);
+        if (/^#?[0-9a-zA-Z]+$/.test(entity)) {
+          out += '&' + entity + ';';
+          i = semi;
+          continue;
+        }
+      }
+    }
+    const replacement = ENTITY_MAP[ch];
+    out += replacement ? replacement : ch;
+  }
+  return out;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function entityEnd(str: string, idx: number): number {
+  const amp = str.lastIndexOf('&', idx);
+  if (amp === -1) return -1;
+  const semi = str.indexOf(';', amp);
+  return semi !== -1 && semi > idx ? semi + 1 : -1;
+}
+
+export function highlight(text: string, query: string, maxHits = 50): string {
+  if (!query) return escapeHtml(text);
+  // Uses JS RegExp case-folding which is effectively ASCII-centric; locale
+  // special-casing (e.g. ß vs "ss") is not handled.
+  const pattern = new RegExp(escapeRegex(query), 'gi');
+  let result = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  let hits = 0;
+  while ((match = pattern.exec(text)) && hits < maxHits) {
+    const end = entityEnd(text, match.index);
+    if (end !== -1) {
+      result += escapeHtml(text.slice(last, end));
+      last = end;
+      pattern.lastIndex = end;
+      continue;
+    }
+    result += escapeHtml(text.slice(last, match.index));
+    result += `<mark class="search-hit">${escapeHtml(match[0])}</mark>`;
+    last = match.index + match[0].length;
+    hits++;
+  }
+  result += escapeHtml(text.slice(last));
+  return result;
+}
+
+export { escapeHtml };

--- a/tests/highlight.test.ts
+++ b/tests/highlight.test.ts
@@ -1,0 +1,68 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { highlight, escapeHtml } from "../src/utils/highlight.ts";
+
+const MARK = /<mark class="search-hit">/g;
+
+test("handles HTML reserved characters", () => {
+  assert.equal(highlight("1 < 2", "<"), "1 <mark class=\"search-hit\">&lt;</mark> 2");
+  assert.equal(highlight("1 > 2", ">"), "1 <mark class=\"search-hit\">&gt;</mark> 2");
+  assert.equal(highlight("a & b", "&"), "a <mark class=\"search-hit\">&amp;</mark> b");
+  assert.equal(
+    highlight('He said "hi"', '"'),
+    'He said <mark class="search-hit">&quot;</mark>hi<mark class="search-hit">&quot;</mark>'
+  );
+  assert.equal(highlight("it's ok", "'"), "it<mark class=\"search-hit\">&#39;</mark>s ok");
+});
+
+test("handles regex metacharacters", () => {
+  const meta = '.*+?^${}()|[]\\';
+  const res = highlight(`X${meta}Y`, meta);
+  assert.equal(res, `X<mark class=\"search-hit\">${escapeHtml(meta)}</mark>Y`);
+});
+
+test("handles SQL wildcard characters", () => {
+  assert.equal(highlight("100% match", "%"), "100<mark class=\"search-hit\">%</mark> match");
+  assert.equal(highlight("file_name", "_"), "file<mark class=\"search-hit\">_</mark>name");
+});
+
+test("does not double escape already-escaped text", () => {
+  const res = highlight("Fish &amp; Chips", "Fish");
+  assert.equal(res, "<mark class=\"search-hit\">Fish</mark> &amp; Chips");
+});
+
+test("does not match inside existing entities", () => {
+  const res = highlight("Fish &amp; Chips", "&");
+  assert.equal(res, "Fish &amp; Chips");
+});
+
+test("enforces max hits", () => {
+  const res = highlight("a a a a", "a", 2);
+  const count = (res.match(MARK) || []).length;
+  assert.equal(count, 2);
+});
+
+test("max hits zero yields no highlights", () => {
+  const res = highlight("a a a a", "a", 0);
+  const count = (res.match(MARK) || []).length;
+  assert.equal(count, 0);
+});
+
+test("counts overlapping hits and respects limit", () => {
+  let res = highlight("aaaa", "aa");
+  let count = (res.match(MARK) || []).length;
+  assert.equal(count, 2);
+  res = highlight("aaaa", "aa", 1);
+  count = (res.match(MARK) || []).length;
+  assert.equal(count, 1);
+});
+
+test("preserves numeric entities", () => {
+  assert.equal(escapeHtml("&#x3C;"), "&#x3C;");
+  assert.equal(escapeHtml("&#60;"), "&#60;");
+});
+
+test("is ASCII-centric for case folding", () => {
+  assert.equal(highlight("İstanbul", "i"), "İstanbul");
+  assert.equal(highlight("straße", "SS"), "straße");
+});


### PR DESCRIPTION
## Summary
- note potential escapeHtml hotspot and clarify ASCII-centric matching
- guard command palette subtitle highlighting
- boost high-contrast visibility of marks
- expand tests for entities, overlapping matches and case folding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ec59b4f4832a90f07558bbb96ca2