### PR TITLE
feat: add atomic file writes helper

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "tracing-subscriber",
  "ts-rs",
  "uuid",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,9 +48,11 @@ once_cell = "1"
 clap = { version = "4", features = ["derive"] }
 similar = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"
+windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
-tempfile = "3"
+
 
 
 [[bin]]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ const FILES_INDEX_VERSION: i64 = 1;
 
 mod attachments;
 pub mod commands;
-mod db;
+pub mod db;
 mod events_tz_backfill;
 mod household; // declare module; avoid `use` to prevent name collision
 mod id;
@@ -532,13 +532,12 @@ async fn files_index_ready(pool: &sqlx::SqlitePool, household_id: &str) -> bool 
         _ => return false,
     };
 
-    let count: i64 = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM files WHERE household_id=?1",
-    )
-    .bind(household_id)
-    .fetch_one(pool)
-    .await
-    .unwrap_or(0);
+    let count: i64 =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM files WHERE household_id=?1")
+            .bind(household_id)
+            .fetch_one(pool)
+            .await
+            .unwrap_or(0);
 
     let max_updated: String = sqlx::query_scalar::<_, String>(
         "SELECT COALESCE(strftime('%Y-%m-%dT%H:%M:%SZ', MAX(updated_at), 'unixepoch'), '1970-01-01T00:00:00Z') FROM files WHERE household_id=?1",
@@ -577,13 +576,11 @@ async fn db_has_vehicle_columns(state: State<'_, AppState>) -> Result<bool, Stri
         return Ok(false);
     }
     let cols = table_columns(pool, "vehicles").await;
-    Ok(
-        cols.contains("reg")
-            || cols.contains("registration")
-            || cols.contains("plate")
-            || cols.contains("nickname")
-            || cols.contains("name")
-    )
+    Ok(cols.contains("reg")
+        || cols.contains("registration")
+        || cols.contains("plate")
+        || cols.contains("nickname")
+        || cols.contains("name"))
 }
 
 #[tauri::command]
@@ -637,7 +634,9 @@ fn coalesce_expr(
 }
 
 fn like_escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 #[tauri::command]
@@ -739,7 +738,11 @@ async fn search_entities(
             let filename: String = r.try_get("filename").unwrap_or_default();
             let ts: i64 = r.try_get("ts").unwrap_or_default();
             let ord_val: i64 = r.try_get("ord").unwrap_or_default();
-            let score = if filename.eq_ignore_ascii_case(&q) { 2 } else { 1 };
+            let score = if filename.eq_ignore_ascii_case(&q) {
+                2
+            } else {
+                1
+            };
             let id: String = r.try_get("id").unwrap_or_default();
             out.push((
                 score,
@@ -1201,10 +1204,12 @@ mod search_tests {
             .execute(&pool)
             .await
             .unwrap();
-        sqlx::query("INSERT INTO files (id, household_id, filename, updated_at) VALUES ('f1','hh','a',0)")
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx::query(
+            "INSERT INTO files (id, household_id, filename, updated_at) VALUES ('f1','hh','a',0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
         sqlx::query(
             "CREATE TABLE files_index_meta (household_id TEXT PRIMARY KEY, last_built_at_utc TEXT NOT NULL, source_row_count INTEGER NOT NULL, source_max_updated_utc TEXT NOT NULL, version INTEGER NOT NULL)",
         )

--- a/src-tauri/tests/write_atomic.rs
+++ b/src-tauri/tests/write_atomic.rs
@@ -1,0 +1,41 @@
+use arklowdun_lib::db::write_atomic;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn commit_writes_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("file.txt");
+    write_atomic(&path, b"hello").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"hello");
+}
+
+#[test]
+fn overwrite_is_atomic() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("file.txt");
+    fs::write(&path, b"old").unwrap();
+    write_atomic(&path, b"new").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+}
+
+#[test]
+fn failure_leaves_original() {
+    let dir = tempdir().unwrap();
+    let existing = dir.path().join("orig.txt");
+    fs::write(&existing, b"old").unwrap();
+    let bad_path = dir.path().join("missing").join("file.txt");
+    assert!(write_atomic(&bad_path, b"data").is_err());
+    assert_eq!(fs::read(&existing).unwrap(), b"old");
+    assert!(!bad_path.parent().unwrap().exists());
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn overwrite_uses_replacefilew() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("file.txt");
+    fs::write(&path, b"old").unwrap();
+    write_atomic(&path, b"new").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"new");
+}


### PR DESCRIPTION
## Summary
- introduce cross-platform `write_atomic` helper for durable file writes
- swap direct `fs::write` usage in schema verifier for `write_atomic`
- add regression tests for atomic file writes

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test write_atomic -- --nocapture`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c660bc3860832aace46f40afd7023f