### PR TITLE
Handle migration panics

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "futures",
  "include_dir",
  "once_cell",
  "paste",
@@ -1286,6 +1287,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1387,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json",
 time = "0.3"
 rrule = { version = "0.14", features = ["serde"] }
 include_dir = "0.7"
+futures = "0.3"
 once_cell = "1"
 clap = { version = "4", features = ["derive"] }
 similar = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1126,7 +1126,7 @@ pub fn run() {
             let handle = app.handle();
             #[allow(clippy::needless_borrow)]
             let pool = tauri::async_runtime::block_on(crate::db::open_sqlite_pool(&handle))?;
-            tauri::async_runtime::block_on(crate::migrate::apply_migrations(&pool))?;
+            tauri::async_runtime::block_on(crate::db::apply_migrations(&pool))?;
             tauri::async_runtime::block_on(async {
                 if let Ok(cols) = sqlx::query("PRAGMA table_info(events);").fetch_all(&pool).await {
                     let names: Vec<String> = cols


### PR DESCRIPTION
## Summary
- wrap migrations with `catch_unwind` and rollback on panic
- expose database migration helper and call from setup

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: gobject-2.0 not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c666f79c4c832a8c45989090c0d20e