### PR TITLE
docs: document migration recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,36 @@ Schema changes are managed through sequential SQL files; see
 [docs/migrations-spec.md](docs/migrations-spec.md) for versioning rules and
 upgrade paths.
 
+## Migration Recovery
+
+- **Restore from backup**
+  - Preferred recovery is restoring the database file or dump from a known-good backup.
+  - Backups usually live in the app data directory or an external backup system.
+
+- **Using downs/ups** (development only)
+  - `*.down.sql` files exist as development aids.
+  - Manual rollback and reapply:
+    ```sh
+    sqlite3 app.db < migrations/NNNN_label.down.sql
+    sqlite3 app.db < migrations/NNNN_label.up.sql
+    ```
+  - Risky and not intended for production—prefer backups.
+
+- **Reapplying ups after a crash**
+  - Failed migrations are wrapped in a transaction; errors roll everything back.
+  - On next start, `apply_migrations` retries automatically. Check logs for the failing SQL.
+
+- **Troubleshooting tips**
+  - Schema drift (table/column mismatch) → delete temp DB and restore from fixture or backup.
+  - Locked database files → close other processes or inspect WAL files.
+  - Foreign key violations during migration → verify test fixtures and data consistency.
+  - Integrity checks:
+    ```sql
+    PRAGMA integrity_check;
+    PRAGMA foreign_key_check;
+    ```
+  - See [docs/migrations-spec.md](docs/migrations-spec.md) for context.
+
 ## Documentation
 
 - [Architecture Overview](docs/architecture/1-overview.md)


### PR DESCRIPTION
## Summary
- add Migration Recovery section explaining backup restores, downs/ups caveats, and troubleshooting

## Testing
- `npm run check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c6d7946160832aa89ba4dd25863ed8