### PR TITLE
feat: add migration CLI

### DIFF
--- a/docs/migration-guidelines.md
+++ b/docs/migration-guidelines.md
@@ -120,6 +120,32 @@ For a clean-room check that builds a temporary database (used in CI):
 npm run schema:ci
 ```
 
+## Migration CLI
+
+A small helper exists for inspecting and controlling migrations locally:
+
+```bash
+# list and status
+cargo run --bin migrate -- list
+cargo run --bin migrate -- status
+
+# apply all pending (prod-like)
+cargo run --bin migrate -- up
+
+# apply up to a target version
+cargo run --bin migrate -- up --to 0015
+
+# DEV-ONLY rollback (requires ARKLOWDUN_ALLOW_DOWN=1, refused in CI)
+ARKLOWDUN_ALLOW_DOWN=1 cargo run --bin migrate -- down
+ARKLOWDUN_ALLOW_DOWN=1 cargo run --bin migrate -- down --to 0012
+
+# use a specific db file
+cargo run --bin migrate -- --db /path/to/app.sqlite3 up --to 0014
+```
+
+* `up`/`down` run each migration inside a transaction and enforce FK checks.
+* `down` is for development only; prefer backup restore for real recovery.
+
 ## Large Migration Strategies
 - Break long-running migrations into smaller steps.
 - Use feature flags or phased rollout when table locks could impact production.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "dirs 5.0.1",
  "futures",
  "include_dir",
  "libc",
@@ -943,11 +944,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -958,7 +980,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -3492,6 +3514,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4498,7 +4531,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.3",
@@ -4549,7 +4582,7 @@ checksum = "67945dbaf8920dbe3a1e56721a419a0c3d085254ab24cff5b9ad55e2b0016e0b"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5249,7 +5282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d92153331e7d02ec09137538996a7786fe679c629c279e82a6be762b7e6fe2"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.2",
@@ -6282,7 +6315,7 @@ dependencies = [
  "block2 0.6.1",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ similar = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
 windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }
+dirs = "5"
 
 [dev-dependencies]
 
@@ -62,3 +63,7 @@ libc = "0.2"
 [[bin]]
 name = "verify_schema"
 path = "scripts/verify_schema.rs"
+
+[[bin]]
+name = "migrate"
+path = "scripts/migrate.rs"

--- a/src-tauri/scripts/migrate.rs
+++ b/src-tauri/scripts/migrate.rs
@@ -1,0 +1,366 @@
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous},
+    ConnectOptions, Row, SqlitePool,
+};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+#[derive(Parser)]
+#[command(name = "migrate", about = "Arklowdun migration helper")]
+struct Cli {
+    /// Optional explicit DB path
+    #[arg(long, value_name = "PATH")]
+    db: Option<PathBuf>,
+
+    /// Print SQL without executing for up/down
+    #[arg(long)]
+    dry_run: bool,
+
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// List migrations and show applied/pending
+    #[command(about, long_about = None)]
+    List,
+    /// Show current migration status
+    #[command(about, long_about = None)]
+    Status,
+    /// Apply pending migrations (optionally up to a target version)
+    #[command(about, long_about = None)]
+    Up {
+        /// Target version (NNNN) to stop at (inclusive)
+        #[arg(long, value_name = "NNNN")]
+        to: Option<String>,
+    },
+    /// DEV-ONLY: Roll back migrations (one step or down to target)
+    #[command(about, long_about = None)]
+    Down {
+        /// Target version (NNNN) to roll back to (stop when current==to)
+        #[arg(long, value_name = "NNNN")]
+        to: Option<String>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = tracing_log::LogTracer::init();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            std::env::var("TAURI_ARKLOWDUN_LOG")
+                .unwrap_or_else(|_| "arklowdun=info,sqlx=warn".into()),
+        )
+        .json()
+        .with_target(true)
+        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+        .try_init();
+
+    let cli = Cli::parse();
+    let db_path = cli.db.unwrap_or(default_db_path()?);
+
+    match cli.cmd {
+        Cmd::List => list(&db_path).await,
+        Cmd::Status => status(&db_path).await,
+        Cmd::Up { to } => up(&db_path, cli.dry_run, to.as_deref()).await,
+        Cmd::Down { to } => down(&db_path, cli.dry_run, to.as_deref()).await,
+    }
+}
+
+fn default_db_path() -> Result<PathBuf> {
+    let base = dirs::data_dir().unwrap_or(std::env::current_dir()?);
+    Ok(base.join("com.paula.arklowdun").join("arklowdun.sqlite3"))
+}
+
+async fn open_pool(db: &Path, create: bool) -> Result<SqlitePool> {
+    if create {
+        if let Some(parent) = db.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+    }
+    let mut opts = SqliteConnectOptions::new().filename(db);
+    if create {
+        opts = opts.create_if_missing(true);
+    } else {
+        opts = opts.create_if_missing(false);
+    }
+    let opts = opts
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Full)
+        .foreign_keys(true)
+        .log_statements(log::LevelFilter::Off);
+    let pool = SqlitePool::connect_with(opts).await?;
+    sqlx::query("PRAGMA busy_timeout = 5000;")
+        .execute(&pool)
+        .await
+        .ok();
+    sqlx::query("PRAGMA wal_autocheckpoint = 1000;")
+        .execute(&pool)
+        .await
+        .ok();
+    Ok(pool)
+}
+
+fn migrations_dir() -> Result<PathBuf> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    Ok(root.join("migrations"))
+}
+
+fn discover_migrations() -> Result<Vec<(String, PathBuf, Option<PathBuf>)>> {
+    let dir = migrations_dir()?;
+    let mut ups = vec![];
+    for entry in fs::read_dir(&dir).with_context(|| format!("read {:?}", dir))? {
+        let p = entry?.path();
+        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+            if name.ends_with(".up.sql") {
+                let stem = name.trim_end_matches(".up.sql").to_string();
+                let down = dir.join(format!("{}.down.sql", stem));
+                ups.push((stem, p.clone(), down.exists().then_some(down)));
+            }
+        }
+    }
+    ups.sort_by_key(|(stem, _, _)| stem.clone());
+    Ok(ups)
+}
+
+async fn applied_set(pool: &SqlitePool) -> Result<HashSet<String>> {
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
+    )
+    .fetch_optional(pool)
+    .await?;
+    if exists.is_none() {
+        return Ok(HashSet::new());
+    }
+    let rows = sqlx::query("SELECT version FROM schema_migrations")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|r| r.try_get::<String, _>("version").ok())
+        .collect())
+}
+
+async fn list(db: &Path) -> Result<()> {
+    let applied = if db.exists() {
+        let pool = open_pool(db, false).await?;
+        applied_set(&pool).await?
+    } else {
+        HashSet::new()
+    };
+    println!("DB: {}", db.display());
+    for (stem, _up, _down) in discover_migrations()? {
+        let fname = format!("{}.up.sql", stem);
+        let state = if applied.contains(&fname) {
+            "applied"
+        } else {
+            "pending"
+        };
+        println!("{:<32}  {}", stem, state);
+    }
+    Ok(())
+}
+
+async fn status(db: &Path) -> Result<()> {
+    let all = discover_migrations()?;
+    let applied = if db.exists() {
+        let pool = open_pool(db, false).await?;
+        applied_set(&pool).await?
+    } else {
+        HashSet::new()
+    };
+    let applied_count = all
+        .iter()
+        .filter(|(stem, _, _)| applied.contains(&format!("{}.up.sql", stem)))
+        .count();
+    let head = all
+        .iter()
+        .rev()
+        .find(|(stem, _, _)| applied.contains(&format!("{}.up.sql", stem)))
+        .map(|(s, _, _)| s.as_str())
+        .unwrap_or("<none>");
+    println!("DB: {}", db.display());
+    println!("Applied: {}/{}", applied_count, all.len());
+    println!("Head: {}", head);
+    Ok(())
+}
+
+async fn up(db: &Path, dry: bool, to: Option<&str>) -> Result<()> {
+    let pool = open_pool(db, true).await?;
+    let all = discover_migrations()?;
+    let applied = applied_set(&pool).await?;
+
+    let mut plan: Vec<(String, String)> = vec![];
+    for (stem, up_path, _) in &all {
+        let fname = format!("{}.up.sql", stem);
+        if applied.contains(&fname) {
+            continue;
+        }
+        plan.push((fname.clone(), fs::read_to_string(up_path)?));
+        if let Some(target) = to {
+            if stem.split('_').next() == Some(target) {
+                break;
+            }
+        }
+    }
+
+    if plan.is_empty() {
+        println!("Nothing to apply.");
+        return Ok(());
+    }
+
+    println!("Plan (up):");
+    for (f, _) in &plan {
+        println!("  {}", f);
+    }
+    if dry {
+        return Ok(());
+    }
+
+    for (filename, sql) in plan {
+        log::info!("migration start {}", filename);
+        let mut tx = pool.begin().await?;
+        sqlx::query("PRAGMA foreign_keys=ON")
+            .execute(&mut *tx)
+            .await?;
+        let start = Instant::now();
+        for stmt in split_stmts(&sql) {
+            sqlx::query(&stmt)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("{}: {}", filename, stmt_preview(&stmt)))?;
+        }
+        if !sqlx::query("PRAGMA foreign_key_check;")
+            .fetch_all(&mut *tx)
+            .await?
+            .is_empty()
+        {
+            anyhow::bail!("foreign key violations in {}", filename);
+        }
+        sqlx::query(
+            "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, strftime('%s','now'))",
+        )
+        .bind(&filename)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        log::info!("migration success {} in {:?}", filename, start.elapsed());
+        if let Some(target) = to {
+            if filename.split('_').next() == Some(target) {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn down(db: &Path, dry: bool, to: Option<&str>) -> Result<()> {
+    if std::env::var("ARKLOWDUN_ALLOW_DOWN").ok().as_deref() != Some("1")
+        || std::env::var("CI").ok() == Some("true".into())
+    {
+        return Err(anyhow!(
+            "Down migrations are disabled. Set ARKLOWDUN_ALLOW_DOWN=1 (not in CI) to proceed.",
+        ));
+    }
+
+    let pool = open_pool(db, true).await?;
+    let all = discover_migrations()?;
+    let applied = applied_set(&pool).await?;
+
+    let mut applied_in_order: Vec<(String, Option<PathBuf>)> = all
+        .into_iter()
+        .filter(|(stem, _up, _down)| applied.contains(&format!("{}.up.sql", stem)))
+        .map(|(stem, _up, down)| (stem, down))
+        .collect();
+
+    if applied_in_order.is_empty() {
+        println!("Nothing to roll back.");
+        return Ok(());
+    }
+
+    let mut plan: Vec<(String, String)> = vec![];
+    loop {
+        let (stem, down_path) = match applied_in_order.pop() {
+            Some(x) => x,
+            None => break,
+        };
+        let fname = format!("{}.down.sql", stem);
+        let path = down_path.ok_or_else(|| anyhow!("no down file for {}", stem))?;
+        let sql = fs::read_to_string(&path)?;
+        plan.push((fname.clone(), sql));
+        if let Some(target) = to {
+            if stem.split('_').next() == Some(target) {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    println!("Plan (down):");
+    for (f, _) in &plan {
+        println!("  {}", f);
+    }
+    if dry {
+        return Ok(());
+    }
+
+    for (filename, sql) in plan {
+        log::info!("rollback start {}", filename);
+        let mut tx = pool.begin().await?;
+        sqlx::query("PRAGMA foreign_keys=ON")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM schema_migrations WHERE version=?1")
+            .bind(filename.replace(".down.sql", ".up.sql"))
+            .execute(&mut *tx)
+            .await
+            .ok();
+        for stmt in split_stmts(&sql) {
+            sqlx::query(&stmt)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("{}: {}", filename, stmt_preview(&stmt)))?;
+        }
+        tx.commit().await?;
+        log::info!("rollback success {}", filename);
+    }
+    Ok(())
+}
+
+fn split_stmts(sql: &str) -> Vec<String> {
+    let cleaned = sql
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    cleaned
+        .split(';')
+        .map(str::trim)
+        .filter(|s| {
+            !s.is_empty()
+                && !s.eq_ignore_ascii_case("BEGIN TRANSACTION")
+                && !s.eq_ignore_ascii_case("COMMIT")
+        })
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn stmt_preview(s: &str) -> String {
+    let s = s.replace('\n', " ");
+    if s.len() > 180 {
+        format!("{}…", &s[..180])
+    } else {
+        s
+    }
+}

--- a/src-tauri/scripts/migrate.rs
+++ b/src-tauri/scripts/migrate.rs
@@ -289,11 +289,7 @@ async fn down(db: &Path, dry: bool, to: Option<&str>) -> Result<()> {
     }
 
     let mut plan: Vec<(String, String)> = vec![];
-    loop {
-        let (stem, down_path) = match applied_in_order.pop() {
-            Some(x) => x,
-            None => break,
-        };
+    while let Some((stem, down_path)) = applied_in_order.pop() {
         let fname = format!("{}.down.sql", stem);
         let path = down_path.ok_or_else(|| anyhow!("no down file for {}", stem))?;
         let sql = fs::read_to_string(&path)?;

--- a/src-tauri/tests/crash_mid_migration.rs
+++ b/src-tauri/tests/crash_mid_migration.rs
@@ -14,10 +14,6 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::tempdir;
-
-#[cfg(unix)]
-use libc;
-
 #[tokio::test]
 async fn crash_mid_migration() -> Result<()> {
     if env::var("CRASH_CHILD").as_deref() == Ok("1") {
@@ -84,11 +80,10 @@ async fn parent() -> Result<()> {
         .connect()
         .await?;
 
-    let exists: Option<String> = sqlx::query_scalar(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='crashy';",
-    )
-    .fetch_optional(&mut conn)
-    .await?;
+    let exists: Option<String> =
+        sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type='table' AND name='crashy';")
+            .fetch_optional(&mut conn)
+            .await?;
     assert!(exists.is_none(), "table `crashy` should not exist");
 
     let ok: String = sqlx::query_scalar("PRAGMA integrity_check;")
@@ -99,8 +94,10 @@ async fn parent() -> Result<()> {
     let quick: String = sqlx::query_scalar("PRAGMA quick_check;")
         .fetch_one(&mut conn)
         .await?;
-    assert!(quick == "ok" || quick == "0", "quick_check expected ok/0 got {quick}");
+    assert!(
+        quick == "ok" || quick == "0",
+        "quick_check expected ok/0 got {quick}"
+    );
 
     Ok(())
 }
-

--- a/src-tauri/tests/migrate_cli.rs
+++ b/src-tauri/tests/migrate_cli.rs
@@ -1,0 +1,68 @@
+use sqlx::sqlite::SqlitePoolOptions;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_migrate")
+}
+
+#[tokio::test]
+async fn list_and_status_empty_db() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let db = dir.path().join("empty.sqlite");
+    let output = Command::new(bin())
+        .args(["--db", db.to_str().unwrap(), "list"])
+        .output()?;
+    assert!(output.status.success());
+    assert!(!db.exists());
+
+    let output = Command::new(bin())
+        .args(["--db", db.to_str().unwrap(), "status"])
+        .output()?;
+    assert!(output.status.success());
+    assert!(!db.exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn up_and_down_roundtrip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let db = dir.path().join("mig.sqlite");
+    let db_arg = db.to_str().unwrap();
+
+    let status = Command::new(bin())
+        .args(["--db", db_arg, "up", "--to", "0001"])
+        .status()?;
+    assert!(status.success());
+
+    {
+        let url = format!("sqlite://{}", db.display());
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await?;
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM schema_migrations")
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, 1);
+    }
+
+    let status = Command::new(bin())
+        .env("ARKLOWDUN_ALLOW_DOWN", "1")
+        .args(["--db", db_arg, "down"])
+        .status()?;
+    assert!(status.success());
+
+    {
+        let url = format!("sqlite://{}", db.display());
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await?;
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sqlite_master")
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(rows, 0);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `migrate` developer CLI to list, apply and roll back SQLite migrations
- document migration CLI usage and flags
- test CLI round-trip for applying and rolling back migrations
- ensure `--to` matches the full migration version to avoid prefix collisions

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --test migrate_cli -- --nocapture`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6db32c7f4832aae213f623fd7b761