### PR TITLE
chore: guard releases against pending migrations

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,41 @@
+# Release
+
+## Pending migrations check
+
+The release process verifies that the target database has applied all migrations found in `migrations/`.
+
+### Running the check manually
+
+```sh
+scripts/check_pending_migrations.sh [path/to/db.sqlite]
+```
+
+The script reads the database path from its first argument or the `DB` environment variable, defaulting to `dev.sqlite`. It compares the migration filenames in `migrations/*.up.sql` with the contents of the `schema_migrations` table. Tokens are matched exactly—the full basename including `.up.sql` is stored in `schema_migrations.version`. If any filenames are missing, the script exits non-zero and lists the pending migrations.
+
+### What "pending migrations" means
+
+A migration is pending when an `*.up.sql` file exists on disk but its version is absent from the `schema_migrations` table in the target database. Shipping the app with pending migrations means the database schema is behind what the code expects.
+
+### Fixing pending migrations
+
+Apply outstanding migrations before releasing:
+
+```sh
+cargo run --bin migrate -- --db "$DB" up
+```
+
+After the database is up to date, rerun the check to confirm it prints:
+
+```
+OK: No pending migrations
+```
+
+## Building a release
+
+Use the `release` npm script to build the application bundle. It runs the pending migrations check before invoking the Tauri build and checks `dev.sqlite` by default:
+
+```sh
+npm run release
+```
+
+The build aborts if any migrations are missing from the target database.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "schema:verify": "scripts/verify_schema.sh --db dev.sqlite --schema schema.sql --verbose",
     "schema:update": "scripts/verify_schema.sh --db dev.sqlite --schema schema.sql --update --verbose",
     "schema:verify:strict": "scripts/verify_schema.sh --db dev.sqlite --schema schema.sql --strict --include-migrations --verbose",
-    "schema:ci": "scripts/ci/verify-schema.sh"
+    "schema:ci": "scripts/ci/verify-schema.sh",
+      "release": "DB=dev.sqlite bash scripts/check_pending_migrations.sh && npm run tauri -- build"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",

--- a/scripts/check_pending_migrations.sh
+++ b/scripts/check_pending_migrations.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Verify that all migrations on disk have been applied to the target database.
+set -eu
+
+DB="${1:-${DB:-dev.sqlite}}"
+echo "Checking pending migrations against DB: $DB"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+MIG_DIR="$SCRIPT_DIR/../migrations"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "ERROR: sqlite3 not found" >&2
+  exit 1
+fi
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: database not found: $DB" >&2
+  exit 1
+fi
+
+set -- "$MIG_DIR"/[0-9]*.up.sql
+if [ ! -e "$1" ]; then
+  echo "OK: No migrations found"
+  exit 0
+fi
+
+if ! applied=$(sqlite3 "$DB" "SELECT version FROM schema_migrations ORDER BY version;" 2>/dev/null); then
+  echo "WARN: schema_migrations table not found; treating as none applied" >&2
+  applied=""
+fi
+
+pending=""
+for f in "$MIG_DIR"/[0-9]*.up.sql; do
+  token=$(basename "$f")
+  if ! printf "%s\n" "$applied" | grep -Fxq "$token"; then
+    pending="${pending}${pending:+ }$token"
+  fi
+done
+
+if [ -n "$pending" ]; then
+  echo "ERROR: pending migrations:" >&2
+  for v in $pending; do
+    echo "  $v" >&2
+  done
+  exit 1
+fi
+
+echo "OK: No pending migrations"


### PR DESCRIPTION
## Summary
- ensure migration check matches exact `*.up.sql` filenames and reports target DB
- wire pending-migration guard into release step with explicit default database
- document canonical migration token and correct command to apply outstanding migrations

## Testing
- `bash scripts/check_pending_migrations.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7bfa3f430832aa56e8802956899cc