### PR TITLE
feat: canonicalize attachment paths

### DIFF
--- a/docs/security/fs-allowlist.md
+++ b/docs/security/fs-allowlist.md
@@ -28,3 +28,20 @@ Examples of the resolved `$APPDATA` base:
 3. Update `src-tauri/tauri.conf.json5` with a commented entry and mirror it in this document.
 4. Verify that paths outside the allowlist are denied at runtime.
 
+
+## Path sanitizer
+
+All UI file operations pass through a canonicalizer that resolves user input to an absolute path within an allowlisted root.
+
+- Separators are normalized and `.` segments collapsed.
+- `..` traversal, UNC paths, and cross-volume drive changes are rejected.
+- Only `$APPDATA` and `$APPDATA/attachments` are valid bases.
+- All symlinks are denied in v1 (may relax once real path resolution is available).
+- Path joins use `@tauri-apps/api/path.join` at runtime for cross-platform correctness.
+
+### Manual verification
+
+1. Attempt to open `../../etc/passwd` → denied.
+2. Try a UNC path like `\\server\share` → denied.
+3. Symlink inside `attachments` pointing outside → denied.
+4. Regular file within `attachments` → allowed.

--- a/src/files/path.ts
+++ b/src/files/path.ts
@@ -1,59 +1,180 @@
-import {
-  appCacheDir,
-  appConfigDir,
-  appDataDir,
-  appLocalDataDir,
-  audioDir,
-  cacheDir,
-  configDir,
-  dataDir,
-  desktopDir,
-  documentDir,
-  downloadDir,
-  fontDir,
-  homeDir,
-  join,
-  localDataDir,
-  pictureDir,
-  publicDir,
-  resourceDir,
-  runtimeDir,
-  tempDir,
-  templateDir,
-  videoDir,
-} from "@tauri-apps/api/path";
-import { sanitizeRelativePath } from "./sanitize.ts";
+export { sanitizeRelativePath } from "./sanitize.ts";
 
-const ROOTS: Record<string, () => Promise<string>> = {
-  appCache: appCacheDir,
-  appConfig: appConfigDir,
-  appData: appDataDir,
-  appLocalData: appLocalDataDir,
-  audio: audioDir,
-  cache: cacheDir,
-  config: configDir,
-  data: dataDir,
-  desktop: desktopDir,
-  document: documentDir,
-  download: downloadDir,
-  font: fontDir,
-  home: homeDir,
-  localData: localDataDir,
-  picture: pictureDir,
-  public: publicDir,
-  resource: resourceDir,
-  runtime: runtimeDir,
-  temp: tempDir,
-  template: templateDir,
-  video: videoDir,
-};
+let appDataDirImpl: (() => Promise<string>) | undefined;
+let lstatImpl: ((path: string) => Promise<any>) | undefined;
+type JoinFn = (...parts: string[]) => string | Promise<string>;
+const defaultJoin: JoinFn = (...parts: string[]) => parts.join("/");
+let joinImpl: JoinFn = defaultJoin;
 
-export { sanitizeRelativePath };
-
-export async function resolvePath(rootKey: string, relativePath: string): Promise<string> {
-  const root = ROOTS[rootKey];
-  if (!root) throw new Error(`Unknown root key: ${rootKey}`);
-  const base = await root();
-  return join(base, sanitizeRelativePath(relativePath));
+async function ensureLoaded() {
+  if (!appDataDirImpl || joinImpl === defaultJoin) {
+    try {
+      const pathMod = await import("@tauri-apps/api/path");
+      appDataDirImpl = appDataDirImpl ?? pathMod.appDataDir;
+      if (joinImpl === defaultJoin) joinImpl = pathMod.join as JoinFn;
+    } catch {
+      appDataDirImpl = appDataDirImpl ?? (async () => {
+        throw new Error("appDataDir unavailable");
+      });
+    }
+  }
+  if (!lstatImpl) {
+    try {
+      const fsmod = await import("@tauri-apps/plugin-fs");
+      lstatImpl = fsmod.lstat;
+    } catch {
+      lstatImpl = async () => ({ isSymbolicLink: false });
+    }
+  }
 }
 
+export type RootKey = "appData" | "attachments";
+
+export interface CanonResult {
+  input: string;
+  rootKey: RootKey;
+  base: string;
+  realPath: string;
+}
+
+export class PathError extends Error {
+  code:
+    | "OUTSIDE_ROOT"
+    | "DOT_DOT_REJECTED"
+    | "UNC_REJECTED"
+    | "CROSS_VOLUME"
+    | "SYMLINK"
+    | "INVALID";
+  details?: unknown;
+  constructor(code: PathError["code"], message: string, details?: unknown) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/** @internal test hook */
+export function __setMocks(mocks: {
+  appDataDir?: () => Promise<string>;
+  join?: JoinFn;
+  lstat?: (path: string) => Promise<any>;
+}) {
+  if (mocks.appDataDir) appDataDirImpl = mocks.appDataDir;
+  if (mocks.join) joinImpl = mocks.join;
+  if (mocks.lstat) lstatImpl = mocks.lstat;
+}
+
+const norm = (s: string): string => {
+  const replaced = s.replace(/\\/g, "/").replace(/\/+/g, "/");
+  let prefix = "";
+  let rest = replaced;
+  if (rest.startsWith("//")) {
+    prefix = "//";
+    rest = rest.slice(2);
+  } else {
+    const drive = rest.match(/^[A-Za-z]:/);
+    if (drive) {
+      prefix = drive[0];
+      rest = rest.slice(drive[0].length);
+      if (rest.startsWith("/")) rest = rest.slice(1);
+    } else if (rest.startsWith("/")) {
+      prefix = "/";
+      rest = rest.slice(1);
+    }
+  }
+  const parts = rest.split("/");
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (stack.length > 0 && stack[stack.length - 1] !== "..") stack.pop();
+      else stack.push("..");
+    } else {
+      stack.push(part);
+    }
+  }
+  const joined = stack.join("/");
+  return prefix + joined;
+};
+
+const driveOf = (p: string): string | null => {
+  const m = p.match(/^[A-Za-z]:/);
+  return m ? m[0].toLowerCase() : null;
+};
+
+async function getBase(rootKey: RootKey): Promise<string> {
+  await ensureLoaded();
+  let base = norm(await (appDataDirImpl as () => Promise<string>)());
+  if (rootKey === "attachments") {
+    base = norm(await joinImpl(base, "attachments"));
+  }
+  if (!base.endsWith("/")) base += "/";
+  return base;
+}
+
+export async function canonicalizeAndVerify(
+  path: string,
+  rootKey: RootKey,
+): Promise<CanonResult> {
+  const raw = path;
+  if (/^\\\\/.test(raw) || /^\/\/[^/]/.test(raw.replace(/\\/g, "/"))) {
+    throw new PathError("UNC_REJECTED", "UNC paths not allowed");
+  }
+  const inputNorm = norm(path);
+  if (inputNorm.split("/").includes("..")) {
+    throw new PathError("DOT_DOT_REJECTED", "Parent traversal not allowed");
+  }
+
+  const base = await getBase(rootKey);
+  let candidate = inputNorm;
+
+  const isAbs = /^([A-Za-z]:|\/)/.test(candidate);
+  if (isAbs) {
+    const baseDrive = driveOf(base);
+    const pathDrive = driveOf(candidate);
+    if (pathDrive && baseDrive && pathDrive !== baseDrive) {
+      throw new PathError("CROSS_VOLUME", "Cross-volume path not allowed");
+    }
+  } else {
+    candidate = norm(await joinImpl(base, candidate));
+  }
+
+  if (!candidate.startsWith(base)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+
+  return { input: path, rootKey, base, realPath: candidate };
+}
+
+export async function rejectSymlinks(
+  realPath: string,
+  rootKey: RootKey,
+): Promise<void> {
+  await ensureLoaded();
+  const base = await getBase(rootKey);
+  const pathNorm = norm(realPath);
+  if (!pathNorm.startsWith(base)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const rel = pathNorm.slice(base.length).split("/").filter(Boolean);
+  let current = base.slice(0, -1);
+  for (const seg of rel) {
+    current = norm(await joinImpl(current, seg));
+    try {
+      const info: any = await (lstatImpl as (path: string) => Promise<any>)(current);
+      const isSymlink = !!(
+        info?.isSymbolicLink ||
+        info?.is_symlink ||
+        info?.fileType === "symlink" ||
+        info?.kind === "symlink" ||
+        (typeof info?.isSymbolicLink === "function" && info.isSymbolicLink())
+      );
+      if (isSymlink) {
+        throw new PathError("SYMLINK", "Symlink not allowed", { path: current });
+      }
+    } catch (e) {
+      if (e instanceof PathError) throw e;
+      break;
+    }
+  }
+}

--- a/tests/path.spec.ts
+++ b/tests/path.spec.ts
@@ -1,0 +1,99 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import {
+  canonicalizeAndVerify,
+  rejectSymlinks,
+  PathError,
+  __setMocks
+} from "../src/files/path.ts";
+
+let mockAppData = "/app";
+const symlinks = new Set<string>();
+let lstatMock = async (p: string) => ({ isSymbolicLink: symlinks.has(p) });
+
+__setMocks({
+  appDataDir: async () => mockAppData,
+  join: (...parts: string[]) => parts.join("/"),
+  lstat: lstatMock,
+});
+
+test.beforeEach(() => {
+  mockAppData = "/app";
+  symlinks.clear();
+  lstatMock = async (p: string) => ({ isSymbolicLink: symlinks.has(p) });
+  __setMocks({ lstat: lstatMock });
+});
+
+test("absolute outside base -> OUTSIDE_ROOT", async () => {
+  await assert.rejects(
+    canonicalizeAndVerify("/etc/passwd", "attachments"),
+    (e: any) => e instanceof PathError && e.code === "OUTSIDE_ROOT",
+  );
+});
+
+test("relative traversal rejected", async () => {
+  await assert.rejects(
+    canonicalizeAndVerify("../../etc/passwd", "attachments"),
+    (e: any) => e instanceof PathError && e.code === "DOT_DOT_REJECTED",
+  );
+});
+
+test("sub/../file normalized", async () => {
+  const res = await canonicalizeAndVerify("sub/../file.txt", "attachments");
+  assert.equal(res.realPath, "/app/attachments/file.txt");
+});
+
+test("UNC path rejected", async () => {
+  await assert.rejects(
+    canonicalizeAndVerify("\\\\server\\share\\foo", "attachments"),
+    (e: any) => e instanceof PathError && e.code === "UNC_REJECTED",
+  );
+});
+
+test("cross-volume rejected", async () => {
+  mockAppData = "C:/Users/Alice/AppData";
+  await assert.rejects(
+    canonicalizeAndVerify("D:/foo", "attachments"),
+    (e: any) => e instanceof PathError && e.code === "CROSS_VOLUME",
+  );
+});
+
+test("separator normalization", async () => {
+  const res = await canonicalizeAndVerify("sub\\\\nested\\\\file.txt", "attachments");
+  assert.equal(res.realPath, "/app/attachments/sub/nested/file.txt");
+});
+
+test("symlink rejected", async () => {
+  symlinks.add("/app/attachments/link");
+  const { realPath } = await canonicalizeAndVerify("link/file.txt", "attachments");
+  await assert.rejects(
+    rejectSymlinks(realPath, "attachments"),
+    (e: any) => e instanceof PathError && e.code === "SYMLINK",
+  );
+});
+
+test("happy paths", async () => {
+  let r = await canonicalizeAndVerify("file.jpg", "attachments");
+  assert.equal(r.realPath, "/app/attachments/file.jpg");
+  await rejectSymlinks(r.realPath, "attachments");
+
+  r = await canonicalizeAndVerify("nested/dir/file.pdf", "attachments");
+  assert.equal(r.realPath, "/app/attachments/nested/dir/file.pdf");
+  await rejectSymlinks(r.realPath, "attachments");
+});
+
+test("absolute path inside base allowed", async () => {
+  const r = await canonicalizeAndVerify("/app/attachments/img.png", "attachments");
+  assert.equal(r.realPath, "/app/attachments/img.png");
+});
+
+test("nonexistent path does not trip symlink check", async () => {
+  __setMocks({
+    lstat: async (p: string) => {
+      if (p.includes("newdir")) throw new Error("ENOENT");
+      return { isSymbolicLink: symlinks.has(p) };
+    },
+  });
+  const r = await canonicalizeAndVerify("newdir/newfile.txt", "attachments");
+  await rejectSymlinks(r.realPath, "attachments");
+});


### PR DESCRIPTION
## Summary
- make path joins cross-platform and reject symlinks consistently
- adjust error codes and docs for strict symlink denial
- add extra unit tests for absolute and nonexistent paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7de5e0de0832a867d5efe7f247b48