### PR TITLE
feat: add safe filesystem wrapper

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,0 +1,7 @@
+# Safe filesystem wrapper
+
+All TypeScript code must import filesystem operations from `src/files/safe-fs.ts`.
+This wrapper enforces canonicalization and the v1 symlink-deny policy before
+accessing disk. Direct imports of `@tauri-apps/plugin-fs` will be blocked in a
+future pull request. The wrapper also re-exports `RootKey` and `PathError` for
+convenience.

--- a/src/files/safe-fs.ts
+++ b/src/files/safe-fs.ts
@@ -1,0 +1,142 @@
+import {
+  RootKey,
+  canonicalizeAndVerify as canonicalizeAndVerifyReal,
+  rejectSymlinks as rejectSymlinksReal,
+  PathError,
+} from "./path.ts";
+export type { RootKey };
+export { PathError };
+import type * as fsTypes from "@tauri-apps/plugin-fs";
+export type FsEntry = fsTypes.DirEntry;
+
+interface FsImpl {
+  readTextFile: typeof fsTypes.readTextFile;
+  writeTextFile: typeof fsTypes.writeTextFile;
+  readDir: typeof fsTypes.readDir;
+  mkdir: typeof fsTypes.mkdir;
+  remove: typeof fsTypes.remove;
+  lstat: typeof fsTypes.lstat;
+}
+
+let fsImpl: FsImpl | null = null;
+
+async function getFs(): Promise<FsImpl> {
+  if (!fsImpl) {
+    const mod = await import("@tauri-apps/plugin-fs");
+    fsImpl = {
+      readTextFile: mod.readTextFile,
+      writeTextFile: mod.writeTextFile,
+      readDir: mod.readDir,
+      mkdir: mod.mkdir,
+      remove: mod.remove,
+      lstat: mod.lstat,
+    };
+  }
+  return fsImpl;
+}
+
+let canonicalizeAndVerifyImpl = canonicalizeAndVerifyReal;
+let rejectSymlinksImpl = rejectSymlinksReal;
+
+/** @internal test hook */
+export function __setMocks(mocks: {
+  fs?: Partial<FsImpl>;
+  canonicalizeAndVerify?: typeof canonicalizeAndVerifyReal;
+  rejectSymlinks?: typeof rejectSymlinksReal;
+}) {
+  if (mocks.fs) fsImpl = { ...(fsImpl ?? ({} as FsImpl)), ...mocks.fs } as FsImpl;
+  if (mocks.canonicalizeAndVerify) canonicalizeAndVerifyImpl = mocks.canonicalizeAndVerify;
+  if (mocks.rejectSymlinks) rejectSymlinksImpl = mocks.rejectSymlinks;
+}
+
+const looksAbsolute = (p: string): boolean => {
+  const norm = p.replace(/\\/g, "/");
+  return /^(?:[A-Za-z]:|\\\\|\/)/.test(norm);
+};
+
+export async function readText(relPath: string, root: RootKey): Promise<string> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  return fs.readTextFile(realPath);
+}
+
+export async function writeText(
+  relPath: string,
+  root: RootKey,
+  data: string,
+): Promise<void> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  await fs.writeTextFile(realPath, data);
+}
+
+export async function readDir(
+  relPath: string,
+  root: RootKey,
+): Promise<FsEntry[]> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  return fs.readDir(realPath);
+}
+
+export async function mkdir(
+  relPath: string,
+  root: RootKey,
+  opts?: { recursive?: boolean },
+): Promise<void> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  await fs.mkdir(realPath, { recursive: opts?.recursive });
+}
+
+export async function removeFile(relPath: string, root: RootKey): Promise<void> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  await fs.remove(realPath);
+}
+
+export async function exists(relPath: string, root: RootKey): Promise<boolean> {
+  if (looksAbsolute(relPath)) {
+    throw new PathError("OUTSIDE_ROOT", "Path outside allowlisted root");
+  }
+  const { realPath } = await canonicalizeAndVerifyImpl(relPath, root);
+  await rejectSymlinksImpl(realPath, root);
+  const fs = await getFs();
+  try {
+    await fs.lstat(realPath);
+    return true;
+  } catch (e: any) {
+    const msg = (e?.message || "").toLowerCase();
+    if (e?.code === "ENOENT" || msg.includes("not found") || msg.includes("no such file")) {
+      return false;
+    }
+    throw e;
+  }
+}
+
+/** Map any PathError to a friendly UI string (for callers’ use). */
+export function toUserMessage(e: unknown): string {
+  if (e instanceof PathError) return "That location isn’t allowed.";
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/tests/safe-fs.spec.ts
+++ b/tests/safe-fs.spec.ts
@@ -1,0 +1,112 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import * as pathMod from "../src/files/path.ts";
+import * as safeFs from "../src/files/safe-fs.ts";
+// Set up base mocks for path operations
+pathMod.__setMocks({
+  appDataDir: async () => "/app",
+  join: (...parts: string[]) => parts.join("/"),
+  lstat: async () => ({ isSymbolicLink: false }),
+});
+
+test("writeText happy path uses canonical path", async () => {
+  let captured: any[] | undefined;
+  safeFs.__setMocks({
+    fs: {
+      writeTextFile: (async (p: string, data: string) => {
+        captured = [p, data];
+      }) as any,
+    },
+  });
+  await safeFs.writeText("x/test.txt", "attachments", "hi");
+  assert.deepEqual(captured, ["/app/attachments/x/test.txt", "hi"]);
+});
+
+test("absolute path denied", async () => {
+  let called = false;
+  safeFs.__setMocks({
+    fs: {
+      readTextFile: (async () => {
+        called = true;
+        return "";
+      }) as any,
+    },
+  });
+  await assert.rejects(
+    safeFs.readText("/Users/me/Desktop/foo.txt", "attachments"),
+    pathMod.PathError,
+  );
+  assert.equal(called, false);
+  const msg = safeFs.toUserMessage(new pathMod.PathError("OUTSIDE_ROOT", ""));
+  assert.equal(msg, "That location isn’t allowed.");
+});
+
+test("exists true when lstat resolves", async () => {
+  safeFs.__setMocks({
+    fs: {
+      lstat: async () => ({}) as any,
+    },
+  });
+  const ok = await safeFs.exists("foo.txt", "attachments");
+  assert.equal(ok, true);
+});
+
+test("exists false when lstat ENOENT", async () => {
+  safeFs.__setMocks({
+    fs: {
+      lstat: async () => {
+        const err: any = new Error("nope");
+        err.code = "ENOENT";
+        throw err;
+      },
+    },
+  });
+  const ok = await safeFs.exists("foo.txt", "attachments");
+  assert.equal(ok, false);
+});
+
+test("exists false when lstat message indicates missing", async () => {
+  safeFs.__setMocks({
+    fs: {
+      lstat: async () => {
+        throw new Error("No such file or directory");
+      },
+    },
+  });
+  const ok = await safeFs.exists("foo.txt", "attachments");
+  assert.equal(ok, false);
+});
+
+test("mkdir passes recursive option", async () => {
+  let args: any[] | undefined;
+  safeFs.__setMocks({
+    fs: {
+      mkdir: (async (p: string, opts?: { recursive?: boolean }) => {
+        args = [p, opts];
+      }) as any,
+    },
+  });
+  await safeFs.mkdir("newdir", "attachments", { recursive: true });
+  assert.deepEqual(args, ["/app/attachments/newdir", { recursive: true }]);
+});
+
+test("sanitizers are invoked", async () => {
+  let canonCalled = 0;
+  let rejectCalled = 0;
+  safeFs.__setMocks({
+    canonicalizeAndVerify: async (p, r) => {
+      canonCalled++;
+      return pathMod.canonicalizeAndVerify(p, r);
+    },
+    rejectSymlinks: async (p, r) => {
+      rejectCalled++;
+      return pathMod.rejectSymlinks(p, r);
+    },
+    fs: {
+      readDir: async () => [],
+    },
+  });
+  await safeFs.readDir("x", "attachments");
+  assert.equal(canonCalled, 1);
+  assert.equal(rejectCalled, 1);
+});


### PR DESCRIPTION
## Summary
- add TypeScript safe-fs wrapper enforcing canonicalization and symlink rejection before delegating to Tauri plugin
- document safe filesystem wrapper and future enforcement
- add unit tests for safe-fs API

## Testing
- `npm test -- tests/safe-fs.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c7ee1497b0832aa74b9b0fad40fe67