### PR TITLE
Guardrail — Block raw @tauri-apps/plugin-fs imports

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -2,6 +2,21 @@
 
 All TypeScript code must import filesystem operations from `src/files/safe-fs.ts`.
 This wrapper enforces canonicalization and the v1 symlink-deny policy before
-accessing disk. Direct imports of `@tauri-apps/plugin-fs` will be blocked in a
-future pull request. The wrapper also re-exports `RootKey` and `PathError` for
+accessing disk. The wrapper also re-exports `RootKey` and `PathError` for
 convenience.
+
+## Filesystem guardrail
+
+All TS file I/O must use `src/files/safe-fs.ts`. Direct imports of
+`@tauri-apps/plugin-fs` are forbidden across `src/**`, except in:
+
+- `src/files/safe-fs.ts` (wrapper implementation)
+- `src/files/path.ts` (runtime lstat + path utilities)
+
+To check locally:
+
+```bash
+npm run check:plugin-fs
+```
+
+The release build runs this guard and will abort if a raw import is introduced.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "schema:update": "scripts/verify_schema.sh --db dev.sqlite --schema schema.sql --update --verbose",
     "schema:verify:strict": "scripts/verify_schema.sh --db dev.sqlite --schema schema.sql --strict --include-migrations --verbose",
     "schema:ci": "scripts/ci/verify-schema.sh",
-      "release": "DB=dev.sqlite bash scripts/check_pending_migrations.sh && npm run tauri -- build"
+    "release": "npm run check:plugin-fs && DB=dev.sqlite bash scripts/check_pending_migrations.sh && npm run tauri -- build"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",


### PR DESCRIPTION
## Summary
- add node guard that rejects `@tauri-apps/plugin-fs` imports outside the sanctioned wrappers
- wire the guard into `check-all` and `release` npm scripts
- document filesystem guardrail in architecture docs

## Testing
- `npm run check:plugin-fs`
- `git grep -n '@tauri-apps/plugin-fs' -- src`
- `npm run check:plugin-fs` *(with temporary raw import; fails as expected)*
- `npm run release` *(with temporary raw import; fails before build)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fb660e74832abc07ee142364980a