### PR TITLE
Add structured FS logging and user-safe error presentation

### DIFF
--- a/src-tauri/src/security/fs_policy.rs
+++ b/src-tauri/src/security/fs_policy.rs
@@ -29,6 +29,21 @@ pub enum FsPolicyError {
     Io(#[from] std::io::Error),
 }
 
+impl FsPolicyError {
+    pub fn name(&self) -> &'static str {
+        match self {
+            FsPolicyError::UncRejected => "UncRejected",
+            FsPolicyError::DotDotRejected => "DotDotRejected",
+            #[cfg(target_os = "windows")]
+            FsPolicyError::CrossVolume => "CrossVolume",
+            FsPolicyError::OutsideRoot => "OutsideRoot",
+            FsPolicyError::Symlink => "Symlink",
+            FsPolicyError::Invalid => "Invalid",
+            FsPolicyError::Io(_) => "Io",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct CanonResult {
     pub real_path: PathBuf,

--- a/src-tauri/tests/log_redaction.rs
+++ b/src-tauri/tests/log_redaction.rs
@@ -1,0 +1,56 @@
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::{fmt, EnvFilter};
+
+#[test]
+fn fs_deny_logs_no_path() {
+    // Capture logs
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer = buf.clone();
+    let _ = fmt()
+        .with_env_filter(EnvFilter::new("arklowdun=info"))
+        .with_writer(move || Redactor(writer.clone()))
+        .json()
+        .try_init();
+
+    // Arrange a fake appdata and mock app
+    let dir = std::env::temp_dir().join("ark_redaction_smoke");
+    std::fs::create_dir_all(&dir).ok();
+    std::env::set_var("ARK_FAKE_APPDATA", &dir);
+
+    let app = tauri::test::mock_app();
+    let handle = app.handle();
+
+    // Trigger a deny via canonicalize_and_verify("..")
+    let err = arklowdun_lib::security::fs_policy::canonicalize_and_verify(
+        "..",
+        arklowdun_lib::security::fs_policy::RootKey::AppData,
+        &handle,
+    )
+    .unwrap_err();
+    let reason = err.name();
+    let ui: arklowdun_lib::security::error_map::UiError = err.into();
+    arklowdun_lib::log_fs_deny(
+        arklowdun_lib::security::fs_policy::RootKey::AppData,
+        &ui,
+        reason,
+    );
+
+    let s = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(s.contains("\"event\":\"fs_guard_check\""));
+    assert!(s.contains("\"ok\":false"));
+    assert!(
+        !s.contains(dir.to_string_lossy().as_ref()),
+        "log leaked a raw path"
+    );
+}
+
+struct Redactor(Arc<Mutex<Vec<u8>>>);
+impl std::io::Write for Redactor {
+    fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(b);
+        Ok(b.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,0 +1,25 @@
+export type FsUiError =
+  | { code: 'NOT_ALLOWED'; message: string }
+  | { code: 'INVALID_INPUT'; message: string }
+  | { code: 'IO/GENERIC'; message: string };
+
+const toast = {
+  error(msg: string) {
+    const el = document.querySelector('#errors');
+    if (el) el.textContent = msg;
+  },
+};
+
+export function presentFsError(e: unknown) {
+  const any = e as Partial<FsUiError> | undefined;
+  const code = any?.code ?? 'IO/GENERIC';
+  const title =
+    code === 'NOT_ALLOWED'
+      ? "That location isn't allowed"
+      : code === 'INVALID_INPUT'
+      ? 'Invalid path'
+      : 'File error';
+  toast.error(title);
+  // Optional dev console crumb without paths
+  console.debug('[fs-deny]', { code, when: new Date().toISOString() });
+}

--- a/src/ui/ImportModal.ts
+++ b/src/ui/ImportModal.ts
@@ -2,6 +2,7 @@ import { listen } from "@tauri-apps/api/event";
 import { call } from "../db/call";
 import { defaultHouseholdId } from "../db/household";
 import { showError } from "./errors";
+import { presentFsError } from "../lib/ipc";
 
 export function ImportModal(el: HTMLElement) {
   el.innerHTML = `
@@ -39,7 +40,13 @@ export function ImportModal(el: HTMLElement) {
         logLink.innerHTML = "";
         const btn = document.createElement("button");
         btn.textContent = "Open log";
-        btn.onclick = () => call("open_path", { path: lp });
+        btn.onclick = async () => {
+          try {
+            await call("open_path", { path: lp });
+          } catch (e) {
+            presentFsError(e);
+          }
+        };
         logLink.appendChild(btn);
       }
       line("Started");


### PR DESCRIPTION
## Summary
- tag FS policy errors with reason names
- log redacted file system checks and denials
- present sanitized file-system errors in the UI
- guard against malformed IPC errors and fix test handle usage

## Testing
- `npm test`
- `cargo test -p arklowdun --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68c82556449c832abe427d231d19c6a3