### PR TITLE
Add rotating file logging and stress tests

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "dirs 5.0.1",
+ "file-rotate",
  "futures",
  "include_dir",
  "libc",
@@ -153,6 +154,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
  "ts-rs",
@@ -1272,6 +1274,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "file-rotate"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+dependencies = [
+ "chrono",
+ "flate2",
 ]
 
 [[package]]
@@ -5340,6 +5352,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ paste = "1.0"
 regex = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json", "time"] }
+tracing-appender = "0.2"
 log = "0.4"
 tracing-log = "0.2"
 time = "0.3"
@@ -56,6 +57,7 @@ windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem"] }
 dirs = "5"
 sha2 = "0.10"
 thiserror = "1"
+file-rotate = "0.7"
 
 [dev-dependencies]
 libc = "0.2"
@@ -74,3 +76,7 @@ path = "scripts/migrate.rs"
 [[bin]]
 name = "sec_smoke"
 path = "scripts/sec_smoke.rs"
+
+[[bin]]
+name = "log_stress"
+path = "tests/bin/log_stress.rs"

--- a/src-tauri/tests/bin/log_stress.rs
+++ b/src-tauri/tests/bin/log_stress.rs
@@ -1,0 +1,37 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{thread::sleep, time::Duration};
+
+fn main() {
+    arklowdun_lib::init_logging();
+
+    let app = tauri::test::mock_app();
+    let handle = app.app_handle();
+
+    if let Err(err) = arklowdun_lib::init_file_logging(&handle) {
+        tracing::warn!(
+            target = "arklowdun",
+            event = "file_logging_disabled",
+            error = %err
+        );
+        std::process::exit(1);
+    }
+
+    let run_id = std::env::var("ARK_STRESS_RUN_ID").unwrap_or_else(|_| "stress".to_string());
+    let lines = std::env::var("ARK_STRESS_LINES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(20_000);
+
+    for idx in 0..lines {
+        tracing::info!(
+            target = "arklowdun",
+            event = "stress_line",
+            run = %run_id,
+            index = idx
+        );
+    }
+
+    arklowdun_lib::flush_file_logs();
+    sleep(Duration::from_millis(200));
+}

--- a/src-tauri/tests/log_file_smoke.rs
+++ b/src-tauri/tests/log_file_smoke.rs
@@ -1,0 +1,63 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{fs, thread::sleep, time::Duration};
+
+#[test]
+fn file_sink_writes_json_lines() {
+    arklowdun_lib::init_logging();
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::env::set_var("ARK_FAKE_APPDATA", tmp.path());
+
+    let app = tauri::test::mock_app();
+    let handle = app.app_handle();
+
+    arklowdun_lib::init_file_logging(&handle).expect("file logging to initialize");
+
+    let base = handle.path().app_data_dir().expect("app data dir");
+    let logs_dir = base.join("logs");
+
+    assert!(logs_dir.is_dir(), "logs dir missing: {:?}", logs_dir);
+
+    tracing::info!(target = "arklowdun", event = "smoke_test", marker = "first");
+    arklowdun_lib::flush_file_logs();
+
+    let log_path = logs_dir.join("arklowdun.log");
+    wait_for_file(&log_path);
+
+    let contents = fs::read_to_string(&log_path).expect("read log file");
+    let last_line = contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .last()
+        .expect("log line present");
+    let value: serde_json::Value = serde_json::from_str(last_line).expect("json log line");
+
+    assert_eq!(
+        value.get("event"),
+        Some(&serde_json::Value::String("smoke_test".into()))
+    );
+    assert_eq!(
+        value.get("level"),
+        Some(&serde_json::Value::String("INFO".into()))
+    );
+    assert!(value.get("timestamp").and_then(|v| v.as_str()).is_some());
+    assert_eq!(
+        value.get("target"),
+        Some(&serde_json::Value::String("arklowdun".into()))
+    );
+}
+
+fn wait_for_file(path: &std::path::Path) {
+    for _ in 0..20 {
+        if path.exists() {
+            if let Ok(metadata) = fs::metadata(path) {
+                if metadata.len() > 0 {
+                    return;
+                }
+            }
+        }
+        sleep(Duration::from_millis(50));
+    }
+    panic!("log file did not appear: {:?}", path);
+}

--- a/src-tauri/tests/log_rotation.rs
+++ b/src-tauri/tests/log_rotation.rs
@@ -1,0 +1,173 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use assert_cmd::prelude::*;
+use serde_json::Value;
+use std::{
+    collections::HashSet,
+    fs,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::Command,
+    thread::sleep,
+    time::Duration,
+};
+use tempfile::tempdir;
+
+#[test]
+fn rotation_survives_restart() {
+    let tmp = tempdir().unwrap();
+    let appdata = tmp.path().join("appdata");
+    fs::create_dir_all(&appdata).unwrap();
+
+    run_stress(&appdata, "first");
+    let first = LogState::capture(&appdata);
+
+    assert!(
+        first.files.len() <= 4,
+        "too many files after first run: {:?}",
+        first.files
+    );
+    assert!(
+        first.rotated_count() >= 2,
+        "rotation did not create multiple files"
+    );
+    assert!(first.run_ids.contains("first"));
+    assert_eq!(first.run_ids.len(), 1, "unexpected runs in first pass");
+
+    run_stress(&appdata, "second");
+    let second = LogState::capture(&appdata);
+
+    assert!(
+        second.files.len() <= 4,
+        "retention cap exceeded: {:?}",
+        second.files
+    );
+    assert!(second.run_ids.contains("first"), "first run logs missing");
+    assert!(second.run_ids.contains("second"), "second run logs missing");
+    let current_run = second
+        .last_current
+        .as_ref()
+        .and_then(|value| value.get("run"))
+        .and_then(Value::as_str);
+    assert_eq!(
+        current_run,
+        Some("second"),
+        "latest log missing second run marker"
+    );
+
+    for path in &second.files {
+        assert!(
+            fs::metadata(path).unwrap().len() > 0,
+            "empty log file: {:?}",
+            path
+        );
+    }
+}
+
+fn run_stress(appdata: &Path, run_id: &str) {
+    let mut cmd = Command::cargo_bin("log_stress").expect("binary built");
+    cmd.env("ARK_FAKE_APPDATA", appdata)
+        .env("TAURI_ARKLOWDUN_LOG_MAX_SIZE_BYTES", "10240")
+        .env("TAURI_ARKLOWDUN_LOG_MAX_FILES", "3")
+        .env("ARK_STRESS_LINES", "20000")
+        .env("ARK_STRESS_RUN_ID", run_id);
+    cmd.assert().success();
+}
+
+#[derive(Debug)]
+struct LogState {
+    files: Vec<PathBuf>,
+    run_ids: HashSet<String>,
+    last_current: Option<Value>,
+}
+
+impl LogState {
+    fn capture(appdata: &Path) -> Self {
+        let logs_dir = appdata.join("logs");
+        wait_for_current_log(&logs_dir);
+
+        let mut files = collect_log_files(&logs_dir);
+        files.sort();
+
+        let mut run_ids = HashSet::new();
+        let mut last_current = None;
+
+        for path in &files {
+            if let Some(value) = read_log_file(path, &mut run_ids) {
+                if path.file_name().and_then(|name| name.to_str()) == Some("arklowdun.log") {
+                    last_current = Some(value);
+                }
+            }
+        }
+
+        Self {
+            files,
+            run_ids,
+            last_current,
+        }
+    }
+
+    fn rotated_count(&self) -> usize {
+        self.files
+            .iter()
+            .filter(|path| path.file_name().and_then(|name| name.to_str()) != Some("arklowdun.log"))
+            .count()
+    }
+}
+
+fn collect_log_files(logs_dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(logs_dir)
+        .unwrap()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.is_file() && path.file_name()?.to_str()?.starts_with("arklowdun.log") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+fn read_log_file(path: &Path, run_ids: &mut HashSet<String>) -> Option<Value> {
+    let file = fs::File::open(path).expect("open log file");
+    let reader = BufReader::new(file);
+    let mut last = None;
+
+    for line in reader.lines() {
+        let line = line.expect("read log line");
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(&line).expect("parse json log");
+        assert_eq!(
+            value.get("target").and_then(Value::as_str),
+            Some("arklowdun")
+        );
+        assert!(value.get("event").is_some(), "missing event field: {value}");
+        assert!(value.get("timestamp").and_then(Value::as_str).is_some());
+        assert_eq!(value.get("level").and_then(Value::as_str), Some("INFO"));
+        if let Some(run) = value.get("run").and_then(Value::as_str) {
+            run_ids.insert(run.to_string());
+        }
+        last = Some(value);
+    }
+
+    last
+}
+
+fn wait_for_current_log(logs_dir: &Path) {
+    let current = logs_dir.join("arklowdun.log");
+    for _ in 0..40 {
+        if let Ok(metadata) = fs::metadata(&current) {
+            if metadata.len() > 0 {
+                return;
+            }
+        }
+        sleep(Duration::from_millis(50));
+    }
+    panic!("log file never materialized: {:?}", current);
+}


### PR DESCRIPTION
## Summary
- add file-rotate + tracing-appender based sink in `init_logging` and initialize it from `run`
- write logs to `<appDataDir>/logs/arklowdun.log` with size/count retention from new env vars
- add stress helper binary plus smoke and rotation integration tests that validate JSON output

## Testing
- `cargo test --tests` *(fails: missing system library glib-2.0 / gobject-2.0 required by tauri)*

------
https://chatgpt.com/codex/tasks/task_e_68c94cbd2a6c832a95fa72a8d5533e82