### PR TITLE
Address crash ID review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ Dev tools:
   cargo test --test log_file_smoke  # checks file JSON sink
   cargo test --test log_rotation    # rotation across restarts
 
+### Crash IDs & Support
+
+- Critical backend failures return a Crash ID to the UI with the banner:
+  `Something went wrong. Crash ID: <ID>.`
+- The same identifier is emitted in every `level=ERROR` log as `crash_id=...` so
+  support can search rotated files: `rg "crash_id=<ID>" logs/arklowdun.log*`.
+- Run `cargo run --bin crash_probe` to generate a sample Crash ID and verify log
+  plumbing end-to-end.
+- See [docs/ops/runbooks.md](docs/ops/runbooks.md) for the triage checklist.
+
 ## Database integrity
 
 Schema constraint guidelines live in [docs/integrity-rules.md](docs/integrity-rules.md).

--- a/docs/ops/runbooks.md
+++ b/docs/ops/runbooks.md
@@ -1,0 +1,49 @@
+# Crash ID Triage
+
+Use this runbook whenever support receives a screenshot or report that includes
+`Something went wrong. Crash ID: <ID>.`
+
+## Collect
+
+1. Ask the user for the full Crash ID string and approximate local timestamp.
+2. Confirm the platform (macOS/Windows/Linux) to locate the correct log
+   directory.
+
+## Locate logs
+
+1. On macOS the default path is
+   `~/Library/Application Support/com.arklowdun.app/logs/`. Windows installs
+   write to `%APPDATA%\com.arklowdun.app\logs\`.
+2. Copy the logs locally if the user cannot send them. Otherwise unpack the
+   archive into a scratch directory.
+
+## Search by Crash ID
+
+```sh
+rg "crash_id=<ID>" arklowdun.log*
+```
+
+- Expect at least one `critical_failure` line and often a preceding
+  `panic_caught` or domain-specific event.
+- When multiple log files match, read the newest timestamp first.
+
+## Analyze
+
+1. Read surrounding log entries (same Crash ID) to understand which command or
+   subsystem failed. Most critical logs include `code` and `message` fields.
+2. Use the stack/context fields in the JSON to correlate with bug reports or
+   telemetry.
+3. If the log came from a panic, also review the `panic_hook` entry for the raw
+   payload/location.
+
+## Follow-up
+
+- File or update a bug with the Crash ID, the triggering action, and the log
+  snippet.
+- Ask the user to retry once a fix ships; Crash IDs are unique per failure.
+
+## Smoke test the pipeline
+
+- Run `cargo run --bin crash_probe` locally. The tool emits a new Crash ID,
+  prints it to stdout, and logs a `crash_probe_triggered` + `critical_failure`
+  pair you can locate via `rg`.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
-uuid = { version = "1", features = ["v7"] }
+uuid = { version = "1", features = ["serde", "v7"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
@@ -80,3 +80,7 @@ path = "scripts/sec_smoke.rs"
 [[bin]]
 name = "log_stress"
 path = "tests/bin/log_stress.rs"
+
+[[bin]]
+name = "crash_probe"
+path = "scripts/crash_probe.rs"

--- a/src-tauri/scripts/crash_probe.rs
+++ b/src-tauri/scripts/crash_probe.rs
@@ -1,0 +1,21 @@
+use arklowdun_lib::AppError;
+
+fn main() {
+    arklowdun_lib::init_logging();
+
+    let error = AppError::critical("SUPPORT/PROBE", "crash probe triggered");
+    if let Some(crash_id) = error.crash_id().cloned() {
+        tracing::error!(
+            target = "arklowdun",
+            event = "crash_probe_triggered",
+            crash_id = %crash_id,
+            code = %error.code(),
+            message = %error.message()
+        );
+        let _ = serde_json::to_string(&error);
+        arklowdun_lib::flush_file_logs();
+        println!("Crash probe executed. Crash ID: {crash_id}");
+    } else {
+        println!("Crash probe executed without crash id (unexpected)");
+    }
+}

--- a/src-tauri/src/error/crash_id.rs
+++ b/src-tauri/src/error/crash_id.rs
@@ -1,0 +1,71 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use ts_rs::TS;
+use uuid::Uuid;
+
+/// Unique identifier used to correlate critical failures across logs and UI.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[repr(transparent)]
+#[serde(transparent)]
+#[ts(type = "string")]
+pub struct CrashId(Uuid);
+
+impl CrashId {
+    /// Generate a new UUIDv7 crash identifier.
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+
+    /// Access the underlying UUID value.
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for CrashId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for CrashId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Uuid::parse_str(s)?))
+    }
+}
+
+impl From<Uuid> for CrashId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<CrashId> for Uuid {
+    fn from(value: CrashId) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_serialized_form() {
+        let id = CrashId::new();
+        let rendered = id.to_string();
+        let json = serde_json::to_string(&id).expect("serialize crash id");
+        assert_eq!(json.trim_matches('"'), rendered);
+        assert!(Uuid::parse_str(&rendered).is_ok());
+    }
+
+    #[test]
+    fn parse_roundtrips() {
+        let id = CrashId::new();
+        let parsed: CrashId = id.to_string().parse().expect("parse crash id");
+        assert_eq!(parsed, id);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,8 @@ use std::{
 };
 use tauri::{Manager, State};
 use thiserror::Error;
-use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_appender::non_blocking::NonBlockingBuilder;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{
     fmt::{self, time::UtcTime, MakeWriter},
     layer::SubscriberExt,
@@ -44,7 +44,10 @@ struct LineBuffered<W: Write + Send> {
 
 impl<W: Write + Send> LineBuffered<W> {
     fn new(inner: W) -> Self {
-        Self { inner, buf: Vec::with_capacity(1024) }
+        Self {
+            inner,
+            buf: Vec::with_capacity(1024),
+        }
     }
 }
 
@@ -121,9 +124,18 @@ struct CountRotator {
 
 impl CountRotator {
     fn new(path: PathBuf, max_bytes: usize, max_files: usize) -> io::Result<Self> {
-        let file = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
         let len = file.metadata().map(|m| m.len()).unwrap_or(0);
-        Ok(Self { path, max_bytes, max_files, file, len })
+        Ok(Self {
+            path,
+            max_bytes,
+            max_files,
+            file,
+            len,
+        })
     }
 
     fn rotate(&mut self) -> io::Result<()> {
@@ -138,7 +150,11 @@ impl CountRotator {
 
         // Shift files: .(n-1) -> .n, current -> .1
         for i in (1..=self.max_files).rev() {
-            let src = if i == 1 { self.path.clone() } else { self.suffixed(i - 1) };
+            let src = if i == 1 {
+                self.path.clone()
+            } else {
+                self.suffixed(i - 1)
+            };
             if src.exists() {
                 let dst = self.suffixed(i);
                 let _ = std::fs::rename(&src, &dst);
@@ -146,14 +162,22 @@ impl CountRotator {
         }
 
         // Create a new current file
-        self.file = std::fs::OpenOptions::new().create(true).write(true).truncate(true).open(&self.path)?;
+        self.file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&self.path)?;
         self.len = 0;
         Ok(())
     }
 
     fn suffixed(&self, idx: usize) -> PathBuf {
         let mut p = self.path.clone();
-        let file_name = p.file_name().and_then(|n| n.to_str()).unwrap_or("").to_string();
+        let file_name = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
         p.set_file_name(format!("{}.{}", file_name, idx));
         p
     }
@@ -170,7 +194,9 @@ impl Write for CountRotator {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> io::Result<()> { self.file.flush() }
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
 }
 
 pub fn init_logging() {
@@ -205,6 +231,7 @@ pub fn init_logging() {
         .with(file_layer);
 
     let _ = subscriber.try_init();
+    crate::error::install_panic_hook();
 }
 
 #[derive(Debug, Error)]
@@ -250,8 +277,12 @@ pub fn init_file_logging<R: tauri::Runtime>(
 
     let (max_bytes, max_files) = file_logging_limits();
     let byte_limit = usize::try_from(max_bytes).unwrap_or(usize::MAX);
-    let rotator = CountRotator::new(log_path.clone(), byte_limit, max_files)
-        .map_err(|source| FileLoggingError::CreateFile { path: log_path.clone(), source })?;
+    let rotator = CountRotator::new(log_path.clone(), byte_limit, max_files).map_err(|source| {
+        FileLoggingError::CreateFile {
+            path: log_path.clone(),
+            source,
+        }
+    })?;
 
     // Use a lossless, larger-buffer non-blocking writer so heavy bursts
     // (like stress tests) don't drop lines before rotation can trigger.

--- a/src-tauri/tests/critical_error.rs
+++ b/src-tauri/tests/critical_error.rs
@@ -1,0 +1,63 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::{fmt, EnvFilter};
+
+#[test]
+fn critical_error_emits_crash_id_and_log() {
+    let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let writer = buf.clone();
+    let _ = fmt()
+        .with_env_filter(EnvFilter::new("arklowdun=trace"))
+        .with_writer(move || TestWriter(writer.clone()))
+        .json()
+        .try_init();
+
+    let error = arklowdun_lib::AppError::critical("UNIT/CRIT", "boom");
+    let crash_id = error
+        .crash_id()
+        .cloned()
+        .expect("critical error assigns crash id");
+    let crash_str = crash_id.to_string();
+
+    let json = serde_json::to_string(&error).expect("serialize");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("parse");
+    assert_eq!(
+        value.get("crash_id").and_then(|v| v.as_str()),
+        Some(crash_str.as_str())
+    );
+    let expected = format!("Something went wrong. Crash ID: {crash_str}.");
+    assert_eq!(
+        value.get("message").and_then(|v| v.as_str()),
+        Some(expected.as_str())
+    );
+    assert!(
+        !json.contains("\"boom\""),
+        "sanitized message leaked original payload: {json}"
+    );
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(
+        logs.contains("\"event\":\"critical_failure\""),
+        "missing critical_failure log: {logs}"
+    );
+    assert!(
+        logs.contains(&format!("\"crash_id\":\"{crash_id}\"")),
+        "log missing crash id: {logs}"
+    );
+}
+
+#[derive(Clone)]
+struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/api/call.ts
+++ b/src/api/call.ts
@@ -32,7 +32,15 @@ export function normalizeError(error: unknown): AppError {
 
     const ctx = normalizeContext(error.context);
 
-    const out: AppError = { code, message, context: ctx };
+    const record = error as UnknownRecord;
+    let crashId: string | undefined;
+    if (typeof record.crash_id === "string") {
+      crashId = record.crash_id;
+    } else if (typeof record.crashId === "string") {
+      crashId = record.crashId;
+    }
+
+    const out: AppError = { code, message, context: ctx, crash_id: crashId };
 
     if (error.cause) out.cause = normalizeError(error.cause);
     else if (typeof error.stack === "string" && !out.context?.stack) {

--- a/src/bindings/AppError.ts
+++ b/src/bindings/AppError.ts
@@ -15,7 +15,11 @@ message: string,
 /**
  * Arbitrary key/value pairs that provide additional context.
  */
-context: Record<string, string> | undefined, 
+context: Record<string, string> | undefined,
+/**
+ * Optional crash identifier that can be shared with support.
+ */
+crash_id?: string,
 /**
  * Optional nested cause that preserves the error chain.
  */

--- a/src/ui/errors.ts
+++ b/src/ui/errors.ts
@@ -7,7 +7,11 @@ export function showError(err: unknown) {
 
   const container = document.querySelector("#errors");
   if (container) {
-    container.textContent = `${error.message} (${error.code})`;
+    if (error.crash_id) {
+      container.textContent = `Something went wrong. Crash ID: ${error.crash_id}.`;
+    } else {
+      container.textContent = `${error.message} (${error.code})`;
+    }
   }
   log.error("error", error);
 }

--- a/tests/app-error-binding.test.ts
+++ b/tests/app-error-binding.test.ts
@@ -9,4 +9,7 @@ test("AppError.ts uses context: Record<string, string> | undefined (optional or 
   // `context: Record<string,string> | undefined` (ts-rs may omit `?` when using a union type override).
   const re = /context\??\s*:\s*Record<string,\s*string>\s*\|\s*undefined/;
   assert.match(txt, re);
+
+  const crash = /crash_id\??\s*:\s*string(?:\s*\|\s*undefined)?/;
+  assert.match(txt, crash);
 });

--- a/tests/normalize-error.test.ts
+++ b/tests/normalize-error.test.ts
@@ -10,6 +10,7 @@ test("normalizeError preserves cause and coerces context values to strings", asy
     code: SAMPLE_CODE,
     message: "Record not found",
     context: { id: 42, stale: false },
+    crash_id: "01890123-aaaa-bbbb-cccc-abcdefabcdef",
     cause: {
       message: "sql row missing",
       context: { reason: ["missing"] },
@@ -24,6 +25,7 @@ test("normalizeError preserves cause and coerces context values to strings", asy
   assert.ok(n.context);
   assert.equal(n.context!.id, "42");
   assert.equal(n.context!.stale, "false");
+  assert.equal(n.crash_id, "01890123-aaaa-bbbb-cccc-abcdefabcdef");
 
   // cause
   assert.ok(n.cause);


### PR DESCRIPTION
## Summary
- restore the serde import on `AppError` and confine crash logging to the custom serializer to avoid duplicate `critical_failure` entries
- enable the `uuid` serde feature and tag `CrashId` as `repr(transparent)` for consistent serialization/FFI handling
- extend the critical error test to ensure the sanitized payload never leaks the original message

## Testing
- `npm test`
- `cargo test` *(fails: missing system dependency glib-2.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c990b8ab44832aa9ddde7b28de1c92