### PR TITLE
Add cross-platform diagnostics collection scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ Dev tools:
   plumbing end-to-end.
 - See [docs/ops/runbooks.md](docs/ops/runbooks.md) for the triage checklist.
 
+## 🚨 DIAGNOSTICS TODO — PRIMETIME BLOCKER
+
+> This release depends on `python3` for log redaction on macOS/Linux.
+> Before any paid/“primetime” release, replace it with a bundled helper binary (e.g. `ark-diag`) or Rust integration.
+> Tracking: PR-Diag-01..04. This MUST be closed before charging users.
+> Until then, the Unix script fails if `python3` is missing (unless `--raw --yes` is used, which skips redaction and warns).
+
+Override the diagnostics size cap with `ARK_MAX_FILE_MB=10` (default 10).
+
+## Diagnostics bundles
+
+- Use `scripts/collect-diagnostics.sh` (macOS/Linux) or
+  `scripts/collect-diagnostics.ps1` (PowerShell) to produce a redacted support
+  archive.
+- The scripts gather logs, config metadata, crash reports and optional database
+  hashes into `diagnostics-<timestamp>-<hash>.zip`.
+- Redaction rules, platform paths and CLI usage are documented in
+  [docs/diagnostics.md](docs/diagnostics.md).
+
 ## Database integrity
 
 Schema constraint guidelines live in [docs/integrity-rules.md](docs/integrity-rules.md).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,116 @@
+# 🚨 IMPORTANT LIMITATION (TEMPORARY)
+Unix collector calls `python3` for redaction. Replace with a bundled helper before any paid/public release.
+If `python3` is missing, only `--raw --yes` will proceed (no redaction) with a warning in the bundle README.
+
+# Diagnostics bundles
+
+The `collect-diagnostics` scripts create a redacted archive that can be sent to
+support when troubleshooting Arklowdun installs. The scripts exist in both
+shell (`scripts/collect-diagnostics.sh`) and PowerShell
+(`scripts/collect-diagnostics.ps1`) variants so the same behaviour is available
+on macOS/Linux and Windows.
+
+```bash
+# macOS/Linux (redacted by default)
+scripts/collect-diagnostics.sh
+
+# Include DB hash metadata
+scripts/collect-diagnostics.sh --include-db
+
+# Raw (no redaction). Use only if support asks:
+scripts/collect-diagnostics.sh --raw --yes
+```
+
+## What gets collected
+
+Each bundle contains a `diagnostics/` folder with:
+
+- `collected/` – redacted copies of application logs, configuration files and
+  the most recent crash report (if one exists).
+- `raw/` – present only when `--raw` is requested. It holds unredacted copies
+  of the same files for advanced troubleshooting.
+- `db/` – present only when `--include-db` is used. Contains `db.meta.json`
+  (size and timestamps) and `db.sha256` (hash of the SQLite database). The
+  database file itself is never copied.
+- `manifest.json` – a record of every file considered (included or skipped)
+  with metadata, redaction flags and checksums.
+- `checksums.txt` – SHA256 hashes for files under `collected/`, `raw/` (if
+  present) and `db/`.
+- `system.json` – platform metadata, script version, resolved paths and
+  timestamp.
+- `README.txt` – summary and safety notes for the generated bundle.
+
+Files are discovered using these defaults (all overridable with flags):
+
+| Platform | Logs directory | Data/config directory | Crash reports |
+| --- | --- | --- | --- |
+| macOS | `~/Library/Logs/Arklowdun/` | `~/Library/Application Support/com.paula.arklowdun/` | `~/Library/Logs/DiagnosticReports/` |
+| Linux | `${XDG_STATE_HOME:-~/.local/state}/Arklowdun/logs/` | `${XDG_DATA_HOME:-~/.local/share}/Arklowdun/` | (stub message only) |
+| Windows | `%LOCALAPPDATA%\Arklowdun\Logs\` | `%APPDATA%\Arklowdun\` | (stub message with next steps) |
+
+## Redaction rules
+
+Redacted copies remove or normalise sensitive information:
+
+- Email addresses → `<redacted:email>`
+- IPv4/IPv6 addresses → `<redacted:ip>`
+- MAC addresses → `<redacted:mac>`
+- Home directory prefixes (macOS/Linux `~/`, Windows `C:\Users\…`) → `<home>`
+- Absolute paths outside the application’s own data/log roots → `<path>`
+- 16+ character hexadecimal tokens (except CrashIDs) → `<redacted:uuid>`
+- Values for keys named `api_key`, `token`, `password`, `secret` (case
+  insensitive) → `<redacted:secret>`
+
+Relative paths inside the app’s own directories are preserved so stack traces
+and file locations remain useful.
+
+Any file larger than 10 MB (override with `ARK_MAX_FILE_MB`) is skipped and the
+manifest records the skip reason.
+
+## CLI flags
+
+```
+--out DIR       Destination directory for the zip (default: Desktop)
+--raw           Include unredacted copies in addition to redacted ones
+--include-db    Record database metadata and SHA256 hash (no DB contents)
+--data-dir DIR  Override the data/config directory
+--logs-dir DIR  Override the logs directory
+--bundle-id ID  Override the bundle identifier used for crash reports
+--yes           Non-interactive mode; auto-confirm the `--raw` warning
+```
+
+Examples:
+
+```bash
+# macOS/Linux
+scripts/collect-diagnostics.sh
+scripts/collect-diagnostics.sh --raw --yes --include-db
+
+# Windows PowerShell
+pwsh scripts/collect-diagnostics.ps1 --out C:\\Temp\\Support
+```
+
+`--raw` prompts before including unredacted files unless `--yes` is supplied.
+If the prompt is declined, the script continues with redacted copies only and
+records a warning.
+
+## Inspecting the bundle
+
+Open `manifest.json` to see exactly which files were included, skipped and why.
+Every entry lists size, modification time and SHA256 checksums. Use
+`checksums.txt` to verify files inside the archive. Platform metadata (platform,
+OS version, architecture, resolved paths) lives in `system.json`.
+
+To review the bundle without extracting the zip, use any archive viewer. The
+generated file name follows `diagnostics-<YYYYMMDD-HHMMSS>-<short-hash>.zip`
+where the short hash is derived from the manifest.
+
+## Sharing with support
+
+After running the script the final line of output prints the absolute path to
+the generated zip. Attach that archive to the support email. Because content is
+redacted by default it is safe to share, but you should still review the README
+and manifest before sending.
+
+If you use `--raw` the README includes an additional warning banner to ensure
+the recipient understands that unredacted files are present.

--- a/scripts/collect-diagnostics.ps1
+++ b/scripts/collect-diagnostics.ps1
@@ -1,0 +1,561 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $env:ARK_SILENCE_TODO) {
+@'
+===============================================================================
+ ⚠️  DIAGNOSTICS TODO: Unix collector depends on python3 (temporary).
+     Replace with a bundled helper (ark-diag) before any paid/public release.
+     Tracking: PR-Diag-01..04.
+===============================================================================
+'@ | Write-Warning
+}
+
+$ScriptVersion = '1.0.0'
+$DefaultBundleId = 'com.paula.arklowdun'
+$MaxFileMbDefault = 10
+
+function Show-Usage {
+    @'
+Usage: scripts/collect-diagnostics.ps1 [options]
+
+Options:
+  --out DIR          Output directory for the diagnostics zip (default: Desktop)
+  --raw              Include raw, unredacted copies (requires confirmation)
+  --include-db       Include hash metadata for the SQLite database
+  --data-dir DIR     Override app data directory
+  --logs-dir DIR     Override logs directory
+  --bundle-id ID     Override bundle identifier
+  --yes              Non-interactive mode; assume consent for --raw
+  --help             Show this help message
+'@
+}
+
+function Resolve-AbsolutePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if ($resolved) {
+        return $resolved.Path
+    }
+    return [System.IO.Path]::GetFullPath([System.IO.Path]::Combine((Get-Location).Path, $Path))
+}
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        [System.IO.Directory]::CreateDirectory($Path) | Out-Null
+    }
+}
+
+function Compute-Sha256 {
+    param([string]$Path)
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-IsoTimestamp {
+    param([datetime]$DateTime)
+    return $DateTime.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+}
+
+function Get-AppVersion {
+    $pathJson = Join-Path $PSScriptRoot '../src-tauri/tauri.conf.json'
+    $pathJson5 = Join-Path $PSScriptRoot '../src-tauri/tauri.conf.json5'
+    $target = $null
+    if (Test-Path -LiteralPath $pathJson) { $target = $pathJson }
+    elseif (Test-Path -LiteralPath $pathJson5) { $target = $pathJson5 }
+    if (-not $target) { return 'unknown' }
+    $content = Get-Content -LiteralPath $target -Raw
+    $match = [regex]::Match($content, '"version"\s*:\s*"([^"]+)"')
+    if ($match.Success) { return $match.Groups[1].Value }
+    return 'unknown'
+}
+
+function Get-OsVersion {
+    if ($IsMacOS) {
+        try { return (sw_vers -productVersion) } catch { return 'macOS' }
+    } elseif ($IsLinux) {
+        $osRelease = '/etc/os-release'
+        if (Test-Path -LiteralPath $osRelease) {
+            $line = Get-Content -LiteralPath $osRelease | Where-Object { $_ -like 'PRETTY_NAME=*' } | Select-Object -First 1
+            if ($line) { return $line.Split('=')[1].Trim('"') }
+        }
+        return 'linux'
+    } else {
+        return [System.Environment]::OSVersion.VersionString
+    }
+}
+
+$maxFileMb = if ($env:ARK_MAX_FILE_MB) { [int]$env:ARK_MAX_FILE_MB } else { $MaxFileMbDefault }
+if ($maxFileMb -le 0) {
+    throw "ARK_MAX_FILE_MB must be a positive integer"
+}
+$maxFileBytes = $maxFileMb * 1024 * 1024
+
+$outDir = $null
+$rawRequested = $false
+$includeDb = $false
+$dataDir = $null
+$logsDir = $null
+$bundleId = $DefaultBundleId
+$yesMode = $false
+
+for ($i = 0; $i -lt $args.Length; $i++) {
+    switch ($args[$i]) {
+        '--out' {
+            if ($i + 1 -ge $args.Length) { throw '--out requires a value' }
+            $i++
+            $outDir = $args[$i]
+        }
+        '--raw' { $rawRequested = $true }
+        '--include-db' { $includeDb = $true }
+        '--data-dir' {
+            if ($i + 1 -ge $args.Length) { throw '--data-dir requires a value' }
+            $i++
+            $dataDir = $args[$i]
+        }
+        '--logs-dir' {
+            if ($i + 1 -ge $args.Length) { throw '--logs-dir requires a value' }
+            $i++
+            $logsDir = $args[$i]
+        }
+        '--bundle-id' {
+            if ($i + 1 -ge $args.Length) { throw '--bundle-id requires a value' }
+            $i++
+            $bundleId = $args[$i]
+        }
+        '--yes' { $yesMode = $true }
+        '--help' { Show-Usage; exit 0 }
+        default { throw "Unknown argument: $($args[$i])" }
+    }
+}
+
+$usedDefaultOut = $false
+if (-not $outDir) {
+    if ($IsWindows) {
+        $outDir = [Environment]::GetFolderPath('Desktop')
+    } else {
+        $outDir = [Environment]::GetFolderPath('Desktop')
+        if (-not $outDir) { $outDir = "$HOME/Desktop" }
+    }
+    $usedDefaultOut = $true
+}
+
+if (-not $dataDir) {
+    if ($IsWindows) {
+        $dataDir = [System.IO.Path]::Combine($env:APPDATA, 'Arklowdun')
+    } elseif ($IsMacOS) {
+        $dataDir = Join-Path $HOME "Library/Application Support/$bundleId"
+    } else {
+        $xdgData = if ($env:XDG_DATA_HOME) { $env:XDG_DATA_HOME } else { Join-Path $HOME '.local/share' }
+        $dataDir = Join-Path $xdgData 'Arklowdun'
+    }
+}
+
+if (-not $logsDir) {
+    if ($IsWindows) {
+        $logsDir = [System.IO.Path]::Combine($env:LOCALAPPDATA, 'Arklowdun', 'Logs')
+    } elseif ($IsMacOS) {
+        $logsDir = Join-Path $HOME 'Library/Logs/Arklowdun'
+    } else {
+        $xdgState = if ($env:XDG_STATE_HOME) { $env:XDG_STATE_HOME } else { Join-Path $HOME '.local/state' }
+        $logsDir = Join-Path $xdgState 'Arklowdun/logs'
+    }
+}
+
+$outDir = Resolve-AbsolutePath $outDir
+if (-not (Test-Path -LiteralPath $outDir)) {
+    if ($usedDefaultOut) {
+        $outDir = (Get-Location).Path
+        Write-Warning "Desktop not found; using $outDir"
+    } else {
+        Ensure-Directory $outDir
+    }
+}
+$outDir = Resolve-AbsolutePath $outDir
+$dataDir = Resolve-AbsolutePath $dataDir
+$logsDir = Resolve-AbsolutePath $logsDir
+Ensure-Directory $outDir
+
+$crashRoot = $null
+if ($IsMacOS) {
+    $crashRoot = Resolve-AbsolutePath (Join-Path $HOME 'Library/Logs/DiagnosticReports')
+}
+
+$rawMode = $false
+if ($rawRequested) {
+    if (-not $yesMode) {
+        $confirmation = Read-Host 'WARNING: --raw includes unredacted files and may expose PII. Continue? (y/N)'
+        if ($confirmation -match '^(y|yes)$') {
+            $rawMode = $true
+        } else {
+            $rawMode = $false
+            Write-Warning 'Raw data collection cancelled by user prompt; continuing with redacted copies only.'
+        }
+    } else {
+        $rawMode = $true
+    }
+}
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("arklowdun-" + [System.Guid]::NewGuid().ToString('N'))
+Ensure-Directory $tempDir
+$bundleRoot = Join-Path $tempDir 'diagnostics'
+$collectedRoot = Join-Path $bundleRoot 'collected'
+$rawRoot = Join-Path $bundleRoot 'raw'
+$dbRoot = Join-Path $bundleRoot 'db'
+Ensure-Directory $bundleRoot
+Ensure-Directory $collectedRoot
+
+$manifest = New-Object System.Collections.Generic.List[object]
+$warnings = New-Object System.Collections.Generic.List[string]
+$exitCode = 0
+
+function Add-ManifestEntry {
+    param(
+        [string]$Path,
+        [string]$Category,
+        [bool]$Included,
+        [string]$Reason,
+        [Nullable[long]]$Size,
+        [Nullable[datetime]]$Mtime,
+        [Nullable[bool]]$Redacted,
+        [string]$Sha,
+        [string]$ShaRaw,
+        [Nullable[int]]$LimitMb
+    )
+    $entry = [ordered]@{
+        path = $Path
+        category = $Category
+        included = $Included
+        size_bytes = if ($Size) { [long]$Size } else { $null }
+        mtime_iso = if ($Mtime) { Get-IsoTimestamp $Mtime } else { $null }
+    }
+    if ($Reason) { $entry['reason'] = $Reason }
+    if ($null -ne $Redacted) { $entry['redacted'] = [bool]$Redacted }
+    if ($Sha) { $entry['sha256'] = $Sha }
+    if ($ShaRaw) { $entry['sha256_raw'] = $ShaRaw }
+    if ($null -ne $LimitMb) { $entry['limit_mb'] = [int]$LimitMb }
+    $manifest.Add([PSCustomObject]$entry)
+}
+
+function Add-Warning {
+    param([string]$Message)
+    $warnings.Add($Message) | Out-Null
+}
+
+function Get-RedactedText {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourcePath,
+        [string]$DataRoot,
+        [string]$LogsRoot
+    )
+    $text = Get-Content -LiteralPath $SourcePath -Raw -ErrorAction Stop
+    if ($HOME) {
+        $text = $text -replace [regex]::Escape($HOME), '<home>'
+    }
+    if ($IsWindows) {
+        $text = [regex]::Replace($text, '(?i)[A-Z]:\\Users\\[^\\/:]+', '<home>')
+    }
+    $patterns = @(
+        @{ Pattern = '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'; Replacement = '<redacted:email>' },
+        @{ Pattern = '\b(?:\d{1,3}\.){3}\d{1,3}\b'; Replacement = '<redacted:ip>' },
+        @{ Pattern = '\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b'; Replacement = '<redacted:ip>' },
+        @{ Pattern = '\b[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}\b'; Replacement = '<redacted:mac>' }
+    )
+    foreach ($rule in $patterns) {
+        $text = [regex]::Replace($text, $rule.Pattern, $rule.Replacement)
+    }
+    $text = [regex]::Replace($text, '(?i)("(?:api_key|token|password|secret)"\s*:\s*)"[^"]*"', '$1"<redacted:secret>"')
+    $text = [regex]::Replace($text, "(?i)('(?:api_key|token|password|secret)'\s*:\s*)'[^']*'", "$1'<redacted:secret>'")
+    $text = [regex]::Replace($text, '(?i)(\b(?:api_key|token|password|secret)\b\s*[=:]\s*)([^\s"\']+)', '$1<redacted:secret>')
+
+    $text = [regex]::Replace($text, '\b[0-9A-Fa-f]{16,}\b', {
+        param($match)
+        $prefix = $match.Input.Substring([Math]::Max(0, $match.Index - 10), [Math]::Min(10, $match.Index))
+        if ($prefix -match 'CrashID') { return $match.Value }
+        return '<redacted:uuid>'
+    })
+
+    $unixPattern = [regex]'/(?!home/)(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+'
+    $text = $unixPattern.Replace($text, {
+        param($match)
+        $token = $match.Value
+        if ($token.Contains('://')) { return $token }
+        $contextLength = [Math]::Min(10, $match.Index)
+        $contextStart = [Math]::Max(0, $match.Index - 10)
+        $context = if ($contextLength -gt 0) { $match.Input.Substring($contextStart, $contextLength) } else { '' }
+        if ($context.Contains('://')) { return $token }
+        $prefix = if ($match.Index -gt 0) { $match.Input.Substring(0, $match.Index) } else { '' }
+        $schemeIndex = $prefix.LastIndexOf('://')
+        if ($schemeIndex -ge 0) {
+            $tail = $prefix.Substring($schemeIndex)
+            if ($tail -notmatch '\s') { return $token }
+        }
+        if ($DataRoot -and $token.StartsWith($DataRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            return '<app-data>' + $token.Substring($DataRoot.Length)
+        }
+        if ($LogsRoot -and $token.StartsWith($LogsRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            return '<app-logs>' + $token.Substring($LogsRoot.Length)
+        }
+        if ($token.StartsWith('<home>/')) { return $token }
+        return '<path>'
+    })
+
+    if ($IsWindows) {
+        $winPattern = [regex]'(?i)[A-Z]:\\[^\s"\']+'
+        $text = $winPattern.Replace($text, {
+            param($match)
+            $token = $match.Value
+            if ($token.Contains('://')) { return $token }
+            $contextLength = [Math]::Min(10, $match.Index)
+            $contextStart = [Math]::Max(0, $match.Index - 10)
+            $context = if ($contextLength -gt 0) { $match.Input.Substring($contextStart, $contextLength) } else { '' }
+            if ($context.Contains('://')) { return $token }
+            $prefix = if ($match.Index -gt 0) { $match.Input.Substring(0, $match.Index) } else { '' }
+            $schemeIndex = $prefix.LastIndexOf('://')
+            if ($schemeIndex -ge 0) {
+                $tail = $prefix.Substring($schemeIndex)
+                if ($tail -notmatch '\s') { return $token }
+            }
+            $norm = $token.Replace('\\', '/').ToLowerInvariant()
+            if ($DataRoot) {
+                $dataNorm = $DataRoot.Replace('\\', '/').ToLowerInvariant()
+                if ($norm.StartsWith($dataNorm)) {
+                    return '<app-data>' + $token.Substring($DataRoot.Length)
+                }
+            }
+            if ($LogsRoot) {
+                $logsNorm = $LogsRoot.Replace('\\', '/').ToLowerInvariant()
+                if ($norm.StartsWith($logsNorm)) {
+                    return '<app-logs>' + $token.Substring($LogsRoot.Length)
+                }
+            }
+            if ($token.ToLowerInvariant().StartsWith('<home>')) { return $token }
+            return '<path>'
+        })
+    }
+
+    return $text
+}
+
+function Process-SourceFile {
+    param(
+        [string]$Category,
+        [string]$SourcePath,
+        [string]$BasePath,
+        [string]$Subdir,
+        [string]$OverrideName
+    )
+    if (-not (Test-Path -LiteralPath $SourcePath)) {
+        Add-ManifestEntry $SourcePath $Category $false 'not_found' $null $null $false $null $null $null
+        return
+    }
+    $info = Get-Item -LiteralPath $SourcePath
+    if ($info.Length -gt $maxFileBytes) {
+        Add-ManifestEntry $SourcePath $Category $false "exceeds ${maxFileMb}MB limit" $info.Length $info.LastWriteTimeUtc $false $null $null $maxFileMb
+        return
+    }
+    $relative = if ($BasePath -and $SourcePath.StartsWith($BasePath, [StringComparison]::OrdinalIgnoreCase)) {
+        $SourcePath.Substring($BasePath.Length).TrimStart([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    } else {
+        [System.IO.Path]::GetFileName($SourcePath)
+    }
+    if ($OverrideName) { $relative = $OverrideName }
+    $dest = Join-Path (Join-Path $collectedRoot $Subdir) $relative
+    Ensure-Directory (Split-Path -Parent $dest)
+    try {
+        $redacted = Get-RedactedText -SourcePath $SourcePath -DataRoot $dataDir -LogsRoot $logsDir
+        [System.IO.File]::WriteAllText($dest, $redacted) | Out-Null
+    } catch {
+        Add-Warning "Failed to redact $SourcePath: $($_.Exception.Message)"
+        Add-ManifestEntry $SourcePath $Category $false 'redaction_failed' $info.Length $info.LastWriteTimeUtc $false $null $null $null
+        if (Test-Path -LiteralPath $dest) { Remove-Item -LiteralPath $dest -Force }
+        return
+    }
+    $sha = Compute-Sha256 $dest
+    $shaRaw = $null
+    if ($rawMode) {
+        $rawDest = Join-Path (Join-Path $rawRoot $Subdir) $relative
+        Ensure-Directory (Split-Path -Parent $rawDest)
+        try {
+            Copy-Item -LiteralPath $SourcePath -Destination $rawDest -Force
+            $shaRaw = Compute-Sha256 $rawDest
+        } catch {
+            Add-Warning "Failed to copy raw file $SourcePath: $($_.Exception.Message)"
+        }
+    }
+    Add-ManifestEntry $SourcePath $Category $true $null $info.Length $info.LastWriteTimeUtc $true $sha $shaRaw $null
+}
+
+function Collect-Logs {
+    if (-not (Test-Path -LiteralPath $logsDir)) { return }
+    Get-ChildItem -LiteralPath $logsDir -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+        $name = $_.Name
+        if ($name -like '*.log' -or $name -like '*.jsonl' -or $name -like '*.ndjson' -or $name -like '*.log.*' -or $name -like '*.jsonl.*' -or $name -like '*.ndjson.*') {
+            Process-SourceFile 'log' $_.FullName $logsDir 'logs' $null
+        }
+    }
+}
+
+function Collect-Config {
+    if (-not (Test-Path -LiteralPath $dataDir)) { return }
+    Get-ChildItem -LiteralPath $dataDir -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+        $name = $_.Name
+        if ($name -like '*.json' -or $name -like '*.toml' -or $name -like '*.ini') {
+            Process-SourceFile 'config' $_.FullName $dataDir 'config' $null
+        }
+    }
+}
+
+function Collect-Crash {
+    if (-not $crashRoot -or -not (Test-Path -LiteralPath $crashRoot)) {
+        $stubPath = Join-Path (Join-Path $collectedRoot 'crash') 'latest.crash.txt'
+        Ensure-Directory (Split-Path -Parent $stubPath)
+        "No crash reports matching '$bundleId' were found on this platform." | Set-Content -LiteralPath $stubPath -Encoding UTF8
+        $origin = if ($crashRoot) { $crashRoot } else { '(none)' }
+        Add-ManifestEntry $origin 'crash' $false 'not_found' $null $null $false $null $null $null
+        return
+    }
+    $latest = Get-ChildItem -LiteralPath $crashRoot -Filter "*${bundleId}*.crash" -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    if (-not $latest) {
+        $latest = Get-ChildItem -LiteralPath $crashRoot -Filter "*${bundleId}*.ips" -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    }
+    if (-not $latest) {
+        $latest = Get-ChildItem -LiteralPath $crashRoot -Filter '*Arklowdun*.crash' -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    }
+    if (-not $latest) {
+        $latest = Get-ChildItem -LiteralPath $crashRoot -Filter '*Arklowdun*.ips' -File -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    }
+    if ($latest) {
+        Process-SourceFile 'crash' $latest.FullName $latest.Directory.FullName 'crash' 'latest.crash.txt'
+    } else {
+        $stubPath = Join-Path (Join-Path $collectedRoot 'crash') 'latest.crash.txt'
+        Ensure-Directory (Split-Path -Parent $stubPath)
+        "No crash reports matching '$bundleId' were found on this system. Checked directory: $crashRoot" | Set-Content -LiteralPath $stubPath -Encoding UTF8
+        Add-ManifestEntry $crashRoot 'crash' $false 'not_found' $null $null $false $null $null $null
+    }
+}
+
+try {
+    Collect-Logs
+    Collect-Config
+    Collect-Crash
+
+    if ($includeDb) {
+        Ensure-Directory $dbRoot
+        $dbPath = if ($env:ARK_DB_PATH) { $env:ARK_DB_PATH } else { Join-Path $dataDir 'app.db' }
+        if (Test-Path -LiteralPath $dbPath) {
+            $dbInfo = Get-Item -LiteralPath $dbPath
+            $dbSha = Compute-Sha256 $dbPath
+            $meta = [ordered]@{
+                path = $dbPath
+                size_bytes = [long]$dbInfo.Length
+                mtime_iso = Get-IsoTimestamp $dbInfo.LastWriteTimeUtc
+            }
+            $meta | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath (Join-Path $dbRoot 'db.meta.json') -Encoding UTF8
+            "$dbSha  $dbPath" | Set-Content -LiteralPath (Join-Path $dbRoot 'db.sha256') -Encoding UTF8
+            Add-ManifestEntry $dbPath 'db' $false 'hash_only' $dbInfo.Length $dbInfo.LastWriteTimeUtc $false $null $dbSha $null
+        } else {
+            Add-Warning "Database file not found at $dbPath"
+            Add-ManifestEntry $dbPath 'db' $false 'not_found' $null $null $false $null $null $null
+        }
+    }
+
+    if ($rawMode) { Ensure-Directory $rawRoot }
+
+    $manifestPath = Join-Path $bundleRoot 'manifest.json'
+    Ensure-Directory (Split-Path -Parent $manifestPath)
+    $manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+    $systemInfo = [ordered]@{
+        bundle_id = $bundleId
+        app_version = Get-AppVersion
+        platform = if ($IsWindows) { 'windows' } elseif ($IsMacOS) { 'macos' } elseif ($IsLinux) { 'linux' } else { 'unknown' }
+        os_version = Get-OsVersion
+        arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+        timestamp_iso = Get-IsoTimestamp (Get-Date)
+        data_dir = $dataDir
+        logs_dir = $logsDir
+        script_version = $ScriptVersion
+    }
+    $systemInfo | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $bundleRoot 'system.json') -Encoding UTF8
+
+    $readmePath = Join-Path $bundleRoot 'README.txt'
+    $readme = @()
+    if ($rawMode) {
+        $readme += '*** WARNING: RAW FILES INCLUDED ***'
+        $readme += 'These diagnostics include raw, unredacted copies of application files.'
+        $readme += 'Please review before sharing.'
+        $readme += ''
+    }
+    $readme += 'Arklowdun Diagnostics Bundle'
+    $readme += '============================'
+    $readme += ''
+    $readme += "Generated by scripts/collect-diagnostics.ps1 (version $ScriptVersion)."
+    $readme += 'Contents include redacted copies of logs, configuration, and crash reports (if present).'
+    $readme += 'A manifest (manifest.json) lists every file considered along with metadata and checksums.'
+    $readme += 'Checksums for collected files are recorded in checksums.txt.'
+    $readme += ''
+    $readme += 'Flags:'
+    $readme += '  --raw        Include unredacted copies (prompted unless --yes)'
+    $readme += '  --include-db Include database hash metadata only'
+    $readme += '  --out DIR    Choose destination directory'
+    $readme += ''
+    $readme += 'Review manifest.json to understand which files were included or skipped.'
+    $readme += 'Redaction replaces emails, IP addresses, MAC addresses, home directory paths, absolute paths outside app scopes, long hex tokens, and secret-like keys.'
+    $readme += 'Relative paths within the app data and logs directories are preserved.'
+    if ($includeDb) {
+        $readme += ''
+        $readme += 'Database metadata is available under db/. The SQLite file itself is not included.'
+    }
+    if (-not $crashRoot) {
+        $readme += ''
+        $readme += 'Crash report stubs are included because automatic discovery is not configured on this platform.'
+    }
+    $readme += ''
+    $readme += 'To inspect raw files (when included), see the raw/ directory.'
+    $readme += 'Share this archive with support by attaching the resulting zip file to your email.'
+    $readme | Set-Content -LiteralPath $readmePath -Encoding UTF8
+
+    $checksumsPath = Join-Path $bundleRoot 'checksums.txt'
+    if (Test-Path -LiteralPath $checksumsPath) { Remove-Item -LiteralPath $checksumsPath -Force }
+    function Add-Checksums {
+        param([string]$Target)
+        if (Test-Path -LiteralPath $Target) {
+            Get-ChildItem -LiteralPath $Target -File -Recurse -ErrorAction SilentlyContinue | Sort-Object FullName | ForEach-Object {
+                $relative = $_.FullName.Substring($bundleRoot.Length + 1)
+                $hash = Compute-Sha256 $_.FullName
+                Add-Content -LiteralPath $checksumsPath -Value "$hash  $relative" -Encoding UTF8
+            }
+        }
+    }
+    Add-Checksums $collectedRoot
+    Add-Checksums $rawRoot
+    Add-Checksums $dbRoot
+
+    $manifestHash = Compute-Sha256 $manifestPath
+    Add-Content -LiteralPath $checksumsPath -Value "$manifestHash  manifest.json" -Encoding UTF8
+    $shortHash = $manifestHash.Substring(0,8)
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $zipName = "diagnostics-$timestamp-$shortHash.zip"
+    $zipPath = Join-Path $outDir $zipName
+    if (Test-Path -LiteralPath $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
+    Compress-Archive -LiteralPath $bundleRoot -DestinationPath $zipPath -Force
+
+    foreach ($warning in $warnings) {
+        Write-Warning $warning
+    }
+    Write-Output $zipPath
+    if ($warnings.Count -gt 0) {
+        $exitCode = 1
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempDir) {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+exit $exitCode

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -1,0 +1,778 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_VERSION="1.0.0"
+DEFAULT_BUNDLE_ID="com.paula.arklowdun"
+MAX_FILE_MB_DEFAULT=10
+PYTHON_AVAILABLE=1
+RAW_NO_REDACTION_FALLBACK=0
+
+log_info() {
+  printf '[INFO] %s\n' "$1" >&2
+}
+
+log_warn() {
+  printf '[WARN] %s\n' "$1" >&2
+}
+
+log_error() {
+  printf '[ERROR] %s\n' "$1" >&2
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/collect-diagnostics.sh [options]
+
+Options:
+  --out DIR          Output directory for the diagnostics zip (default: ~/Desktop)
+  --raw              Include raw, unredacted copies (requires confirmation)
+  --include-db       Include hash metadata for the SQLite database
+  --data-dir DIR     Override app data directory
+  --logs-dir DIR     Override logs directory
+  --bundle-id ID     Override bundle identifier
+  --yes              Non-interactive mode; assume consent for --raw
+  --help             Show this help message
+USAGE
+}
+
+# ====== 🚨 TEMPORARY PYTHON DEPENDENCY — MUST BE REMOVED BEFORE PRIMETIME ======
+if [[ "${ARK_SILENCE_TODO:-0}" != "1" ]]; then
+  cat >&2 <<'BANNER'
+================================================================================
+ ⚠️  DIAGNOSTICS TODO: This collector depends on python3 for redaction.
+     Replace with a bundled helper (ark-diag) before any paid/public release.
+     Tracking: PR-Diag-01..04. --raw --yes skips redaction (unsafe).
+================================================================================
+BANNER
+fi
+# ==============================================================================
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Required command '$1' is not available"
+    exit 2
+  fi
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  PYTHON_AVAILABLE=0
+  log_error "python3 is required for redaction (temporary dependency)."
+  if [[ " $* " == *" --raw "* ]] && [[ " $* " == *" --yes "* ]]; then
+    log_warn "Proceeding WITHOUT redaction due to --raw --yes; bundle will include RAW files only."
+    # allow run to continue; ensure README in bundle reiterates this
+    RAW_NO_REDACTION_FALLBACK=1
+  else
+    log_error "Install python3 or re-run with --raw --yes to proceed without redaction."
+    exit 2
+  fi
+fi
+
+require_command zip
+
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA_CMD=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+  SHA_CMD=(shasum -a 256)
+else
+  log_error "Neither sha256sum nor shasum is available"
+  exit 2
+fi
+
+manifest_entries=()
+warnings=()
+
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  s=${s//$'\f'/\\f}
+  s=${s//$'\b'/\\b}
+  printf '%s' "$s"
+}
+
+add_manifest_entry() {
+  local path="$1" category="$2" included="$3" reason="$4" size="$5" mtime="$6" redacted="$7" sha="$8" sha_raw="$9" limit_mb
+  limit_mb="${10:-}"
+  local json="{\"path\":\"$(json_escape "$path")\",\"category\":\"$(json_escape "$category")\",\"included\":$included"
+  if [ -n "$reason" ]; then
+    json="$json,\"reason\":\"$(json_escape "$reason")\""
+  fi
+  if [ -n "$size" ]; then
+    json="$json,\"size_bytes\":$size"
+  else
+    json="$json,\"size_bytes\":null"
+  fi
+  if [ -n "$mtime" ]; then
+    json="$json,\"mtime_iso\":\"$(json_escape "$mtime")\""
+  else
+    json="$json,\"mtime_iso\":null"
+  fi
+  if [ -n "$redacted" ]; then
+    json="$json,\"redacted\":$redacted"
+  fi
+  if [ -n "$sha" ]; then
+    json="$json,\"sha256\":\"$sha\""
+  fi
+  if [ -n "$sha_raw" ]; then
+    json="$json,\"sha256_raw\":\"$sha_raw\""
+  fi
+  if [ -n "$limit_mb" ]; then
+    json="$json,\"limit_mb\":$limit_mb"
+  fi
+  json="$json}"
+  manifest_entries+=("$json")
+}
+
+iso_from_epoch() {
+  local epoch="$1"
+  if date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -d "@$epoch" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u -r "$epoch" '+%Y-%m-%dT%H:%M:%SZ'
+  fi
+}
+
+get_file_size() {
+  local path="$1"
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%s' "$path"
+  else
+    stat -f '%z' "$path"
+  fi
+}
+
+get_file_mtime_epoch() {
+  local path="$1"
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%Y' "$path"
+  else
+    stat -f '%m' "$path"
+  fi
+}
+
+get_file_mtime_iso() {
+  local path="$1"
+  local epoch
+  epoch=$(get_file_mtime_epoch "$path")
+  iso_from_epoch "$epoch"
+}
+
+compute_sha256() {
+  "${SHA_CMD[@]}" "$1" | awk '{print $1}'
+}
+
+abs_path() {
+  local input="$1"
+  if [ "${PYTHON_AVAILABLE:-1}" = "1" ]; then
+    python3 - "$input" <<'PY'
+import os
+import sys
+
+path = os.path.expanduser(sys.argv[1])
+print(os.path.abspath(path))
+PY
+  else
+    local expanded="$input"
+    if [[ "$expanded" == ~* ]]; then
+      if [[ "$expanded" == "~" ]]; then
+        expanded="$HOME"
+      elif [[ "$expanded" == ~/* ]]; then
+        expanded="$HOME/${expanded#~/}"
+      fi
+    fi
+    if [ -d "$expanded" ]; then
+      (cd "$expanded" 2>/dev/null && pwd) || printf '%s\n' "$expanded"
+    else
+      local dir
+      local base
+      dir=$(dirname "$expanded")
+      base=$(basename "$expanded")
+      (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd)" "$base") || printf '%s\n' "$expanded"
+    fi
+  fi
+}
+
+redact_file() {
+  local src="$1" dest="$2" data_root="$3" logs_root="$4"
+  if [ "${PYTHON_AVAILABLE:-1}" != "1" ]; then
+    return 1
+  fi
+  ARK_DATA_ROOT="$data_root" ARK_LOGS_ROOT="$logs_root" python3 - "$src" "$dest" <<'PY'
+import os
+import re
+import sys
+
+src = sys.argv[1]
+dest = sys.argv[2]
+home = os.path.expanduser('~')
+data_root = os.environ.get('ARK_DATA_ROOT', '')
+logs_root = os.environ.get('ARK_LOGS_ROOT', '')
+
+try:
+    with open(src, 'r', encoding='utf-8', errors='replace') as handle:
+        text = handle.read()
+except Exception as exc:
+    raise SystemExit(f"failed to read {src}: {exc}")
+
+def replace_home(value: str) -> str:
+    if not home:
+        return value
+    replaced = value.replace(home, '<home>')
+    if os.name == 'nt':
+        pattern = re.compile(re.escape(home), re.IGNORECASE)
+        replaced = pattern.sub('<home>', replaced)
+    if home.startswith('/Users/'):
+        replaced = replaced.replace(home, '<home>')
+    win_home = re.compile(r'(?i)[A-Z]:\\Users\\[^\\/:]+')
+    replaced = win_home.sub('<home>', replaced)
+    return replaced
+
+text = replace_home(text)
+
+patterns = [
+    (re.compile(r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'), '<redacted:email>'),
+    (re.compile(r'\b(?:\d{1,3}\.){3}\d{1,3}\b'), '<redacted:ip>'),
+    (re.compile(r'\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b'), '<redacted:ip>'),
+    (re.compile(r'\b[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}\b'), '<redacted:mac>'),
+]
+for pattern, repl in patterns:
+    text = pattern.sub(repl, text)
+
+secret_json = re.compile(r'(?i)("(?:api_key|token|password|secret)"\s*:\s*)"[^"]*"')
+secret_json_single = re.compile(r"(?i)('(api_key|token|password|secret)'\s*:\s*)'[^']*'")
+secret_assign = re.compile(r'(?i)(\b(?:api_key|token|password|secret)\b\s*[=:]\s*)([^\s"\']+)')
+
+text = secret_json.sub(lambda m: m.group(1) + '"<redacted:secret>"', text)
+text = secret_json_single.sub(lambda m: m.group(1) + "'<redacted:secret>'", text)
+text = secret_assign.sub(lambda m: m.group(1) + '<redacted:secret>', text)
+
+hex_pattern = re.compile(r'\b[0-9A-Fa-f]{16,}\b')
+
+def redact_hex(match: re.Match) -> str:
+    start = match.start()
+    prefix = match.string[max(0, start - 10):start]
+    if 'CrashID' in prefix:
+        return match.group(0)
+    return '<redacted:uuid>'
+
+text = hex_pattern.sub(redact_hex, text)
+
+def redact_path_token(token: str) -> str:
+    if data_root and token.startswith(data_root):
+        return '<app-data>' + token[len(data_root):]
+    if logs_root and token.startswith(logs_root):
+        return '<app-logs>' + token[len(logs_root):]
+    if token.startswith('<home>/'):
+        return token
+    return '<path>'
+
+abs_path_pattern = re.compile(r'/(?!home/)(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+')
+
+def replace_abs_path(match: re.Match) -> str:
+    token = match.group(0)
+    if '://' in token:
+        return token
+    start = match.start()
+    context = match.string[max(0, start - 10):start]
+    if '://' in context:
+        return token
+    prefix = match.string[:start]
+    scheme_index = prefix.rfind('://')
+    if scheme_index != -1:
+        tail = prefix[scheme_index:start]
+        if not any(ch.isspace() for ch in tail):
+            return token
+    return redact_path_token(token)
+
+text = abs_path_pattern.sub(replace_abs_path, text)
+
+if os.name == 'nt':
+    win_abs = re.compile(r'(?i)[A-Z]:\\[^\s"\']+')
+
+    def redact_win_path(match: re.Match) -> str:
+        token = match.group(0)
+        if '://' in token:
+            return token
+        start = match.start()
+        context = match.string[max(0, start - 10):start]
+        if '://' in context:
+            return token
+        prefix = match.string[:start]
+        scheme_index = prefix.rfind('://')
+        if scheme_index != -1:
+            tail = prefix[scheme_index:start]
+            if not any(ch.isspace() for ch in tail):
+                return token
+        norm = token.replace('\\', '/').lower()
+        data_norm = data_root.replace('\\', '/').lower() if data_root else ''
+        logs_norm = logs_root.replace('\\', '/').lower() if logs_root else ''
+        if data_norm and norm.startswith(data_norm):
+            return '<app-data>' + token[len(data_root):]
+        if logs_norm and norm.startswith(logs_norm):
+            return '<app-logs>' + token[len(logs_root):]
+        if token.lower().startswith('<home>'):
+            return token
+        return '<path>'
+
+    text = win_abs.sub(redact_win_path, text)
+
+with open(dest, 'w', encoding='utf-8') as handle:
+    handle.write(text)
+PY
+}
+
+add_warning() {
+  warnings+=("$1")
+}
+
+write_manifest() {
+  local file="$1"
+  {
+    printf '[\n'
+    local total=${#manifest_entries[@]}
+    local idx=0
+    for entry in "${manifest_entries[@]}"; do
+      printf '  %s' "$entry"
+      idx=$((idx + 1))
+      if [ "$idx" -lt "$total" ]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    done
+    printf ']\n'
+  } > "$file"
+}
+
+get_app_version() {
+  local file
+  if [ -f "src-tauri/tauri.conf.json" ]; then
+    file="src-tauri/tauri.conf.json"
+  elif [ -f "src-tauri/tauri.conf.json5" ]; then
+    file="src-tauri/tauri.conf.json5"
+  else
+    printf 'unknown'
+    return
+  fi
+  local version
+  version=$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" | head -n 1)
+  if [ -n "$version" ]; then
+    printf '%s' "$version"
+  else
+    printf 'unknown'
+  fi
+}
+
+get_os_version() {
+  if command -v sw_vers >/dev/null 2>&1; then
+    sw_vers -productVersion
+  elif [ -f /etc/os-release ]; then
+    awk -F= '$1=="PRETTY_NAME" {gsub(/"/, "", $2); print $2}' /etc/os-release
+  else
+    printf 'unknown'
+  fi
+}
+
+MAX_FILE_MB=${ARK_MAX_FILE_MB:-$MAX_FILE_MB_DEFAULT}
+if ! [[ "$MAX_FILE_MB" =~ ^[0-9]+$ ]]; then
+  log_error "ARK_MAX_FILE_MB must be an integer"
+  exit 2
+fi
+MAX_FILE_BYTES=$((MAX_FILE_MB * 1024 * 1024))
+
+out_dir=""
+out_dir_provided=false
+raw_requested=false
+include_db=false
+data_dir=""
+logs_dir=""
+bundle_id="$DEFAULT_BUNDLE_ID"
+yes_mode=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out)
+      shift || { log_error "--out requires a value"; exit 2; }
+      out_dir="$1"
+      out_dir_provided=true
+      ;;
+    --raw)
+      raw_requested=true
+      ;;
+    --include-db)
+      include_db=true
+      ;;
+    --data-dir)
+      shift || { log_error "--data-dir requires a value"; exit 2; }
+      data_dir="$1"
+      ;;
+    --logs-dir)
+      shift || { log_error "--logs-dir requires a value"; exit 2; }
+      logs_dir="$1"
+      ;;
+    --bundle-id)
+      shift || { log_error "--bundle-id requires a value"; exit 2; }
+      bundle_id="$1"
+      ;;
+    --yes)
+      yes_mode=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      log_error "Unknown option: $1"
+      usage
+      exit 2
+      ;;
+    *)
+      log_error "Unexpected argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+  shift || break
+done
+
+platform=$(uname -s)
+case "$platform" in
+  Darwin)
+    default_out="$HOME/Desktop"
+    default_data_dir="$HOME/Library/Application Support/$bundle_id"
+    default_logs_dir="$HOME/Library/Logs/Arklowdun"
+    crash_root="$HOME/Library/Logs/DiagnosticReports"
+    ;;
+  Linux)
+    default_out="$HOME/Desktop"
+    default_data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/Arklowdun"
+    default_logs_dir="${XDG_STATE_HOME:-$HOME/.local/state}/Arklowdun/logs"
+    crash_root=""
+    ;;
+  *)
+    default_out="$HOME/Desktop"
+    default_data_dir="$HOME/Library/Application Support/$bundle_id"
+    default_logs_dir="$HOME/Library/Logs/Arklowdun"
+    crash_root="$HOME/Library/Logs/DiagnosticReports"
+    ;;
+esac
+
+used_default_out=false
+if [ -z "$out_dir" ]; then
+  out_dir="$default_out"
+  used_default_out=true
+fi
+if [ -z "$data_dir" ]; then
+  data_dir="$default_data_dir"
+fi
+if [ -z "$logs_dir" ]; then
+  logs_dir="$default_logs_dir"
+fi
+
+out_dir=$(abs_path "$out_dir")
+if [ ! -d "$out_dir" ]; then
+  if $used_default_out; then
+    out_dir="$(pwd)"
+    out_dir=$(abs_path "$out_dir")
+    log_warn "Desktop not found; using $out_dir"
+  else
+    if ! mkdir -p "$out_dir"; then
+      log_error "Failed to create output directory $out_dir"
+      exit 2
+    fi
+  fi
+fi
+data_dir=$(abs_path "$data_dir")
+logs_dir=$(abs_path "$logs_dir")
+
+mkdir -p "$out_dir"
+
+if [ -n "${crash_root:-}" ]; then
+  crash_root=$(abs_path "$crash_root")
+fi
+
+data_root_env="$data_dir"
+logs_root_env="$logs_dir"
+
+raw_mode=false
+if $raw_requested; then
+  if ! $yes_mode; then
+    printf 'WARNING: --raw will include unredacted files that may contain sensitive information. Continue? [y/N] ' >&2
+    read -r answer || answer=""
+    case "$answer" in
+      y|Y|yes|YES)
+        raw_mode=true
+        ;;
+      *)
+        add_warning "Raw data collection was cancelled by user confirmation prompt."
+        raw_mode=false
+        ;;
+    esac
+  else
+    raw_mode=true
+  fi
+fi
+
+if [ "${RAW_NO_REDACTION_FALLBACK:-0}" = "1" ]; then
+  raw_mode=true
+fi
+
+work_dir=$(mktemp -d 2>/dev/null || mktemp -d -t arklowdun)
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT INT TERM
+
+bundle_root="$work_dir/diagnostics"
+collected_root="$bundle_root/collected"
+raw_root="$bundle_root/raw"
+db_root="$bundle_root/db"
+mkdir -p "$collected_root" "$bundle_root"
+
+process_source_file() {
+  local category="$1" src="$2" base="$3" subdir="$4" dest_name="$5"
+  local reason="" sha="" sha_raw="" redacted=false
+  if [ ! -f "$src" ]; then
+    add_manifest_entry "$src" "$category" false "not_found" "" "" "false" "" "" ""
+    return
+  fi
+  local size
+  size=$(get_file_size "$src")
+  local mtime
+  mtime=$(get_file_mtime_iso "$src")
+  if [ "$size" -gt "$MAX_FILE_BYTES" ]; then
+    reason="exceeds ${MAX_FILE_MB}MB limit"
+    add_manifest_entry "$src" "$category" false "$reason" "$size" "$mtime" "false" "" "" "$MAX_FILE_MB"
+    return
+  fi
+  local relative
+  local base_trim=${base%/}
+  case "$src" in
+    "$base_trim"/*)
+      relative=${src#"$base_trim/"}
+      ;;
+    *)
+      relative=$(basename "$src")
+      ;;
+  esac
+  if [ -n "$dest_name" ]; then
+    relative="$dest_name"
+  fi
+  local dest="$collected_root/$subdir/$relative"
+  mkdir -p "$(dirname "$dest")"
+  if [ "${RAW_NO_REDACTION_FALLBACK:-0}" = "1" ]; then
+    printf 'Raw-only fallback: see raw/%s\n' "$relative" > "$dest"
+    sha=$(compute_sha256 "$dest")
+    local raw_dest="$raw_root/$subdir/$relative"
+    mkdir -p "$(dirname "$raw_dest")"
+    if cp "$src" "$raw_dest"; then
+      sha_raw=$(compute_sha256 "$raw_dest")
+    else
+      add_warning "Failed to copy raw file $src"
+    fi
+    add_manifest_entry "$src" "$category" true "raw_fallback" "$size" "$mtime" "false" "$sha" "$sha_raw" ""
+    return
+  fi
+  if ! redact_file "$src" "$dest" "$data_root_env" "$logs_root_env"; then
+    add_warning "Failed to redact $src"
+    add_manifest_entry "$src" "$category" false "redaction_failed" "$size" "$mtime" "false" "" "" ""
+    rm -f "$dest"
+    return
+  fi
+  redacted=true
+  sha=$(compute_sha256 "$dest")
+  if $raw_mode; then
+    local raw_dest="$raw_root/$subdir/$relative"
+    mkdir -p "$(dirname "$raw_dest")"
+    if cp "$src" "$raw_dest"; then
+      sha_raw=$(compute_sha256 "$raw_dest")
+    else
+      add_warning "Failed to copy raw file $src"
+    fi
+  fi
+  add_manifest_entry "$src" "$category" true "" "$size" "$mtime" "$redacted" "$sha" "$sha_raw" ""
+}
+
+collect_logs() {
+  if [ ! -d "$logs_dir" ]; then
+    return
+  fi
+  while IFS= read -r -d '' file; do
+    local name
+    name=$(basename "$file")
+    case "$name" in
+      *.log|*.jsonl|*.ndjson|*.log.*|*.jsonl.*|*.ndjson.*)
+        process_source_file "log" "$file" "$logs_dir" "logs" ""
+        ;;
+    esac
+  done < <(find "$logs_dir" -type f -print0 2>/dev/null)
+}
+
+collect_config() {
+  if [ ! -d "$data_dir" ]; then
+    return
+  fi
+  while IFS= read -r -d '' file; do
+    local name
+    name=$(basename "$file")
+    case "$name" in
+      *.json|*.toml|*.ini)
+        process_source_file "config" "$file" "$data_dir" "config" ""
+        ;;
+    esac
+  done < <(find "$data_dir" -type f -print0 2>/dev/null)
+}
+
+collect_crash() {
+  local crash_file=""
+  if [ -n "$crash_root" ] && [ -d "$crash_root" ]; then
+    local latest_epoch=0
+    while IFS= read -r -d '' file; do
+      local epoch
+      epoch=$(get_file_mtime_epoch "$file")
+      if [ "$epoch" -gt "$latest_epoch" ]; then
+        latest_epoch="$epoch"
+        crash_file="$file"
+      fi
+    done < <(find "$crash_root" -type f \( -name "*${bundle_id}*.crash" -o -name "*${bundle_id}*.ips" -o -name "*Arklowdun*.crash" -o -name "*Arklowdun*.ips" \) -print0 2>/dev/null)
+  fi
+  if [ -n "$crash_file" ]; then
+    process_source_file "crash" "$crash_file" "$(dirname "$crash_file")" "crash" "latest.crash.txt"
+  else
+    mkdir -p "$collected_root/crash"
+    local stub="$collected_root/crash/latest.crash.txt"
+    cat <<STUB > "$stub"
+No crash reports matching "$bundle_id" were found on this system.
+Checked directory: ${crash_root:-N/A}
+STUB
+    add_manifest_entry "${crash_root:-N/A}" "crash" false "not_found" "" "" "false" "" "" ""
+  fi
+}
+
+collect_logs
+collect_config
+collect_crash
+
+if $include_db; then
+  mkdir -p "$db_root"
+  db_path="${ARK_DB_PATH:-$data_dir/app.db}"
+  if [ -f "$db_path" ]; then
+    db_size=$(get_file_size "$db_path")
+    db_mtime=$(get_file_mtime_iso "$db_path")
+    db_sha=$(compute_sha256 "$db_path")
+    cat <<META > "$db_root/db.meta.json"
+{
+  "path": "$(json_escape "$db_path")",
+  "size_bytes": $db_size,
+  "mtime_iso": "$(json_escape "$db_mtime")"
+}
+META
+    printf '%s  %s\n' "$db_sha" "$db_path" > "$db_root/db.sha256"
+    add_manifest_entry "$db_path" "db" false "hash_only" "$db_size" "$db_mtime" "false" "" "$db_sha" ""
+  else
+    add_warning "Database file not found at $db_path"
+    add_manifest_entry "$db_path" "db" false "not_found" "" "" "false" "" "" ""
+  fi
+fi
+
+if $raw_mode; then
+  mkdir -p "$raw_root"
+fi
+
+write_manifest "$bundle_root/manifest.json"
+
+system_os_version=$(get_os_version)
+app_version=$(get_app_version)
+platform_id=$(uname -s | tr '[:upper:]' '[:lower:]')
+arch_id=$(uname -m)
+timestamp_iso=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+cat <<SYS > "$bundle_root/system.json"
+{
+  "bundle_id": "$(json_escape "$bundle_id")",
+  "app_version": "$(json_escape "$app_version")",
+  "platform": "$(json_escape "$platform_id")",
+  "os_version": "$(json_escape "$system_os_version")",
+  "arch": "$(json_escape "$arch_id")",
+  "timestamp_iso": "$(json_escape "$timestamp_iso")",
+  "data_dir": "$(json_escape "$data_dir")",
+  "logs_dir": "$(json_escape "$logs_dir")",
+  "script_version": "$(json_escape "$SCRIPT_VERSION")"
+}
+SYS
+
+readme_file="$bundle_root/README.txt"
+{
+  if [ "${RAW_NO_REDACTION_FALLBACK:-0}" = "1" ]; then
+    printf '*** WARNING: NO REDACTION APPLIED ***\n'
+    printf 'python3 not found; you used --raw --yes. This bundle contains unredacted files.\n'
+    printf 'Review carefully before sharing.\n\n'
+  fi
+  if $raw_mode; then
+    printf '*** WARNING: RAW FILES INCLUDED ***\n'
+    printf 'These diagnostics include raw, unredacted copies of application files.\n'
+    printf 'Please review before sharing.\n\n'
+  fi
+  printf 'Arklowdun Diagnostics Bundle\n'
+  printf '============================\n\n'
+  printf 'This archive was generated by scripts/collect-diagnostics.sh (version %s).\n' "$SCRIPT_VERSION"
+  printf 'Contents include redacted copies of logs, configuration, and crash reports (if present).\n'
+  printf 'A manifest (manifest.json) lists every file considered along with metadata and checksums.\n'
+  printf 'Checksums for collected files are recorded in checksums.txt.\n\n'
+  printf 'Flags:\n'
+  printf '  --raw        Include unredacted copies (prompted unless --yes)\n'
+  printf '  --include-db Include database hash metadata only\n'
+  printf '  --out DIR    Choose destination directory\n\n'
+  printf 'Review manifest.json to understand which files were included or skipped.\n'
+  printf 'Redaction replaces emails, IP addresses, MAC addresses, home directory paths,\n'
+  printf 'absolute paths outside app scopes, long hex tokens, and secret-like keys.\n'
+  printf 'Relative paths within the app data and logs directories are preserved.\n\n'
+  if $include_db; then
+    printf 'Database metadata is available under db/. The SQLite file itself is not included.\n\n'
+  fi
+  if [ -z "$crash_root" ]; then
+    printf 'Crash report stubs are included because automatic discovery is not configured on this platform.\n\n'
+  fi
+  printf 'To inspect raw files (when included), see the raw/ directory.\n'
+  printf 'Share this archive with support by attaching the resulting zip file to your email.\n'
+} > "$readme_file"
+
+generate_checksums() {
+  local target_dir="$1"
+  if [ -d "$target_dir" ]; then
+    while IFS= read -r -d '' file; do
+      local rel=${file#"$bundle_root/"}
+      local sha
+      sha=$(compute_sha256 "$file")
+      printf '%s  %s\n' "$sha" "$rel" >> "$bundle_root/checksums.txt"
+    done < <(find "$target_dir" -type f -print0 2>/dev/null)
+  fi
+}
+
+> "$bundle_root/checksums.txt"
+generate_checksums "$collected_root"
+generate_checksums "$raw_root"
+generate_checksums "$db_root"
+
+manifest_hash=$(compute_sha256 "$bundle_root/manifest.json")
+printf '%s  %s\n' "$manifest_hash" "manifest.json" >> "$bundle_root/checksums.txt"
+short_hash=${manifest_hash:0:8}
+timestamp=$(date '+%Y%m%d-%H%M%S')
+zip_name="diagnostics-${timestamp}-${short_hash}.zip"
+zip_path="$out_dir/$zip_name"
+
+(cd "$work_dir" && zip -rq "$zip_path" diagnostics)
+
+exit_code=0
+if [ ${#warnings[@]} -gt 0 ]; then
+  for warn_msg in "${warnings[@]}"; do
+    log_warn "$warn_msg"
+  done
+  exit_code=1
+fi
+
+printf '%s\n' "$zip_path"
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- highlight the temporary python3 dependency for diagnostics in README/docs, add a TL;DR usage snippet, and note the ARK_MAX_FILE_MB override
- add prominent TODO banners to both collectors and allow the Bash script to proceed with --raw --yes when python3 is missing while strengthening the bundle README warning
- keep PowerShell parity messaging so Windows users also see the primetime blocker reminder
- extend the collectors with manifest checksum entries, .ips crash discovery, safer raw fallbacks, URL-aware path redaction, oversize metadata, and Desktop fallback handling

## Testing
- bash -n scripts/collect-diagnostics.sh
- pwsh -NoLogo -NoProfile -File scripts/collect-diagnostics.ps1 --help *(fails: pwsh not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3e7fd68832aa2c031290eae45ed