### PR TITLE
Fix diagnostics capabilities configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ sample.json
 arklowdun@0.1.0
 tauri
 *.sqlite-*
+src-tauri/resources/docs/diagnostics.md
+
+docs/samples/*.zip

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See the [Arklowdun Master Plan](docs/master-plan.md) for the high-level strategi
 
 Recommended IDE: VS Code with Tauri and rust-analyzer extensions.
 
+> Build note: the Tauri build script runs `git rev-parse HEAD` to embed the current commit hash. When building from a source archive without the `.git` directory, the About pane and diagnostics summary will display `unknown`.
+
 ## Logging & Verbosity
 
 - Backend (Rust):
@@ -73,7 +75,7 @@ Override the diagnostics size cap with `ARK_MAX_FILE_MB=10` (default 10).
   archive.
 - The scripts gather logs, config metadata, crash reports and optional database
   hashes into `diagnostics-<timestamp>-<hash>.zip`.
-- Redaction rules, platform paths and CLI usage are documented in
+- The full diagnostics guide (UI summary, CLI collectors, redaction policy, and sample bundles) lives in
   [docs/diagnostics.md](docs/diagnostics.md).
 
 ## Database integrity

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,116 +1,213 @@
-# 🚨 IMPORTANT LIMITATION (TEMPORARY)
-Unix collector calls `python3` for redaction. Replace with a bundled helper before any paid/public release.
-If `python3` is missing, only `--raw --yes` will proceed (no redaction) with a warning in the bundle README.
+# Diagnostics & Logging
 
-# Diagnostics bundles
+The diagnostics collectors capture everything an operator needs to triage issues without exposing customer secrets. Every bundle is redacted, offline, and reviewable before it ever leaves a workstation.
 
-The `collect-diagnostics` scripts create a redacted archive that can be sent to
-support when troubleshooting Arklowdun installs. The scripts exist in both
-shell (`scripts/collect-diagnostics.sh`) and PowerShell
-(`scripts/collect-diagnostics.ps1`) variants so the same behaviour is available
-on macOS/Linux and Windows.
-
-```bash
-# macOS/Linux (redacted by default)
-scripts/collect-diagnostics.sh
-
-# Include DB hash metadata
-scripts/collect-diagnostics.sh --include-db
-
-# Raw (no redaction). Use only if support asks:
-scripts/collect-diagnostics.sh --raw --yes
-```
-
-## What gets collected
-
-Each bundle contains a `diagnostics/` folder with:
-
-- `collected/` – redacted copies of application logs, configuration files and
-  the most recent crash report (if one exists).
-- `raw/` – present only when `--raw` is requested. It holds unredacted copies
-  of the same files for advanced troubleshooting.
-- `db/` – present only when `--include-db` is used. Contains `db.meta.json`
-  (size and timestamps) and `db.sha256` (hash of the SQLite database). The
-  database file itself is never copied.
-- `manifest.json` – a record of every file considered (included or skipped)
-  with metadata, redaction flags and checksums.
-- `checksums.txt` – SHA256 hashes for files under `collected/`, `raw/` (if
-  present) and `db/`.
-- `system.json` – platform metadata, script version, resolved paths and
-  timestamp.
-- `README.txt` – summary and safety notes for the generated bundle.
-
-Files are discovered using these defaults (all overridable with flags):
-
-| Platform | Logs directory | Data/config directory | Crash reports |
-| --- | --- | --- | --- |
-| macOS | `~/Library/Logs/Arklowdun/` | `~/Library/Application Support/com.paula.arklowdun/` | `~/Library/Logs/DiagnosticReports/` |
-| Linux | `${XDG_STATE_HOME:-~/.local/state}/Arklowdun/logs/` | `${XDG_DATA_HOME:-~/.local/share}/Arklowdun/` | (stub message only) |
-| Windows | `%LOCALAPPDATA%\Arklowdun\Logs\` | `%APPDATA%\Arklowdun\` | (stub message with next steps) |
+- **Always review the archive before sharing.** Redaction replaces sensitive tokens, and the manifest normalises paths to scoped tokens (for example `<app-data>`, `<app-logs>`, `<home>`). Original absolute paths never appear in the bundle. Confirm the bundle contains only the information you intend to share.
+- **Databases are never included.** The collectors optionally add `db/db.meta.json` and `db/db.sha256` so support can confirm hashes, but the SQLite file itself is excluded.
+- **No network calls.** Diagnostics run entirely on the local machine – they do not upload, fetch, or phone home.
 
 ## Redaction rules
 
-Redacted copies remove or normalise sensitive information:
+Unless `--raw` is supplied (Linux/macOS) or the `--raw` confirmation is accepted (Windows), every collected text file is sanitised. The Python/PowerShell redactors:
 
-- Email addresses → `<redacted:email>`
-- IPv4/IPv6 addresses → `<redacted:ip>`
-- MAC addresses → `<redacted:mac>`
-- Home directory prefixes (macOS/Linux `~/`, Windows `C:\Users\…`) → `<home>`
-- Absolute paths outside the application’s own data/log roots → `<path>`
-- 16+ character hexadecimal tokens (except CrashIDs) → `<redacted:uuid>`
-- Values for keys named `api_key`, `token`, `password`, `secret` (case
-  insensitive) → `<redacted:secret>`
+- replace e-mail addresses, IPv4/IPv6 addresses, and MAC addresses with `<redacted:…>` tokens;
+- mask JSON-style and assignment-style secrets (keys named `api_key`, `token`, `password`, `secret`);
+- collapse long hexadecimal tokens to `<redacted:uuid>` (Crash IDs stay intact);
+- normalise home directories to `<home>` and strip absolute paths outside the Arklowdun data/log roots, replacing them with `<path>` or `<app-data>` / `<app-logs>` tokens.
 
-Relative paths inside the app’s own directories are preserved so stack traces
-and file locations remain useful.
+`--raw` skips redaction entirely and should only be used when explicitly requested by engineering. `--raw --yes` (macOS/Linux) assumes consent and is required when python3 is not available.
 
-Any file larger than 10 MB (override with `ARK_MAX_FILE_MB`) is skipped and the
-manifest records the skip reason.
+## Tooling overview
 
-## CLI flags
+| Workflow | What you get | When to use |
+| --- | --- | --- |
+| **Settings → About and diagnostics → Copy diagnostics summary** | Platform, version, commit hash, active `RUST_LOG` value, and the last 200 log lines. | First-line support. Copy/paste directly into tickets or Slack threads. |
+| **`scripts/collect-diagnostics.sh`** (Linux/macOS) | Full redacted bundle (`diagnostics-YYYYMMDD-HHMMSS-<manifest-hash>.zip`). | Operators with shell access. Attach to support cases after review. |
+| **`scripts\collect-diagnostics.ps1`** (Windows) | Same bundle format with PowerShell-native redaction. | Windows operators. |
+
+## In-app diagnostics summary
+
+1. Open **Settings → About and diagnostics**.
+2. Click **Copy diagnostics summary**. The status line confirms when the text is on your clipboard and shows the most recent payload for verification.
+3. Paste the summary into the support ticket or escalation chat. If full logs are required, follow up with the CLI collector bundle.
+
+Example payload (macOS/Linux sample):
 
 ```
---out DIR       Destination directory for the zip (default: Desktop)
---raw           Include unredacted copies in addition to redacted ones
---include-db    Record database metadata and SHA256 hash (no DB contents)
---data-dir DIR  Override the data/config directory
---logs-dir DIR  Override the logs directory
---bundle-id ID  Override the bundle identifier used for crash reports
---yes           Non-interactive mode; auto-confirm the `--raw` warning
+Platform: linux (x86_64)
+App version: 0.1.0
+Commit: unknown
+RUST_LOG: (not set)
+Log file: /workspace/Arklowdun/diagnostics-home/.local/state/Arklowdun/logs/arklowdun.log
+Log tail (1 line):
+2025-02-11T10:00:00Z INFO arklowdun booting app for diagnostics sample
 ```
 
-Examples:
+> The summary never includes attachments, configuration files, or databases—just the snapshot listed above.
+
+## CLI collectors
+
+Run the collector that matches your platform from the repository root.
+
+### macOS & Linux
 
 ```bash
-# macOS/Linux
-scripts/collect-diagnostics.sh
-scripts/collect-diagnostics.sh --raw --yes --include-db
-
-# Windows PowerShell
-pwsh scripts/collect-diagnostics.ps1 --out C:\\Temp\\Support
+bash scripts/collect-diagnostics.sh --include-db --yes
 ```
 
-`--raw` prompts before including unredacted files unless `--yes` is supplied.
-If the prompt is declined, the script continues with redacted copies only and
-records a warning.
+### Windows
 
-## Inspecting the bundle
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\collect-diagnostics.ps1 --include-db --yes
+```
 
-Open `manifest.json` to see exactly which files were included, skipped and why.
-Every entry lists size, modification time and SHA256 checksums. Use
-`checksums.txt` to verify files inside the archive. Platform metadata (platform,
-OS version, architecture, resolved paths) lives in `system.json`.
+The flags accepted by both collectors are stable:
 
-To review the bundle without extracting the zip, use any archive viewer. The
-generated file name follows `diagnostics-<YYYYMMDD-HHMMSS>-<short-hash>.zip`
-where the short hash is derived from the manifest.
+- `--out DIR` – destination directory (defaults to the Desktop, falling back to the current working directory when the Desktop cannot be resolved).
+- `--raw` – include unredacted copies of every collected file (explicit confirmation required unless `--yes` is supplied).
+- `--include-db` – add `db/db.meta.json` and `db/db.sha256` for the SQLite database (the database file itself is never copied).
+- `--data-dir DIR` / `--logs-dir DIR` – override the auto-detected application data or log directories.
+- `--bundle-id ID` – override the macOS bundle identifier used when resolving paths.
+- `--yes` – run non-interactively (accepts the `--raw` prompt on macOS/Linux and Windows).
+- `--help` – print usage.
 
-## Sharing with support
+### Default paths
 
-After running the script the final line of output prints the absolute path to
-the generated zip. Attach that archive to the support email. Because content is
-redacted by default it is safe to share, but you should still review the README
-and manifest before sending.
+| Platform | Data directory | Logs directory |
+| --- | --- | --- |
+| macOS | `~/Library/Application Support/com.paula.arklowdun` (or overridden `--bundle-id`) | `~/Library/Logs/Arklowdun` |
+| Windows | `%APPDATA%\Arklowdun` | `%LOCALAPPDATA%\Arklowdun\Logs` |
+| Linux | `${XDG_DATA_HOME:-~/.local/share}/Arklowdun` | `${XDG_STATE_HOME:-~/.local/state}/Arklowdun/logs` |
 
-If you use `--raw` the README includes an additional warning banner to ensure
-the recipient understands that unredacted files are present.
+The collectors emit the resulting archive to the Desktop by default. When the Desktop is not resolvable (for example on headless servers), they log `Desktop not found; using <cwd>` and drop the zip alongside the script.
+
+### Naming, exit codes, and logging
+
+- Archive naming follows `diagnostics-YYYYMMDD-HHMMSS-<manifest-sha256-prefix>.zip`.
+- Exit codes: `0` = success, `1` = completed with warnings (e.g. missing crash report, raw copy failures), `2` = fatal error / bad invocation.
+- Log rotation is configured for **5 files at 5 MB each** (see `DEFAULT_LOG_MAX_SIZE_BYTES` and `DEFAULT_LOG_MAX_FILES` in `src-tauri/src/lib.rs`).
+
+## Bundle contents
+
+Every bundle contains the following top-level files and directories:
+
+- `README.txt` – describes the bundle, flags, and redaction rules.
+- `manifest.json` – machine-readable index of every file examined.
+- `system.json` – platform metadata (bundle ID, app version, OS version, architecture, timestamp, data/log paths, script version).
+- `checksums.txt` – SHA-256 checksums for every collected file plus `manifest.json`.
+- `collected/` – redacted copies of logs, configuration files, and crash data (`crash/latest.crash.txt` is always present, even if it only reports “not found”).
+- `db/` – optional hash metadata when `--include-db` is supplied (`db.meta.json`, `db.sha256`). The SQLite database file is **never** copied.
+- `raw/` – only present when `--raw` was requested.
+
+### Manifest schema (real output)
+
+```json
+[
+  {
+    "path": "<app-logs>/arklowdun.log",
+    "category": "log",
+    "included": true,
+    "size_bytes": 71,
+    "mtime_iso": "2025-09-17T06:33:17Z",
+    "redacted": true,
+    "sha256": "9e2738107835f7faf5caed3c7294f516667f753214eb0ff41ed3543c3e95239d"
+  },
+  {
+    "path": "<app-data>/settings.json",
+    "category": "config",
+    "included": true,
+    "size_bytes": 17,
+    "mtime_iso": "2025-09-17T06:33:17Z",
+    "redacted": true,
+    "sha256": "057c817c6a65ba4c95e68d754eaf8323b5714e95d5ecb624049f5afe95e47ba4"
+  },
+  {
+    "path": "N/A",
+    "category": "crash",
+    "included": false,
+    "reason": "not_found",
+    "size_bytes": null,
+    "mtime_iso": null,
+    "redacted": false
+  },
+  {
+    "path": "<app-data>/app.db",
+    "category": "db",
+    "included": false,
+    "reason": "hash_only",
+    "size_bytes": 0,
+    "mtime_iso": "2025-09-17T06:34:14Z",
+    "redacted": false,
+    "sha256_raw": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+]
+```
+
+Each manifest entry includes:
+
+- `path` – redacted, normalised source path (`<app-logs>`, `<app-data>`, `<home>`, or `<path>` for out-of-scope locations, plus `N/A` when nothing was discovered).
+- `category` – `log`, `config`, `crash`, `db`, etc.
+- `included` – `true` when the file was collected under `collected/`.
+- `reason` – explains why a file was skipped (`not_found`, `exceeds <limit>MB limit`, `redaction_failed`, `hash_only`).
+- `size_bytes` / `mtime_iso` – original metadata when available.
+- `redacted` – `true` when the collector produced a sanitised copy.
+- `sha256` – checksum for the redacted copy.
+- `sha256_raw` – present only when `--raw` is active or for hash metadata (`db.sha256`).
+- `limit_mb` – set when a file exceeded the size ceiling (default 10 MB, override with `ARK_MAX_FILE_MB`).
+
+### system.json example
+
+```json
+{
+  "bundle_id": "com.paula.arklowdun",
+  "app_version": "0.1.0",
+  "platform": "linux",
+  "os_version": "Ubuntu 24.04.2 LTS",
+  "arch": "x86_64",
+  "timestamp_iso": "2025-09-17T06:33:28Z",
+  "data_dir": "/workspace/Arklowdun/diagnostics-home/.local/share/Arklowdun",
+  "logs_dir": "/workspace/Arklowdun/diagnostics-home/.local/state/Arklowdun/logs",
+  "script_version": "1.0.0"
+}
+```
+
+## Support workflow
+
+1. Run the appropriate collector (`Copy diagnostics` for summaries, CLI for full bundles).
+2. Review `manifest.json`, `system.json`, and the redacted files in `collected/`.
+3. Confirm `checksums.txt` lists each collected file plus `manifest.json`. (Optional: run `sha256sum -c checksums.txt` or `Get-FileHash`.)
+4. Ensure the crash stub (`collected/crash/latest.crash.txt`) is present. If the manifest reports `not_found`, the stub explains which directory was checked.
+5. Attach the zip to the support ticket. Include the diagnostics summary in the ticket body so reviewers see the basics immediately.
+
+### Verification checklist
+
+- Expected top-level files: `README.txt`, `manifest.json`, `system.json`, `checksums.txt`.
+- Expected directories: `collected/` (with `crash/latest.crash.txt`), optional `logs/`, `config/`, `raw/`, and `db/` depending on flags and source availability.
+- Oversized (>10 MB) files appear in `manifest.json` with `included=false` and `reason="exceeds 10MB limit"` unless the size limit is raised.
+- When `--include-db` is used, verify that `db/db.meta.json` reports the on-disk path and `db/db.sha256` contains the hash—no `.db` file should be inside the archive.
+
+## Sample bundle (generate locally)
+
+You can generate a reference bundle locally for demos or validation:
+
+```bash
+scripts/collect-diagnostics.sh --include-db --yes --out docs/samples
+```
+
+This writes a zip like:
+
+```
+docs/samples/diagnostics-YYYYMMDD-HHMMSS-<manifest-hash>.zip
+```
+
+> Note: sample zips are **not** committed to the repo. They’re ignored by `.gitignore` to keep the repository lean.
+
+## Logging details
+
+- Application logs live in the platform-specific directories listed above.
+- Rotation keeps the current log plus four rolled files (5 × 5 MB).
+- The diagnostics summary always reads from the active log and trims to the newest 200 lines.
+
+---
+
+For quick access, open **Settings → About and diagnostics** and click **Help → Diagnostics guide** to launch this document in your system viewer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-clipboard-manager": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-fs": "^2",
         "@tauri-apps/plugin-notification": "^2",
@@ -1620,6 +1621,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-clipboard-manager": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz",
+      "integrity": "sha512-81NOBA2P+OTY8RLkBwyl9ZR/0CeggLub4F6zxcxUIfFOAqtky7J61+K/MkH2SC1FMxNBxrX0swDuKvkjkHadlA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.6.0"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",
     "@tauri-apps/plugin-notification": "^2",

--- a/scripts/make-sample-bundle.sh
+++ b/scripts/make-sample-bundle.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+mkdir -p docs/samples
+scripts/collect-diagnostics.sh --include-db --yes --out docs/samples
+
+echo
+printf 'Sample written to docs/samples/. Remember: .gitignore prevents committing zips.\n'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -119,6 +119,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.1",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arklowdun"
 version = "0.1.0"
 dependencies = [
@@ -144,6 +165,7 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-notification",
@@ -250,7 +272,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.0.8",
  "slab",
  "windows-sys 0.60.2",
 ]
@@ -281,7 +303,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -307,7 +329,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.60.2",
@@ -513,6 +535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +882,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1220,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1307,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1354,12 @@ dependencies = [
  "chrono",
  "flate2",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1597,6 +1672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+dependencies = [
+ "rustix 1.0.8",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1867,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1989,7 +2084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2103,6 +2198,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "tiff",
 ]
 
 [[package]]
@@ -2403,6 +2512,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -2519,6 +2634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,7 +2685,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.16",
  "windows-sys 0.60.2",
@@ -2614,6 +2745,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify-rust"
@@ -3000,6 +3141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3273,16 @@ checksum = "42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -3353,6 +3514,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.9.3",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,7 +3536,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.60.2",
 ]
 
@@ -3489,6 +3663,21 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3830,6 +4019,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -3837,7 +4039,7 @@ dependencies = [
  "bitflags 2.9.3",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
 
@@ -4743,7 +4945,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4788,6 +4990,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.5",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adddd9e9275b20e77af3061d100a25a884cced3c4c9ef680bd94dd0f7e26c1ca"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -5012,7 +5229,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.60.2",
 ]
 
@@ -5089,6 +5306,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5446,10 +5677,22 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.16",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f943391d896cdfe8eec03a04d7110332d445be7df856db382dd96a730667562c"
+dependencies = [
+ "memchr",
+ "nom",
+ "once_cell",
+ "petgraph",
 ]
 
 [[package]]
@@ -5829,7 +6072,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.0.8",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5842,7 +6085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.3",
- "rustix",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5856,6 +6099,19 @@ dependencies = [
  "bitflags 2.9.3",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.9.3",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5970,6 +6226,12 @@ dependencies = [
  "windows",
  "windows-core",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "whoami"
@@ -6470,6 +6732,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5ff8d0e60065f549fafd9d6cb626203ea64a798186c80d8e7df4f8af56baeb"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 0.38.44",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6540,6 +6821,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.0.8",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -6704,6 +7002,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+tauri-plugin-clipboard-manager = "2"
 uuid = { version = "1", features = ["serde", "v7"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "0.10"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,8 +1,11 @@
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     ensure_ts_bindings_dir();
+    sync_diagnostics_doc();
+    emit_git_commit();
     tauri_build::build();
 }
 
@@ -16,4 +19,54 @@ fn ensure_ts_bindings_dir() {
             err
         );
     }
+}
+
+fn sync_diagnostics_doc() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| "".into());
+    let source = PathBuf::from(&manifest_dir).join("../docs/diagnostics.md");
+    println!("cargo:rerun-if-changed={}", source.display());
+
+    if !source.exists() {
+        println!(
+            "cargo:warning=diagnostics guide not found at {}; skipping resource copy",
+            source.display()
+        );
+        return;
+    }
+
+    let target_dir = PathBuf::from(&manifest_dir).join("resources/docs");
+    if let Err(err) = std::fs::create_dir_all(&target_dir) {
+        println!(
+            "cargo:warning=failed to prepare diagnostics resource directory {}: {}",
+            target_dir.display(),
+            err
+        );
+        return;
+    }
+
+    let target = target_dir.join("diagnostics.md");
+    if let Err(err) = std::fs::copy(&source, &target) {
+        println!(
+            "cargo:warning=failed to copy diagnostics guide to resources: {}",
+            err
+        );
+    }
+}
+
+fn emit_git_commit() {
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output();
+
+    let commit = match output {
+        Ok(out) if out.status.success() => {
+            let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if raw.is_empty() {
+                "unknown".to_string()
+            } else {
+                raw
+            }
+        }
+        _ => "unknown".to_string(),
+    };
+
+    println!("cargo:rustc-env=ARK_GIT_HASH={commit}");
 }

--- a/src-tauri/capabilities/clipboard.json
+++ b/src-tauri/capabilities/clipboard.json
@@ -1,0 +1,7 @@
+{
+  "identifier": "clipboard",
+  "description": "Allow copying diagnostics to the system clipboard",
+  "permissions": [
+    "clipboard-manager:write-text"
+  ]
+}

--- a/src-tauri/capabilities/opener-doc.json
+++ b/src-tauri/capabilities/opener-doc.json
@@ -1,0 +1,14 @@
+{
+  "identifier": "open-diagnostics-doc",
+  "description": "Allow opening the bundled diagnostics guide",
+  "permissions": [
+    "opener:allow-open"
+  ],
+  "windows": [
+    {
+      "label": "main",
+      "urls": ["*"],
+      "scope": ["$RESOURCE/**"]
+    }
+  ]
+}

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,164 @@
+use serde::Serialize;
+use std::{env, fs, path::PathBuf};
+
+use crate::{git_commit_hash, resolve_logs_dir, AppError, AppResult, LOG_FILE_NAME};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Summary {
+    pub platform: String,
+    pub arch: String,
+    pub app_version: String,
+    pub commit_hash: String,
+    pub rust_log: Option<String>,
+    pub rust_log_source: Option<String>,
+    pub log_path: String,
+    pub log_available: bool,
+    pub log_tail: Vec<String>,
+    pub log_truncated: bool,
+    pub log_lines_returned: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AboutInfo {
+    pub app_version: String,
+    pub commit_hash: String,
+}
+
+pub fn gather_summary<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> AppResult<Summary> {
+    let platform = env::consts::OS.to_string();
+    let arch = env::consts::ARCH.to_string();
+    let app_version = app.package_info().version.to_string();
+    let commit_hash = git_commit_hash().to_string();
+
+    let mut rust_log_source = None;
+    let rust_log = env::var("RUST_LOG")
+        .ok()
+        .map(|value| {
+            rust_log_source = Some(String::from("RUST_LOG"));
+            value
+        })
+        .or_else(|| {
+            env::var("TAURI_ARKLOWDUN_LOG").ok().map(|value| {
+                rust_log_source = Some(String::from("TAURI_ARKLOWDUN_LOG"));
+                value
+            })
+        });
+
+    let logs_dir = resolve_logs_dir(app).map_err(|err| {
+        AppError::new("DIAGNOSTICS/LOGS_DIR", "Failed to locate log directory")
+            .with_context("error", err.to_string())
+    })?;
+
+    let log_path = logs_dir.join(LOG_FILE_NAME);
+    let log_path_str = log_path.display().to_string();
+
+    let mut log_tail: Vec<String> = Vec::new();
+    let mut log_truncated = false;
+    let mut log_available = false;
+
+    if log_path.exists() {
+        log_available = true;
+        let content = fs::read_to_string(&log_path).map_err(|err| {
+            AppError::new("DIAGNOSTICS/READ_LOG", "Failed to read log file")
+                .with_context("path", log_path_str.clone())
+                .with_context("error", err.to_string())
+        })?;
+        let lines: Vec<&str> = content.lines().collect();
+        let total = lines.len();
+        let start = total.saturating_sub(200);
+        log_truncated = total > 200;
+        log_tail = lines
+            .into_iter()
+            .skip(start)
+            .map(|line| line.to_string())
+            .collect();
+    }
+
+    let log_lines_returned = log_tail.len();
+
+    Ok(Summary {
+        platform,
+        arch,
+        app_version,
+        commit_hash,
+        rust_log,
+        rust_log_source,
+        log_path: log_path_str,
+        log_available,
+        log_tail,
+        log_truncated,
+        log_lines_returned,
+    })
+}
+
+pub fn about_info<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> AboutInfo {
+    AboutInfo {
+        app_version: app.package_info().version.to_string(),
+        commit_hash: git_commit_hash().to_string(),
+    }
+}
+
+pub fn resolve_doc_path<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> AppResult<String> {
+    use tauri::path::BaseDirectory;
+
+    let path_manager = app.path();
+
+    let candidates = [
+        "resources/docs/diagnostics.md",
+        "docs/diagnostics.md",
+    ];
+
+    for relative in candidates {
+        match path_manager.resolve(relative, BaseDirectory::Resource) {
+            Ok(path) => {
+                if path.exists() {
+                    return Ok(path.to_string_lossy().to_string());
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    target: "arklowdun",
+                    event = "diagnostics_doc_resolve_failed",
+                    candidate = relative,
+                    error = %err
+                );
+            }
+        }
+    }
+
+    if let Ok(mut resource_dir) = path_manager.resource_dir() {
+        let mut nested = resource_dir.clone();
+        nested.push("docs");
+        nested.push("diagnostics.md");
+        if nested.exists() {
+            return Ok(nested.to_string_lossy().to_string());
+        }
+
+        resource_dir.push("diagnostics.md");
+        if resource_dir.exists() {
+            return Ok(resource_dir.to_string_lossy().to_string());
+        }
+    }
+
+    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../docs/diagnostics.md");
+    let fallback_display = fallback.to_string_lossy().to_string();
+    if fallback.exists() {
+        return Ok(fallback.to_string_lossy().to_string());
+    }
+
+    Err(
+        AppError::new(
+            "DIAGNOSTICS/DOC_MISSING",
+            "Diagnostics guide is not bundled",
+        )
+        .with_context(
+            "searched",
+            format!(
+                "resources/docs/diagnostics.md, docs/diagnostics.md, resource_dir/docs/diagnostics.md, resource_dir/diagnostics.md, {}",
+                fallback_display
+            ),
+        ),
+    )
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ const FILES_INDEX_VERSION: i64 = 1;
 const DEFAULT_LOG_MAX_SIZE_BYTES: u64 = 5_000_000;
 const DEFAULT_LOG_MAX_FILES: usize = 5;
 const LOG_DIR_NAME: &str = "logs";
-const LOG_FILE_NAME: &str = "arklowdun.log";
+pub(crate) const LOG_FILE_NAME: &str = "arklowdun.log";
 
 static FILE_LOG_WRITER: OnceCell<NonBlocking> = OnceCell::new();
 static FILE_LOG_GUARD: OnceCell<WorkerGuard> = OnceCell::new();
@@ -94,6 +94,7 @@ impl<'a> MakeWriter<'a> for RotatingFileWriter {
 mod attachments;
 pub mod commands;
 pub mod db;
+mod diagnostics;
 pub mod error;
 mod events_tz_backfill;
 mod household; // declare module; avoid `use` to prevent name collision
@@ -235,6 +236,10 @@ pub fn init_logging() {
     crate::error::install_panic_hook();
 }
 
+pub(crate) fn git_commit_hash() -> &'static str {
+    option_env!("ARK_GIT_HASH").unwrap_or("unknown")
+}
+
 #[derive(Debug, Error)]
 pub enum FileLoggingError {
     #[error("app data directory unavailable")]
@@ -365,7 +370,7 @@ pub fn init_file_logging_standalone(bundle_id: &str) -> Result<PathBuf, FileLogg
     Ok(log_path)
 }
 
-fn resolve_logs_dir<R: tauri::Runtime>(
+pub(crate) fn resolve_logs_dir<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> Result<PathBuf, FileLoggingError> {
     if let Ok(fake) = std::env::var("ARK_FAKE_APPDATA") {
@@ -1641,6 +1646,34 @@ async fn open_path(app: tauri::AppHandle, path: String) -> AppResult<()> {
     .await
 }
 
+#[tauri::command]
+async fn diagnostics_summary(app: tauri::AppHandle) -> AppResult<diagnostics::Summary> {
+    let app = app.clone();
+    dispatch_async_app_result(move || {
+        let app = app;
+        async move {
+            crate::flush_file_logs();
+            diagnostics::gather_summary(&app)
+        }
+    })
+    .await
+}
+
+#[tauri::command]
+fn about_metadata(app: tauri::AppHandle) -> AppResult<diagnostics::AboutInfo> {
+    Ok(diagnostics::about_info(&app))
+}
+
+#[tauri::command]
+async fn diagnostics_doc_path(app: tauri::AppHandle) -> AppResult<String> {
+    let app = app.clone();
+    dispatch_async_app_result(move || {
+        let app = app;
+        async move { diagnostics::resolve_doc_path(&app) }
+    })
+    .await
+}
+
 #[macro_export]
 macro_rules! app_commands {
     ($($extra:ident),* $(,)?) => {
@@ -1739,6 +1772,9 @@ macro_rules! app_commands {
             shopping_items_restore,
             attachment_open,
             attachment_reveal,
+            diagnostics_summary,
+            diagnostics_doc_path,
+            about_metadata,
             $($extra),*
         ]
     };
@@ -1751,6 +1787,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             let handle = app.handle();
             if let Err(err) = crate::init_file_logging(&handle) {

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -25,7 +25,9 @@
       "capabilities": [
         "default",
         "window-management",
-        "sql"
+        "sql",
+        "clipboard",
+        "open-diagnostics-doc"
       ]
     }
   },
@@ -38,6 +40,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/docs/diagnostics.md"
     ]
   },
   "plugins": {

--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -1,3 +1,6 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { openPath } from "@tauri-apps/plugin-opener";
+import { fetchAboutMetadata, fetchDiagnosticsSummary, resolveDiagnosticsDocPath } from "./api/diagnostics";
 import { createEmptyState } from "./ui/emptyState";
 import { STR } from "./ui/strings";
 
@@ -30,7 +33,30 @@ export function SettingsView(container: HTMLElement) {
 
     <section class="card settings__section" aria-labelledby="settings-about">
       <h3 id="settings-about">About and diagnostics</h3>
-      <div class="settings__empty"></div>
+      <div class="settings__body settings__body--about">
+        <dl class="settings__meta">
+          <div class="settings__meta-item">
+            <dt>Version</dt>
+            <dd data-settings-version>Loading…</dd>
+          </div>
+          <div class="settings__meta-item">
+            <dt>Commit</dt>
+            <dd><span data-settings-commit title="Loading…">Loading…</span></dd>
+          </div>
+        </dl>
+        <p class="settings__note">
+          Copying diagnostics only captures the quick summary: platform, app version, commit hash, the active RUST_LOG value, and the last
+          200 lines from the rotating log file.
+        </p>
+        <div class="settings__actions">
+          <button type="button" class="settings__button" data-copy-diagnostics>
+            Copy diagnostics summary
+          </button>
+          <a href="#" class="settings__link" data-open-diagnostics-doc>Help → Diagnostics guide</a>
+        </div>
+        <div class="settings__status" data-settings-status role="status" aria-live="polite"></div>
+        <pre class="settings__preview" data-diagnostics-preview hidden aria-label="Latest copied diagnostics summary"></pre>
+      </div>
     </section>
   `;
 
@@ -47,5 +73,130 @@ export function SettingsView(container: HTMLElement) {
       e.preventDefault();
       document.querySelector<HTMLAnchorElement>("#nav-dashboard")?.click();
     });
+
+  setupAboutAndDiagnostics(section);
+}
+
+function describeError(error: unknown): string {
+  if (!error) return "Unknown error";
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && "message" in error) {
+    return String((error as { message?: unknown }).message ?? "Unknown error");
+  }
+  return JSON.stringify(error);
+}
+
+function formatSummary(summary: Awaited<ReturnType<typeof fetchDiagnosticsSummary>>): string {
+  const rustSource = summary.rustLogSource && summary.rustLogSource !== "RUST_LOG"
+    ? `${summary.rustLogSource} → RUST_LOG`
+    : "RUST_LOG";
+  const rustValue = summary.rustLog ?? "(not set)";
+  const lines: string[] = [
+    `Platform: ${summary.platform} (${summary.arch})`,
+    `App version: ${summary.appVersion}`,
+    `Commit: ${summary.commitHash}`,
+    `${rustSource}: ${rustValue}`,
+    `Log file: ${summary.logPath}${summary.logAvailable ? "" : " (not found)"}`,
+  ];
+
+  if (summary.logTail.length) {
+    const truncatedNote = summary.logTruncated ? ", truncated to last 200 lines" : "";
+    const tailDescriptor = `Log tail (${summary.logLinesReturned} line${summary.logLinesReturned === 1 ? "" : "s"}${truncatedNote})`;
+    lines.push(tailDescriptor, "");
+    lines.push(...summary.logTail);
+  } else {
+    lines.push("Log tail: <no log lines available>");
+  }
+
+  return lines.join("\n");
+}
+
+async function copyToClipboard(text: string) {
+  try {
+    await writeText(text);
+    return;
+  } catch (_) {
+    // fall back to the Web Clipboard API and, if needed, a hidden textarea for environments
+    // (like unit tests) where the plugin is not available.
+  }
+
+  try {
+    await navigator?.clipboard?.writeText?.(text);
+    return;
+  } catch (_) {
+    // fall through to the hidden textarea approach.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "absolute";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+  const successful = document.execCommand("copy");
+  textarea.remove();
+  if (!successful) {
+    throw new Error("Clipboard copy was blocked. Copy the summary from the preview.");
+  }
+}
+
+async function setupAboutAndDiagnostics(root: HTMLElement) {
+  const container = root.querySelector<HTMLElement>(".settings__body--about");
+  if (!container) return;
+
+  const versionEl = container.querySelector<HTMLElement>("[data-settings-version]");
+  const commitEl = container.querySelector<HTMLElement>("[data-settings-commit]");
+  const statusEl = container.querySelector<HTMLElement>("[data-settings-status]");
+  const previewEl = container.querySelector<HTMLPreElement>("[data-diagnostics-preview]");
+  const copyButton = container.querySelector<HTMLButtonElement>("[data-copy-diagnostics]");
+  const helpLink = container.querySelector<HTMLAnchorElement>("[data-open-diagnostics-doc]");
+
+  try {
+    const meta = await fetchAboutMetadata();
+    if (versionEl) versionEl.textContent = meta.appVersion;
+    if (commitEl) {
+      const shortHash = meta.commitHash === "unknown" ? meta.commitHash : meta.commitHash.slice(0, 12);
+      commitEl.textContent = shortHash;
+      commitEl.setAttribute("title", meta.commitHash);
+    }
+  } catch (error) {
+    if (statusEl) statusEl.textContent = `Failed to load version information: ${describeError(error)}`;
+  }
+
+  copyButton?.addEventListener("click", async (event) => {
+    event.preventDefault();
+    if (!statusEl || !previewEl || !copyButton) return;
+
+    copyButton.disabled = true;
+    statusEl.textContent = "Collecting diagnostics summary…";
+    previewEl.hidden = true;
+    try {
+      const summary = await fetchDiagnosticsSummary();
+      const text = formatSummary(summary);
+      await copyToClipboard(text);
+      statusEl.textContent = "Diagnostics summary copied. Review before sharing.";
+      previewEl.hidden = false;
+      previewEl.textContent = text;
+    } catch (error) {
+      statusEl.textContent = `Failed to copy diagnostics: ${describeError(error)}`;
+    } finally {
+      copyButton.disabled = false;
+    }
+  });
+
+  helpLink?.addEventListener("click", async (event) => {
+    event.preventDefault();
+    if (!statusEl) return;
+    statusEl.textContent = "Opening diagnostics guide…";
+    try {
+      const path = await resolveDiagnosticsDocPath();
+      await openPath(path);
+      statusEl.textContent = "Diagnostics guide opened in your default viewer.";
+    } catch (error) {
+      statusEl.textContent = `Failed to open diagnostics guide: ${describeError(error)}`;
+    }
+  });
 }
 

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -1,0 +1,32 @@
+import { call } from "./call";
+
+export interface DiagnosticsSummary {
+  platform: string;
+  arch: string;
+  appVersion: string;
+  commitHash: string;
+  rustLog?: string;
+  rustLogSource?: string;
+  logPath: string;
+  logAvailable: boolean;
+  logTail: string[];
+  logTruncated: boolean;
+  logLinesReturned: number;
+}
+
+export interface AboutMetadata {
+  appVersion: string;
+  commitHash: string;
+}
+
+export function fetchDiagnosticsSummary(): Promise<DiagnosticsSummary> {
+  return call<DiagnosticsSummary>("diagnostics_summary");
+}
+
+export function fetchAboutMetadata(): Promise<AboutMetadata> {
+  return call<AboutMetadata>("about_metadata");
+}
+
+export function resolveDiagnosticsDocPath(): Promise<string> {
+  return call<string>("diagnostics_doc_path");
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -607,6 +607,98 @@ footer a.footer__settings {
   outline-offset: 2px;
 }
 
+/* ========================================================================== */
+/* SETTINGS → ABOUT & DIAGNOSTICS                                             */
+/* ========================================================================== */
+
+.settings__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.settings__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.settings__meta-item {
+  min-width: 12rem;
+}
+
+.settings__meta-item dt {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.settings__meta-item dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.settings__note {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.settings__button {
+  cursor: pointer;
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+  border: none;
+  border-radius: var(--radius-base);
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+}
+
+.settings__button:hover,
+.settings__button:focus-visible {
+  background-color: var(--color-accent-soft-hover);
+  color: var(--color-text);
+}
+
+.settings__button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.settings__link {
+  font-weight: 600;
+}
+
+.settings__status {
+  min-height: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.settings__preview {
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  padding: var(--space-2) var(--space-3);
+  max-height: 240px;
+  overflow: auto;
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, "Courier New", monospace;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
 .footer__utilities {
   display: flex;
   gap: var(--space-2);

--- a/src/types/tauri-plugin-clipboard-manager.d.ts
+++ b/src/types/tauri-plugin-clipboard-manager.d.ts
@@ -1,0 +1,3 @@
+declare module "@tauri-apps/plugin-clipboard-manager" {
+  export function writeText(text: string): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add clipboard capability configuration so the diagnostics copy command can access the OS clipboard
- permit opening the bundled diagnostics guide by granting the opener plugin resource scope
- declare minimal TypeScript types for the clipboard plugin to keep the type checker happy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ca4d6d5300832ab69856e014d17fc4