### PR TITLE
feat: polish responsive layout and add theme toggle

### DIFF
--- a/docs/responsive-utilities.md
+++ b/docs/responsive-utilities.md
@@ -1,0 +1,19 @@
+# Responsive utilities
+
+A small set of layout helpers ensure the shell and feature panes compress cleanly on narrow viewports. They are intentionally minimal so that the main layout styles remain authoritative.
+
+## Breakpoints
+
+- **md (≤900px)** — matches the sidebar collapse threshold and tablet widths.
+- **sm (≤600px)** — used for compact phone layouts.
+
+## Available classes
+
+| Utility | Purpose | Notes |
+| --- | --- | --- |
+| `.hide-md` | Visually hides an element at the md breakpoint and below while leaving it in the accessibility tree. | Used for sidebar labels so the icon-only rail stays screen-reader friendly. |
+| `.hide-sm` | Same behaviour as `.hide-md`, but for the sm breakpoint. | Handy for trimming non-essential labels on very small screens. |
+| `.stack-md` | Forces a flex container into a column layout at the md breakpoint. | Keep the element a flex container; the utility only adjusts direction/alignments. |
+| `.grow-xs` | Allows a flex child to grow and fill available space at the sm breakpoint. | Useful for action buttons that should become full-width on phones. |
+
+Add utilities sparingly—if a screen needs bespoke behaviour, prefer a dedicated component style instead of piling on helpers.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arklowdun — Home Management</title>
+    <script>
+      (() => {
+        const storageKey = "arklowdun.theme";
+        const fallback = "system";
+        try {
+          const stored = localStorage.getItem(storageKey);
+          const theme = stored === "light" || stored === "dark" || stored === "system" ? stored : fallback;
+          document.documentElement.dataset.theme = theme;
+        } catch (error) {
+          document.documentElement.dataset.theme = fallback;
+          console.warn("theme bootstrap failed", error);
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.ts" defer></script>
   </head>
 

--- a/src/BillsView.ts
+++ b/src/BillsView.ts
@@ -32,12 +32,16 @@ async function renderBills(listEl: HTMLUListElement, bills: Bill[]) {
     li.appendChild(
       createEmptyState({
         title: STR.empty.billsTitle,
-        description: STR.empty.billsDesc,
-        actionLabel: "Add bill",
-        onAction: () =>
-          document
-            .querySelector<HTMLInputElement>("#bill-amount")
-            ?.focus(),
+        body: STR.empty.billsDesc,
+        cta: {
+          kind: "button",
+          label: "Add bill",
+          onClick: () => {
+            document
+              .querySelector<HTMLInputElement>("#bill-amount")
+              ?.focus();
+          },
+        },
       }),
     );
     listEl.appendChild(li);

--- a/src/BudgetView.ts
+++ b/src/BudgetView.ts
@@ -53,10 +53,16 @@ async function renderSummary(
     td.appendChild(
       createEmptyState({
         title: STR.empty.budgetTitle,
-        description: STR.empty.budgetDesc,
-        actionLabel: "Add category",
-        onAction: () =>
-          document.querySelector<HTMLInputElement>("#cat-name")?.focus(),
+        body: STR.empty.budgetDesc,
+        cta: {
+          kind: "button",
+          label: "Add category",
+          onClick: () => {
+            document
+              .querySelector<HTMLInputElement>("#cat-name")
+              ?.focus();
+          },
+        },
       }),
     );
     tr.appendChild(td);

--- a/src/DashboardView.ts
+++ b/src/DashboardView.ts
@@ -113,7 +113,7 @@ export async function DashboardView(container: HTMLElement) {
       listEl.appendChild(
         createEmptyState({
           title: STR.empty.dashboardTitle,
-          description: "You're all caught up.",
+          body: "You're all caught up.",
         }),
       );
     }

--- a/src/FilesView.ts
+++ b/src/FilesView.ts
@@ -75,8 +75,10 @@ export async function FilesView(container: HTMLElement) {
 
   const header = document.createElement('header');
   header.className = 'files__header';
+  header.classList.add('stack-md');
 
   const headerInfo = document.createElement('div');
+  headerInfo.className = 'files__header-info';
   const title = document.createElement('h2');
   title.textContent = 'Files';
   const breadcrumbNav = document.createElement('nav');

--- a/src/InsuranceView.ts
+++ b/src/InsuranceView.ts
@@ -32,12 +32,16 @@ async function renderPolicies(listEl: HTMLUListElement, policies: Policy[]) {
     li.appendChild(
       createEmptyState({
         title: STR.empty.policiesTitle,
-        description: STR.empty.policiesDesc,
-        actionLabel: "Add policy",
-        onAction: () =>
-          document
-            .querySelector<HTMLInputElement>("#policy-amount")
-            ?.focus(),
+        body: STR.empty.policiesDesc,
+        cta: {
+          kind: "button",
+          label: "Add policy",
+          onClick: () => {
+            document
+              .querySelector<HTMLInputElement>("#policy-amount")
+              ?.focus();
+          },
+        },
       }),
     );
     listEl.appendChild(li);

--- a/src/InventoryView.ts
+++ b/src/InventoryView.ts
@@ -24,12 +24,16 @@ async function renderInventory(listEl: HTMLUListElement, items: InventoryItem[])
     li.appendChild(
       createEmptyState({
         title: STR.empty.inventoryTitle,
-        description: STR.empty.inventoryDesc,
-        actionLabel: "Add item",
-        onAction: () =>
-          document
-            .querySelector<HTMLAnchorElement>("#nav-inventory")
-            ?.click(),
+        body: STR.empty.inventoryDesc,
+        cta: {
+          kind: "button",
+          label: "Add item",
+          onClick: () => {
+            document
+              .querySelector<HTMLAnchorElement>("#nav-inventory")
+              ?.click();
+          },
+        },
         icon: "📦",
       }),
     );

--- a/src/PropertyView.ts
+++ b/src/PropertyView.ts
@@ -25,12 +25,16 @@ async function renderDocs(listEl: HTMLUListElement, docs: PropertyDocument[]) {
     li.appendChild(
       createEmptyState({
         title: STR.empty.propertyTitle,
-        description: STR.empty.propertyDesc,
-        actionLabel: "Add document",
-        onAction: () =>
-          document
-            .querySelector<HTMLInputElement>("#prop-desc")
-            ?.focus(),
+        body: STR.empty.propertyDesc,
+        cta: {
+          kind: "button",
+          label: "Add document",
+          onClick: () => {
+            document
+              .querySelector<HTMLInputElement>("#prop-desc")
+              ?.focus();
+          },
+        },
       }),
     );
     listEl.appendChild(li);

--- a/src/ShoppingListView.ts
+++ b/src/ShoppingListView.ts
@@ -38,12 +38,16 @@ export async function ShoppingListView(container: HTMLElement) {
       wrap.appendChild(
         createEmptyState({
           title: STR.empty.shoppingTitle,
-          description: STR.empty.shoppingDesc,
-          actionLabel: "Add item",
-          onAction: () =>
-            document
-              .querySelector<HTMLFormElement>("#item-form")
-              ?.dispatchEvent(new Event("submit")),
+          body: STR.empty.shoppingDesc,
+          cta: {
+            kind: "button",
+            label: "Add item",
+            onClick: () => {
+              document
+                .querySelector<HTMLFormElement>("#item-form")
+                ?.dispatchEvent(new Event("submit"));
+            },
+          },
         }),
       );
       listEl.appendChild(wrap);

--- a/src/VehiclesView.ts
+++ b/src/VehiclesView.ts
@@ -22,7 +22,7 @@ export async function VehiclesView(container: HTMLElement) {
           li.appendChild(
             createEmptyState({
               title: STR.empty.vehiclesTitle,
-              description: STR.empty.vehiclesDesc,
+              body: STR.empty.vehiclesDesc,
             }),
           );
           listEl?.appendChild(li);

--- a/src/features/files/components/FilesList.ts
+++ b/src/features/files/components/FilesList.ts
@@ -28,7 +28,6 @@ export interface FilesListProps {
   emptyState?: {
     icon?: EmptyStateIcon;
     title: string;
-    description?: string;
     body?: string;
     actionLabel?: string;
   };
@@ -51,12 +50,10 @@ function renderEmptyState(props: FilesListProps): HTMLTableRowElement {
   const cell = document.createElement('td');
   cell.colSpan = 5;
   if (props.emptyState) {
-    const body =
-      props.emptyState.body ?? props.emptyState.description ?? undefined;
     const empty = createEmptyState({
       icon: props.emptyState.icon,
       title: props.emptyState.title,
-      body,
+      body: props.emptyState.body,
       cta:
         props.emptyState.actionLabel && props.onEmptyAction
           ? {

--- a/src/features/files/components/FilesToolbar.ts
+++ b/src/features/files/components/FilesToolbar.ts
@@ -108,6 +108,7 @@ export function createFilesToolbar(props: FilesToolbarProps): FilesToolbarInstan
   const selectButton = createButton({
     label: 'Select Directory',
     variant: 'ghost',
+    className: 'grow-xs',
     onClick: () => {
       void props.onSelectDirectory();
     },
@@ -116,11 +117,13 @@ export function createFilesToolbar(props: FilesToolbarProps): FilesToolbarInstan
   const newFolderButton = createButton({
     label: 'New Folder',
     variant: 'ghost',
+    className: 'grow-xs',
   });
 
   const newFileButton = createButton({
     label: 'New File',
     variant: 'ghost',
+    className: 'grow-xs',
   });
 
   container.append(selectButton, newFolderButton, newFileButton);

--- a/src/layout/Footer.ts
+++ b/src/layout/Footer.ts
@@ -1,4 +1,5 @@
 import type { AppPane } from "../store";
+import { createThemeToggle } from "@ui/ThemeToggle";
 
 type IconVariant = "solid" | "regular";
 
@@ -58,6 +59,7 @@ export function Footer(items: FooterItemConfig[]): FooterInstance {
 
     const span = document.createElement("span");
     span.textContent = primaryItem.label;
+    span.className = "footer__label hide-sm";
     anchor.appendChild(span);
 
     footer.appendChild(anchor);
@@ -97,6 +99,10 @@ export function Footer(items: FooterItemConfig[]): FooterInstance {
   question.setAttribute("aria-hidden", "true");
   help.appendChild(question);
   utilities.appendChild(help);
+
+  const toggle = createThemeToggle();
+  toggle.element.classList.add("grow-xs");
+  utilities.appendChild(toggle.element);
 
   footer.appendChild(utilities);
 

--- a/src/layout/Sidebar.ts
+++ b/src/layout/Sidebar.ts
@@ -42,9 +42,13 @@ export interface SidebarInstance {
   getLink(id: AppPane): HTMLAnchorElement | undefined;
 }
 
+function iconVariantClass(variant: IconVariant): string {
+  return variant === "solid" ? ICON_VARIANT_CLASS.solid : ICON_VARIANT_CLASS.regular;
+}
+
 function setIconVariant(icon: HTMLElement, variant: IconVariant) {
   icon.classList.remove(ICON_VARIANT_CLASS.solid, ICON_VARIANT_CLASS.regular);
-  icon.classList.add(ICON_VARIANT_CLASS[variant]);
+  icon.classList.add(iconVariantClass(variant));
 }
 
 function createLink(item: SidebarItemConfig): SidebarEntry {
@@ -56,13 +60,14 @@ function createLink(item: SidebarItemConfig): SidebarEntry {
   if (item.ariaLabel) link.setAttribute("aria-label", item.ariaLabel);
 
   const icon = document.createElement("i");
-  icon.className = `nav__icon ${ICON_VARIANT_CLASS[item.icon.defaultVariant]} ${item.icon.name}`;
+  icon.className = `nav__icon ${iconVariantClass(item.icon.defaultVariant)} ${item.icon.name}`;
   icon.setAttribute("aria-hidden", "true");
   if (item.icon.fixed) icon.dataset.fixed = "true";
   link.appendChild(icon);
 
   const label = document.createElement("span");
   label.textContent = item.label;
+  label.className = "sidebar__label hide-md";
   link.appendChild(label);
 
   return { item, link, icon };
@@ -89,6 +94,7 @@ export function Sidebar(props: SidebarProps): SidebarInstance {
 
   const title = document.createElement("h1");
   title.textContent = "Arklowdun";
+  title.className = "brand__title hide-md";
   brand.appendChild(title);
   top.appendChild(brand);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,9 +28,12 @@ import { initKeyboardMap } from "@ui/keys";
 import { actions, type AppPane } from "./store";
 import { emit } from "./store/events";
 import { runViewCleanups } from "./utils/viewLifecycle";
+import { initTheme } from "@ui/ThemeToggle";
 
 const isTauri = !!import.meta.env.TAURI;
 const appWindow = isTauri ? getCurrentWindow() : null;
+
+initTheme();
 
 interface LayoutContext {
   page: PageInstance;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,7 +3,8 @@
 :root {
   --radius-sm: 6px;
   --z-index-dropdown: 200;
-
+  --layout-sidebar-collapsed: 72px;
+  --layout-sidebar-collapsed-sm: 56px;
 }
 
 [hidden] {
@@ -36,6 +37,18 @@ body {
   overflow: hidden; // switch to 'auto' if you need full-page scroll
 }
 
+@media (max-width: 900px) {
+  body {
+    grid-template-columns: var(--layout-sidebar-collapsed) 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    grid-template-columns: var(--layout-sidebar-collapsed-sm) 1fr;
+  }
+}
+
 /* 2) Ensure your app root always covers the viewport */
 #app {
   min-height: 100vh;
@@ -62,17 +75,66 @@ main {
   background-color: var(--color-panel);
 }
 
+@media (max-width: 600px) {
+  .container {
+    padding: var(--space-3) var(--space-2) var(--space-4);
+  }
+}
+
 /* Hide content visually but keep it accessible to screen readers */
-.sr-only {
+@mixin visually-hidden {
   position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.sr-only {
+  @include visually-hidden;
+}
+
+/* Responsive utility helpers */
+.hide-md,
+.hide-sm {
+  position: static;
+}
+
+@media (max-width: 900px) {
+  .hide-md {
+    @include visually-hidden;
+  }
+}
+
+@media (max-width: 600px) {
+  .hide-sm {
+    @include visually-hidden;
+  }
+}
+
+.stack-md {
+  gap: var(--space-3);
+}
+
+@media (max-width: 900px) {
+  .stack-md {
+    flex-direction: column !important;
+    align-items: stretch !important;
+  }
+}
+
+.grow-xs {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 600px) {
+  .grow-xs {
+    flex: 1 1 0%;
+  }
 }
 
 /* ========================================================================== */
@@ -292,6 +354,12 @@ textarea:focus-visible {
   transition: background-color 0.2s, transform 0.12s ease, box-shadow 0.12s ease;
 }
 
+@media (max-width: 600px) {
+  .btn {
+    padding: var(--space-1) var(--space-2);
+  }
+}
+
 .btn:hover {
   background-color: var(--color-accent-soft);
   transform: translateY(-1px);
@@ -474,6 +542,10 @@ textarea:focus-visible {
   margin: 0;
 }
 
+.sidebar__label {
+  white-space: nowrap;
+}
+
 .brand {
   display: flex;
   align-items: baseline;
@@ -615,7 +687,83 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 900px) {
+  .sidebar {
+    inline-size: var(--layout-sidebar-collapsed);
+    padding: var(--space-3) var(--space-2);
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .sidebar__top {
+    align-items: center;
+  }
+
+  .brand {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .brand__logo {
+    width: 28px;
+    height: 28px;
+  }
+
+  .sidebar a.manage-link,
+  .sidebar .nav a {
+    justify-content: center;
+    inline-size: 48px;
+    block-size: 48px;
+    padding: 0;
+    gap: 0;
+    border-radius: var(--radius-pill);
+  }
+
+  .sidebar a.manage-link {
+    align-self: center;
+  }
+
+  .sidebar .nav {
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .nav__icon {
+    font-size: 1.125rem;
+  }
+
+  .sidebar__divider {
+    margin: var(--space-2) 0;
+  }
+
+  .sidebar__cmd-button {
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--radius-pill);
+  }
+}
+
+@media (max-width: 600px) {
+  .sidebar {
+    inline-size: var(--layout-sidebar-collapsed-sm);
+  }
+
+  .sidebar a.manage-link,
+  .sidebar .nav a {
+    inline-size: 44px;
+    block-size: 44px;
+  }
+
+  .sidebar__cmd-button {
+    width: 36px;
+    height: 36px;
+  }
+}
+
+@media (min-width: 901px) and (max-width: 1100px) {
   .sidebar {
     padding-inline: var(--space-3);
   }
@@ -627,8 +775,10 @@ footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
   padding: 0 var(--space-3);
-  block-size: 44px;
+  min-block-size: 44px;
   background-color: var(--color-panel);
   border-block-start: 1px solid var(--color-sidebar-rule);
 }
@@ -762,7 +912,9 @@ footer a.footer__settings {
 
 .footer__utilities {
   display: flex;
+  align-items: center;
   gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 .footer__utilities a,
@@ -793,6 +945,85 @@ footer a.footer__settings {
 
 .footer__utilities i {
   color: currentColor;
+}
+
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  padding-right: var(--space-4);
+  block-size: 36px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-panel);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.theme-toggle::after {
+  content: "";
+  position: absolute;
+  inset-inline-end: var(--space-2);
+  top: 50%;
+  transform: translateY(-50%);
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--color-text-muted);
+  pointer-events: none;
+}
+
+.theme-toggle:focus-within {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle__label {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+}
+
+.theme-toggle__select {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  padding-right: var(--space-2);
+  min-width: 5.5rem;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.theme-toggle__select:focus-visible {
+  outline: none;
+}
+
+@media (max-width: 720px) {
+  footer {
+    justify-content: flex-start;
+    padding-block: var(--space-2);
+  }
+
+  .footer__utilities {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+    gap: var(--space-1);
+  }
+
+  .footer__utilities a,
+  .footer__utilities button {
+    inline-size: 40px;
+    block-size: 40px;
+  }
+}
+
+@media (max-width: 600px) {
+  .theme-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 /* ========================================================================== */
@@ -911,12 +1142,27 @@ footer a.footer__settings {
 .files__header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
 }
 
 .files__actions {
   display: flex;
   gap: var(--space-2);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.files__header-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.files__header-info h2 {
+  margin: 0;
+  text-align: left;
 }
 
 .breadcrumb {
@@ -957,6 +1203,36 @@ footer a.footer__settings {
 }
 
 .files__panel { overflow-x: auto; }
+
+@media (max-width: 900px) {
+  .files__header {
+    justify-content: flex-start;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 720px) {
+  .breadcrumb {
+    flex-wrap: wrap;
+  }
+
+  .files__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .files__actions .btn {
+    flex: 1 1 calc(50% - var(--space-2));
+    min-width: 8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .files__actions .btn {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+}
 
 .files__error-region {
   margin-bottom: var(--space-2);

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -29,6 +29,28 @@ html, body {
 /* Headings: subtle premium feel */
 h1, h2, h3 { letter-spacing: -0.01em; }
 
+@mixin theme-dark {
+  --color-background: #1f2937;
+  --color-panel: #111827;
+  --color-text: #f9fafb;
+  --color-text-muted: #9ca3af;
+  --color-border: #374151;
+  --color-accent: #ff7e36;
+  --color-accent-text: #ffffff;
+  --color-accent-soft: #3b2a21;
+  --color-accent-soft-hover: #4c372b;
+  --color-sidebar-bg: #1e293b;
+  --color-sidebar-border: #334155;
+  --color-rule: #2a2f38;
+  --color-sidebar-rule: var(--color-rule);
+  --shadow-base: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --color-row-hover: #4c372b;
+  --overlay-bg: rgba(0, 0, 0, 0.6);
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.6);
+  --color-bg: var(--color-panel);
+  color-scheme: dark;
+}
+
 /* Theme tokens and base styles scoped to theme-v1 */
 .theme-v1 {
   /* Colors */
@@ -75,6 +97,7 @@ h1, h2, h3 { letter-spacing: -0.01em; }
   color: var(--color-text);
   font-family: var(--font-family-base);
   font-size: var(--font-size-base);
+  color-scheme: light;
 }
 
 @supports (color: color-mix(in srgb, black, white)) {
@@ -87,13 +110,6 @@ h1, h2, h3 { letter-spacing: -0.01em; }
     );
   }
 }
-
-/* (Optional, future) Dark theme override
-.theme-v1[data-theme="dark"] {
-  --color-rule: #2a2f38;
-  --color-sidebar-rule: var(--color-rule);
-}
-*/
 
 .theme-v1 a {
   color: var(--color-accent);
@@ -110,24 +126,14 @@ h1, h2, h3 { letter-spacing: -0.01em; }
   box-shadow: var(--shadow-base);
 }
 
+:root[data-theme="dark"] .theme-v1,
+.theme-v1[data-theme="dark"] {
+  @include theme-dark;
+}
+
 @media (prefers-color-scheme: dark) {
-  .theme-v1 {
-    --color-background: #1f2937;
-    --color-panel: #111827;
-    --color-text: #f9fafb;
-    --color-text-muted: #9ca3af;
-    --color-border: #374151;
-    --color-accent: #ff7e36;
-    --color-accent-text: #ffffff;
-    /* Opaque "pale orange" surfaces for dark UI */
-    --color-accent-soft: #3b2a21; /* base surface */
-    --color-accent-soft-hover: #4c372b; /* hover/active surface */
-    --color-sidebar-bg: #1e293b;
-    --color-sidebar-border: #334155;
-    --shadow-base: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --color-row-hover: #4c372b;
-    --overlay-bg: rgba(0, 0, 0, 0.6);
-    --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.6);
-    --color-bg: var(--color-panel);
+  :root:not([data-theme="light"]) .theme-v1,
+  .theme-v1:not([data-theme="light"]) {
+    @include theme-dark;
   }
 }

--- a/src/ui/ThemeToggle.ts
+++ b/src/ui/ThemeToggle.ts
@@ -1,0 +1,156 @@
+const STORAGE_KEY = "arklowdun.theme";
+
+export type ThemePreference = "system" | "light" | "dark";
+
+const VALID_VALUES = new Set<ThemePreference>(["system", "light", "dark"]);
+
+let currentTheme: ThemePreference = "system";
+let initialised = false;
+let media: MediaQueryList | null = null;
+const listeners = new Set<(theme: ThemePreference) => void>();
+
+function readStoredTheme(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && VALID_VALUES.has(stored as ThemePreference)) {
+      return stored as ThemePreference;
+    }
+  } catch (error) {
+    console.warn("theme storage read failed", error);
+  }
+  return "system";
+}
+
+function notify() {
+  for (const listener of listeners) {
+    listener(currentTheme);
+  }
+}
+
+function isSystemDark(): boolean {
+  return media?.matches ?? false;
+}
+
+function resolveColorScheme(theme: ThemePreference): "light" | "dark" {
+  if (theme === "dark") return "dark";
+  if (theme === "light") return "light";
+  return isSystemDark() ? "dark" : "light";
+}
+
+function applyTheme(theme: ThemePreference): void {
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  if (document.body) {
+    document.body.dataset.theme = theme;
+  }
+  const scheme = resolveColorScheme(theme);
+  root.style.colorScheme = scheme;
+}
+
+function persist(theme: ThemePreference): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch (error) {
+    console.warn("theme storage write failed", error);
+  }
+}
+
+function handleSystemChange(): void {
+  if (currentTheme !== "system") return;
+  applyTheme(currentTheme);
+  notify();
+}
+
+export function initTheme(): ThemePreference {
+  if (initialised) return currentTheme;
+  media = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
+  currentTheme = readStoredTheme();
+  applyTheme(currentTheme);
+  if (media) {
+    media.addEventListener("change", handleSystemChange);
+  }
+  initialised = true;
+  return currentTheme;
+}
+
+export function getTheme(): ThemePreference {
+  return currentTheme;
+}
+
+export function setTheme(theme: ThemePreference): void {
+  if (!VALID_VALUES.has(theme)) {
+    throw new Error(`Invalid theme preference: ${theme}`);
+  }
+  if (currentTheme === theme) {
+    persist(theme);
+    applyTheme(theme);
+    return;
+  }
+  currentTheme = theme;
+  persist(theme);
+  applyTheme(theme);
+  notify();
+}
+
+export function onThemeChange(listener: (theme: ThemePreference) => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export interface ThemeToggleInstance {
+  element: HTMLLabelElement;
+  destroy(): void;
+}
+
+export function createThemeToggle(): ThemeToggleInstance {
+  initTheme();
+
+  const container = document.createElement("label");
+  container.className = "theme-toggle";
+
+  const text = document.createElement("span");
+  text.className = "theme-toggle__label";
+  text.textContent = "Theme";
+
+  const select = document.createElement("select");
+  select.name = "theme";
+  select.className = "theme-toggle__select";
+  select.setAttribute("aria-label", "Select theme preference");
+
+  const options: Array<{ value: ThemePreference; label: string }> = [
+    { value: "system", label: "System" },
+    { value: "light", label: "Light" },
+    { value: "dark", label: "Dark" },
+  ];
+
+  for (const option of options) {
+    const opt = document.createElement("option");
+    opt.value = option.value;
+    opt.textContent = option.label;
+    select.appendChild(opt);
+  }
+
+  select.value = getTheme();
+
+  select.addEventListener("change", () => {
+    const next = select.value as ThemePreference;
+    setTheme(next);
+  });
+
+  container.append(text, select);
+
+  const unsubscribe = onThemeChange((theme) => {
+    if (select.value !== theme) {
+      select.value = theme;
+    }
+  });
+
+  return {
+    element: container,
+    destroy() {
+      unsubscribe();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a theme controller with persisted toggle and restructure theme tokens for explicit light/dark handling
- introduce documented responsive utility classes and collapse the sidebar/toolbar layouts at narrow widths
- refine footer and files view spacing for small screens and add responsive utility documentation

## Testing
- npm run typecheck *(fails: pre-existing EmptyState type errors)*
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cbd878d088832aba1c34256cb1dbe2