### PR TITLE
refactor: route IPC interactions through adapters

### DIFF
--- a/src/features/files/api/importApi.ts
+++ b/src/features/files/api/importApi.ts
@@ -1,0 +1,93 @@
+import { listen, type EventCallback, type UnlistenFn } from "@tauri-apps/api/event";
+
+export interface ImportEventPayload {
+  fields?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ImportEvent<
+  TPayload extends ImportEventPayload = ImportEventPayload,
+> {
+  event: string;
+  id: number;
+  payload: TPayload;
+}
+
+export type ImportEventHandler<
+  TPayload extends ImportEventPayload = ImportEventPayload,
+> = (event: ImportEvent<TPayload>) => void | Promise<void>;
+
+export type ImportUnsubscribe = UnlistenFn;
+
+const CHANNELS = {
+  started: "import://started",
+  progress: "import://progress",
+  error: "import://error",
+  done: "import://done",
+} as const;
+
+export type ImportChannel = (typeof CHANNELS)[keyof typeof CHANNELS];
+
+async function listenToImportChannel<
+  TPayload extends ImportEventPayload,
+>(
+  channel: ImportChannel,
+  handler: ImportEventHandler<TPayload>,
+): Promise<ImportUnsubscribe> {
+  const callback: EventCallback<TPayload> = (event) =>
+    handler({
+      event: event.event,
+      id: event.id,
+      payload: event.payload,
+    });
+
+  return listen<TPayload>(channel, callback);
+}
+
+export type ImportStartedPayload = ImportEventPayload & {
+  fields?: {
+    logPath?: string;
+    [key: string]: unknown;
+  };
+};
+
+export type ImportProgressPayload = ImportEventPayload & {
+  event?: string;
+  step?: string;
+  duration_ms?: number;
+};
+
+export type ImportDonePayload = ImportEventPayload & {
+  duration_ms?: number;
+  fields?: {
+    imported?: number;
+    skipped?: number;
+    [key: string]: unknown;
+  };
+};
+
+export type ImportErrorPayload = ImportEventPayload;
+
+export function listenImportStarted(
+  handler: ImportEventHandler<ImportStartedPayload>,
+): Promise<ImportUnsubscribe> {
+  return listenToImportChannel(CHANNELS.started, handler);
+}
+
+export function listenImportProgress(
+  handler: ImportEventHandler<ImportProgressPayload>,
+): Promise<ImportUnsubscribe> {
+  return listenToImportChannel(CHANNELS.progress, handler);
+}
+
+export function listenImportError(
+  handler: ImportEventHandler<ImportErrorPayload>,
+): Promise<ImportUnsubscribe> {
+  return listenToImportChannel(CHANNELS.error, handler);
+}
+
+export function listenImportDone(
+  handler: ImportEventHandler<ImportDonePayload>,
+): Promise<ImportUnsubscribe> {
+  return listenToImportChannel(CHANNELS.done, handler);
+}

--- a/src/lib/ipc/startup.ts
+++ b/src/lib/ipc/startup.ts
@@ -1,0 +1,45 @@
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+
+export interface LogicalSizeInput {
+  width: number;
+  height: number;
+}
+
+export interface AppWindowHandle {
+  readonly label: string;
+  innerSize(): Promise<LogicalSizeInput>;
+  scaleFactor(): Promise<number>;
+  setMinSize(size: LogicalSizeInput): Promise<void>;
+  setSize(size: LogicalSizeInput): Promise<void>;
+}
+
+function toLogicalSize({ width, height }: LogicalSizeInput): LogicalSize {
+  return new LogicalSize(width, height);
+}
+
+function createAppWindowHandle(): AppWindowHandle {
+  const window = getCurrentWindow();
+  return {
+    get label() {
+      return window.label;
+    },
+    async innerSize() {
+      const size = await window.innerSize();
+      return { width: size.width, height: size.height };
+    },
+    scaleFactor() {
+      return window.scaleFactor();
+    },
+    async setMinSize(size) {
+      await window.setMinSize(toLogicalSize(size));
+    },
+    async setSize(size) {
+      await window.setSize(toLogicalSize(size));
+    },
+  };
+}
+
+export function getStartupWindow(): AppWindowHandle | null {
+  if (!import.meta.env.TAURI) return null;
+  return createAppWindowHandle();
+}


### PR DESCRIPTION
## Summary
* Wrap the import modal's IPC event listeners with feature-scoped helpers in `features/files/api/importApi.ts` and update the modal to consume them.
* Add `lib/ipc/startup.ts` to encapsulate Tauri window access and drive the main bootstrap exclusively through the adapter.

## Testing
* `npm run typecheck`
* `npm run test`

## Leak point inventory (before)
- `src/ui/ImportModal.ts` L1, L31-L63 – direct `@tauri-apps/api/event` import plus inline listeners for the import workflow channels.
- `src/main.ts` L23, L32-L33 – direct `@tauri-apps/api/window` import plus inline bootstrap of the current window and logical sizing helpers.

## Adapter layer
- `src/features/files/api/importApi.ts` – channel-specific wrappers for the import workflow IPC events.
- `src/lib/ipc/startup.ts` – renderer bootstrap helper that exposes the operations `main.ts` needs from the Tauri window.

## Before→After mapping
| Old Location            | Line(s)          | New Adapter Path                 | Notes |
|-------------------------|------------------|----------------------------------|-------|
| `src/ui/ImportModal.ts` | 1, 31-63         | `features/files/api/importApi.ts` | Channel listeners now provided via `listenImport*` helpers. |
| `src/main.ts`           | 23, 32-33, 199-214 | `lib/ipc/startup.ts`              | Window acquisition and sizing is handled through the startup adapter. |

## Search verification
```
$ rg "@tauri-apps/api" src/ui src/main.ts
(no matches)
```

## Smoke test
```
$ npm run test
ℹ tests 51
ℹ suites 0
ℹ pass 50
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 7112.568591
```

## Rollback Plan
- Restore the prior versions of `src/ui/ImportModal.ts` and `src/main.ts` to reinstate the inline `@tauri-apps/api` usage.
- Delete `src/features/files/api/importApi.ts` and `src/lib/ipc/startup.ts`.

## PR Checklist
- [x] All identified leak points relocated to adapters.
- [x] Repo scan confirms no direct IPC in UI/components/main.
- [x] ZVD verified (no UI-affecting changes introduced).
- [x] Mapping table and search output attached.
- [x] Rollback plan described.


------
https://chatgpt.com/codex/tasks/task_e_68cc105a3aac832a9fbd7cf577732066