### PR TITLE
Define feature barrels & update consumers

### DIFF
--- a/src/CalendarView.ts
+++ b/src/CalendarView.ts
@@ -6,7 +6,7 @@ import {
 } from "./notification";
 import { nowMs } from "./db/time";
 import { defaultHouseholdId } from "./db/household";
-import type { Event } from "./models";
+import type { CalendarEvent } from "@features/calendar";
 import {
   actions,
   selectors,
@@ -28,10 +28,10 @@ function defaultWindow(): { start: number; end: number } {
 
 async function fetchEvents(
   windowRange: { start: number; end: number } = defaultWindow(),
-): Promise<{ items: Event[]; window: { start: number; end: number } }> {
+): Promise<{ items: CalendarEvent[]; window: { start: number; end: number } }> {
   const hh = await defaultHouseholdId();
   console.log("events_list_range window", windowRange);
-  const items = await call<Event[]>("events_list_range", {
+  const items = await call<CalendarEvent[]>("events_list_range", {
     householdId: hh,
     start: windowRange.start,
     end: windowRange.end,
@@ -40,15 +40,18 @@ async function fetchEvents(
 }
 
 async function saveEvent(
-  event: Omit<Event, "id" | "created_at" | "updated_at" | "household_id" | "deleted_at">,
-): Promise<Event> {
+  event: Omit<
+    CalendarEvent,
+    "id" | "created_at" | "updated_at" | "household_id" | "deleted_at"
+  >,
+): Promise<CalendarEvent> {
   const hh = await defaultHouseholdId();
-  return await call<Event>("event_create", {
+  return await call<CalendarEvent>("event_create", {
     data: { ...event, household_id: hh },
   });
 }
 
-function renderMonth(root: HTMLElement, events: Event[]) {
+function renderMonth(root: HTMLElement, events: CalendarEvent[]) {
   root.innerHTML = "";
   const now = new Date(nowMs());
   const year = now.getFullYear();
@@ -118,7 +121,7 @@ function renderMonth(root: HTMLElement, events: Event[]) {
   root.appendChild(table);
 }
 
-async function scheduleNotifications(events: Event[]) {
+async function scheduleNotifications(events: CalendarEvent[]) {
   let granted = await isPermissionGranted();
   if (!granted) {
     granted = (await requestPermission()) === "granted";

--- a/src/FilesView.ts
+++ b/src/FilesView.ts
@@ -22,11 +22,12 @@ import {
 } from './store';
 import { emit, on } from './store/events';
 import { runViewCleanups, registerViewCleanup } from './utils/viewLifecycle';
-import createFilesList, {
+import {
+  createFilesList,
+  createFilesToolbar,
   type FilesListItem,
   type FilesListRowAction,
-} from '@features/files/components/FilesList';
-import createFilesToolbar from '@features/files/components/FilesToolbar';
+} from '@features/files';
 import createButton from '@ui/Button';
 
 const ROOT: RootKey = 'attachments';

--- a/src/NotesView.ts
+++ b/src/NotesView.ts
@@ -3,7 +3,7 @@ import { openDb } from "./db/open";
 import { newUuidV7 } from "./db/id";
 import { defaultHouseholdId } from "./db/household";
 import { showError } from "./ui/errors";
-import type { Note } from "./models";
+import type { Note } from "@features/notes";
 import {
   actions,
   selectors,

--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -1,5 +1,9 @@
 import { writeText } from "@lib/ipc/clipboard";
-import { fetchAboutMetadata, fetchDiagnosticsSummary, openDiagnosticsDoc } from "./api/diagnostics";
+import {
+  fetchAboutMetadata,
+  fetchDiagnosticsSummary,
+  openDiagnosticsDoc,
+} from "@features/settings";
 import { createEmptyState } from "./ui/EmptyState";
 import { STR } from "./ui/strings";
 import createButton from "@ui/Button";

--- a/src/features/calendar/index.ts
+++ b/src/features/calendar/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Event as CalendarEvent } from "@bindings/Event";

--- a/src/features/files/index.ts
+++ b/src/features/files/index.ts
@@ -1,1 +1,28 @@
-export {};
+export { default as createFilesList } from "./components/FilesList";
+export type {
+  FilesListInstance,
+  FilesListItem,
+  FilesListProps,
+  FilesListRowAction,
+} from "./components/FilesList";
+
+export { default as createFilesToolbar } from "./components/FilesToolbar";
+export type { FilesToolbarInstance, FilesToolbarProps } from "./components/FilesToolbar";
+
+export {
+  listenImportDone,
+  listenImportError,
+  listenImportProgress,
+  listenImportStarted,
+} from "./api/importApi";
+export type {
+  ImportChannel,
+  ImportDonePayload,
+  ImportErrorPayload,
+  ImportEvent,
+  ImportEventHandler,
+  ImportEventPayload,
+  ImportProgressPayload,
+  ImportStartedPayload,
+  ImportUnsubscribe,
+} from "./api/importApi";

--- a/src/features/notes/index.ts
+++ b/src/features/notes/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Note } from "./model/note";

--- a/src/features/notes/model/note.ts
+++ b/src/features/notes/model/note.ts
@@ -1,0 +1,13 @@
+export interface Note {
+  id: string;
+  text: string;
+  color: string;
+  x: number;
+  y: number;
+  z?: number;
+  household_id?: string;
+  position: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at?: number | null;
+}

--- a/src/features/settings/api/diagnostics.ts
+++ b/src/features/settings/api/diagnostics.ts
@@ -1,4 +1,4 @@
-import { call } from "./call";
+import { call } from "@lib/ipc/call";
 
 export interface DiagnosticsSummary {
   platform: string;

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,1 +1,6 @@
-export {};
+export {
+  fetchAboutMetadata,
+  fetchDiagnosticsSummary,
+  openDiagnosticsDoc,
+} from "./api/diagnostics";
+export type { AboutMetadata, DiagnosticsSummary } from "./api/diagnostics";

--- a/src/models.ts
+++ b/src/models.ts
@@ -146,20 +146,6 @@ export interface Expense {
   deleted_at?: number;
 }
 
-export interface Note {
-  id: string;
-  text: string;
-  color: string;
-  x: number;
-  y: number;
-  z?: number;
-  household_id?: string;
-  position: number;
-  created_at: number;
-  updated_at: number;
-  deleted_at?: number | null;
-}
-
 export interface ShoppingItem {
   id: string;
   text: string;

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -10,12 +10,12 @@ import type {
   PetMedicalRecord,
   FamilyMember,
   InventoryItem,
-  Note,
   ShoppingItem,
   Event,
   BudgetCategory,
   Expense,
 } from "./models";
+import type { Note } from "@features/notes";
 
 type ListOpts = {
   householdId: string;

--- a/src/repos/index.ts
+++ b/src/repos/index.ts
@@ -6,9 +6,9 @@ import type {
   Pet,
   FamilyMember,
   InventoryItem,
-  Note,
   ShoppingItem,
 } from "../models";
+import type { Note } from "@features/notes";
 import type { Event } from "../bindings/Event";
 
 export const billsRepo = createCrudRepo<Bill, NewRow<Bill>, PatchRow<Bill>>("bills");

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 import type { FsEntryLite as FsEntry } from "./types";
-import type { Event, Note } from "../models";
+import type { Note } from "@features/notes";
+import type { Event } from "../models";
 import type {
   FilesUpdatedPayload,
   EventsUpdatedPayload,

--- a/src/ui/ImportModal.ts
+++ b/src/ui/ImportModal.ts
@@ -7,7 +7,7 @@ import {
   listenImportError,
   listenImportProgress,
   listenImportStarted,
-} from "@features/files/api/importApi";
+} from "@features/files";
 
 export function ImportModal(el: HTMLElement) {
   el.innerHTML = `


### PR DESCRIPTION
## Summary
- add feature barrels for files, calendar, notes, and settings so their public surfaces are explicit
- update views and supporting UI to consume features via the barrels instead of deep or relative imports
- move the note model and diagnostics API into their respective features so the barrels no longer depend on app root modules while keeping the same public exports

## Testing
- `npm run typecheck`

## Feature public APIs
- files: createFilesList, createFilesToolbar, listenImportDone, listenImportError, listenImportProgress, listenImportStarted (plus FilesList*/FilesToolbar*/Import* types)
- calendar: CalendarEvent type (alias of bindings Event)
- notes: Note type (feature-owned model)
- settings: fetchAboutMetadata, fetchDiagnosticsSummary, openDiagnosticsDoc (plus AboutMetadata, DiagnosticsSummary types)

## Import mappings
| Before | After |
| --- | --- |
| `@features/files/components/FilesList` | `@features/files` |
| `@features/files/components/FilesToolbar` | `@features/files` |
| `@features/files/api/importApi` | `@features/files` |
| `./models` (CalendarView) | `@features/calendar` |
| `./models` (NotesView) | `@features/notes` |
| `./api/diagnostics` | `@features/settings` |

## Compliance scan
```
$ rg "@features/.*/(components|api|model|hooks)" -n src
```
(no matches)


------
https://chatgpt.com/codex/tasks/task_e_68cc16853b50832ab067a91a378bb3f6