### PR TITLE
feat(migrations): add time indexes and startup guard for pending backfill

### DIFF
--- a/docs/v1-beta-gate/02-timekeeping/PR2.md
+++ b/docs/v1-beta-gate/02-timekeeping/PR2.md
@@ -43,13 +43,20 @@ This prevents silent performance issues and enforces data integrity before featu
 3. **Guard Demo (Pass):** Run on a DB after backfill → app starts normally; CLI exits 0.  
 4. **Idempotency Proof:** Run migration twice; indexes unchanged on second run.  
 5. **Error Copy:** Paste the exact failure message and ensure it is human-readable.  
-6. **Config Note:** Document the CLI flag/command for running the guard manually.  
+6. **Config Note:** Document the CLI flag/command for running the guard manually.
+
+---
+
+## Operations
+- Run the guard manually with `cargo run --bin migrate -- check` to view pending counts.
+- Apply the PR-1 timezone backfill via `cargo run --bin time-backfill -- --household-id <HOUSEHOLD> [--default-tz <TZ>]` (the guard refers to this as `backfill --apply`).
+- Dev-only bypass: set `ARKLOWDUN_SKIP_BACKFILL_GUARD=1` (ignored in release builds) when iterating locally.
 
 ---
 
 ## Rollback Plan
-- Dropping the new indexes is safe via `DROP INDEX IF EXISTS …`; no schema data loss.  
-- Migration guard logic can be disabled by reverting the startup check.  
+- Dropping the new indexes is safe via `DROP INDEX IF EXISTS …`; no schema data loss.
+- Migration guard logic can be disabled by reverting the startup check.
 - Document how to bypass guard temporarily in dev builds (env flag), but not in production.
 
 ---

--- a/migrations/0021_events_end_at_utc_index.down.sql
+++ b/migrations/0021_events_end_at_utc_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS events_household_end_at_utc_idx;

--- a/migrations/0021_events_end_at_utc_index.up.sql
+++ b/migrations/0021_events_end_at_utc_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS events_household_end_at_utc_idx ON events(household_id, end_at_utc);

--- a/src-tauri/schema.sql
+++ b/src-tauri/schema.sql
@@ -3,6 +3,7 @@ CREATE UNIQUE INDEX bills_household_position_idx ON bills(household_id, position
 CREATE INDEX bills_household_updated_idx ON bills(household_id, updated_at);
 CREATE UNIQUE INDEX budget_categories_household_position_idx ON budget_categories(household_id, position) WHERE deleted_at IS NULL;
 CREATE INDEX budget_categories_household_updated_idx ON budget_categories(household_id, updated_at);
+CREATE INDEX events_household_end_at_utc_idx ON events(household_id, end_at_utc);
 CREATE INDEX events_household_start_at_utc_idx ON events(household_id, start_at_utc);
 CREATE INDEX events_household_updated_idx ON events(household_id, updated_at);
 CREATE INDEX expenses_category_date_idx ON expenses(category_id, date);

--- a/src-tauri/src/migration_guard.rs
+++ b/src-tauri/src/migration_guard.rs
@@ -1,0 +1,164 @@
+use anyhow::{anyhow, Result};
+use sqlx::{Row, SqlitePool};
+use std::collections::HashSet;
+use tracing::{error, info, warn};
+
+pub const BACKFILL_GUARD_BYPASS_ENV: &str = "ARKLOWDUN_SKIP_BACKFILL_GUARD";
+
+#[derive(Debug, Clone)]
+pub struct HouseholdBackfillStatus {
+    pub household_id: String,
+    pub missing_start_at_utc: i64,
+    pub missing_end_at_utc: i64,
+    pub missing_total: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackfillGuardStatus {
+    pub total_missing: i64,
+    pub households: Vec<HouseholdBackfillStatus>,
+}
+
+pub fn format_guard_failure(total_missing: i64) -> String {
+    format!(
+        "Backfill required: {total_missing} events missing UTC values. Run backfill --apply before continuing."
+    )
+}
+
+fn guard_bypass_enabled() -> bool {
+    let value = match std::env::var(BACKFILL_GUARD_BYPASS_ENV) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let enabled = matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES");
+    if cfg!(debug_assertions) {
+        enabled
+    } else {
+        if enabled {
+            warn!(
+                target: "arklowdun",
+                event = "backfill_guard_bypass_ignored",
+                env = BACKFILL_GUARD_BYPASS_ENV,
+                reason = "release_build"
+            );
+        }
+        false
+    }
+}
+
+pub async fn ensure_events_indexes(pool: &SqlitePool) -> Result<()> {
+    let rows = sqlx::query("PRAGMA index_list('events');")
+        .fetch_all(pool)
+        .await?;
+    let mut names = HashSet::new();
+    for row in rows {
+        if let Ok(name) = row.try_get::<String, _>("name") {
+            names.insert(name);
+        }
+    }
+    let has_start = names.contains("events_household_start_at_utc_idx");
+    let has_end = names.contains("events_household_end_at_utc_idx");
+    info!(
+        target: "arklowdun",
+        event = "events_index_check",
+        has_start_at_utc = has_start,
+        has_end_at_utc = has_end
+    );
+    let mut missing = Vec::new();
+    if !has_start {
+        missing.push("events_household_start_at_utc_idx");
+    }
+    if !has_end {
+        missing.push("events_household_end_at_utc_idx");
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        error!(
+            target: "arklowdun",
+            event = "events_index_missing",
+            missing = %missing.join(", ")
+        );
+        Err(anyhow!(format!(
+            "Missing required events index(es): {}. Run migrations before continuing.",
+            missing.join(", ")
+        )))
+    }
+}
+
+pub async fn check_events_backfill(pool: &SqlitePool) -> Result<BackfillGuardStatus> {
+    let rows = sqlx::query(
+        "SELECT household_id,
+                SUM(CASE WHEN start_at_utc IS NULL THEN 1 ELSE 0 END) AS missing_start,
+                SUM(CASE WHEN end_at IS NOT NULL AND end_at_utc IS NULL THEN 1 ELSE 0 END) AS missing_end,
+                COUNT(*) AS missing_total
+           FROM events
+          WHERE start_at_utc IS NULL
+             OR (end_at IS NOT NULL AND end_at_utc IS NULL)
+          GROUP BY household_id
+          ORDER BY household_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut households = Vec::with_capacity(rows.len());
+    let mut total_missing = 0i64;
+    for row in rows {
+        let household_id: String = row.try_get("household_id")?;
+        let missing_start: i64 = row.try_get("missing_start")?;
+        let missing_end: i64 = row.try_get("missing_end")?;
+        let missing_total: i64 = row.try_get("missing_total")?;
+        total_missing += missing_total;
+        households.push(HouseholdBackfillStatus {
+            household_id,
+            missing_start_at_utc: missing_start,
+            missing_end_at_utc: missing_end,
+            missing_total,
+        });
+    }
+
+    Ok(BackfillGuardStatus {
+        total_missing,
+        households,
+    })
+}
+
+pub async fn enforce_events_backfill_guard(pool: &SqlitePool) -> Result<BackfillGuardStatus> {
+    let status = check_events_backfill(pool).await?;
+    let pending_details: Vec<String> = status
+        .households
+        .iter()
+        .map(|h| format!("{}:{}", h.household_id, h.missing_total))
+        .collect();
+
+    info!(
+        target: "arklowdun",
+        event = "backfill_guard_status",
+        total_missing = status.total_missing,
+        households_with_pending = status.households.len(),
+        pending = %pending_details.join(", ")
+    );
+
+    if guard_bypass_enabled() {
+        warn!(
+            target: "arklowdun",
+            event = "backfill_guard_bypassed",
+            env = BACKFILL_GUARD_BYPASS_ENV,
+            total_missing = status.total_missing
+        );
+        return Ok(status);
+    }
+
+    if status.total_missing > 0 {
+        let message = format_guard_failure(status.total_missing);
+        error!(
+            target: "arklowdun",
+            event = "backfill_guard_blocked",
+            total_missing = status.total_missing,
+            message = %message
+        );
+        return Err(anyhow!(message));
+    }
+
+    Ok(status)
+}

--- a/src-tauri/tests/migrate_from_zero.rs
+++ b/src-tauri/tests/migrate_from_zero.rs
@@ -99,6 +99,7 @@ async fn migrate_from_zero_is_correct_and_idempotent() -> Result<()> {
     }
 
     assert_index_exists(&pool, "events_household_start_at_utc_idx").await?;
+    assert_index_exists(&pool, "events_household_end_at_utc_idx").await?;
 
     assert_fk_and_integrity_ok(&pool).await?;
 

--- a/src-tauri/tests/migrate_sample.rs
+++ b/src-tauri/tests/migrate_sample.rs
@@ -52,6 +52,18 @@ async fn migrate_fixture_sample_db() -> Result<()> {
         assert_eq!(name.as_deref(), Some(t), "expected table {t}");
     }
 
+    for idx in [
+        "events_household_start_at_utc_idx",
+        "events_household_end_at_utc_idx",
+    ] {
+        let found: Option<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type='index' AND name=?1")
+                .bind(idx)
+                .fetch_optional(&pool)
+                .await?;
+        assert_eq!(found.as_deref(), Some(idx), "expected index {idx}");
+    }
+
     // events new columns present
     let cols: Vec<String> = sqlx::query("PRAGMA table_info(events);")
         .fetch_all(&pool)

--- a/src-tauri/tests/migration_guard.rs
+++ b/src-tauri/tests/migration_guard.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use arklowdun_lib::{migrate, migration_guard};
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::SqlitePool;
+
+async fn setup_pool() -> Result<SqlitePool> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await?;
+    migrate::apply_migrations(&pool).await?;
+    sqlx::query(
+        "INSERT INTO household (id, name, created_at, updated_at) VALUES ('hh', 'Household', 0, 0)",
+    )
+    .execute(&pool)
+    .await?;
+    Ok(pool)
+}
+
+#[tokio::test]
+async fn guard_detects_pending_events() -> Result<()> {
+    let pool = setup_pool().await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, title, start_at, household_id, created_at, updated_at)
+         VALUES ('evt', 'Test', 0, 'hh', 0, 0)",
+    )
+    .execute(&pool)
+    .await?;
+
+    migration_guard::ensure_events_indexes(&pool).await?;
+    let status = migration_guard::check_events_backfill(&pool).await?;
+    assert_eq!(status.total_missing, 1);
+    assert_eq!(status.households.len(), 1);
+
+    let err = migration_guard::enforce_events_backfill_guard(&pool)
+        .await
+        .expect_err("guard should block when UTC values missing");
+    assert_eq!(err.to_string(), migration_guard::format_guard_failure(1));
+    Ok(())
+}
+
+#[tokio::test]
+async fn guard_allows_clean_database() -> Result<()> {
+    let pool = setup_pool().await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, title, start_at, start_at_utc, household_id, created_at, updated_at)
+         VALUES ('evt', 'Test', 0, 0, 'hh', 0, 0)",
+    )
+    .execute(&pool)
+    .await?;
+
+    migration_guard::ensure_events_indexes(&pool).await?;
+    let status = migration_guard::enforce_events_backfill_guard(&pool).await?;
+    assert_eq!(status.total_missing, 0);
+    Ok(())
+}

--- a/src-tauri/tests/rollback.rs
+++ b/src-tauri/tests/rollback.rs
@@ -127,6 +127,7 @@ async fn rollback_all_migrations_leaves_clean_db() -> Result<()> {
         assert_table_exists(&pool, t).await?;
     }
     assert_index_exists(&pool, "events_household_start_at_utc_idx").await?;
+    assert_index_exists(&pool, "events_household_end_at_utc_idx").await?;
     assert_fk_and_integrity_ok(&pool).await?;
 
     let expected = list_up_versions()?;


### PR DESCRIPTION
## Scope
- Create or validate supporting indexes for `events` and related tables:
  - `(household_id, start_at_utc)`
  - `(household_id, end_at_utc)` if relevant
  - Any legacy indexes that must be dropped/replaced should be documented.
- Implement a migration guard that runs on startup:
  - Detects if there are events with `*_utc` fields still null after PR-1.
  - If found, the app aborts with a clear, actionable error (both in CLI and UI contexts).
- Provide a CLI subcommand to run only the migration guard check, printing a summary of pending backfill.

## Non-Goals
- No actual backfill logic — this was delivered in PR-1.
- No UI/UX for managing backfill — only a technical guard and index enforcement.
- No advanced indexing strategies (e.g. covering or partial indexes) unless performance evidence demands them.

## Acceptance Criteria
- **Index Creation:** On a clean schema, required indexes are present after migration.
- **Idempotency:** Running migration multiple times does not duplicate indexes.
- **Guard Behaviour:**
  - If pending rows exist, app startup fails fast with clear message: “Backfill required: X events missing UTC values. Run backfill --apply before continuing.”
  - If no pending rows, startup proceeds normally.
- **CLI Command:** `migrate:check` reports counts of pending rows and exits 0 if clean, non-zero if backfill required.
- **Cross-Platform:** Guard must work in dev, test, and production builds with identical logic.
- **Logging:** Logs include index verification result and backfill requirement status.

## Evidence
1. **Schema Snapshot (`PRAGMA index_list(events)` before/after 0021)**
   ```
   $ sqlite3 /tmp/events_before.iFFp.sqlite "PRAGMA index_list(events);"
   0|idx_events_household_title|0|c|0
   1|idx_events_household_rrule|0|c|0
   2|events_household_start_at_utc_idx|0|c|0
   3|idx_events_household_active|0|c|1
   4|events_household_updated_idx|0|c|0
   5|sqlite_autoindex_events_1|1|pk|0

   $ sqlite3 /tmp/events_before.iFFp.sqlite "PRAGMA index_list(events);"
   0|events_household_end_at_utc_idx|0|c|0
   1|idx_events_household_title|0|c|0
   2|idx_events_household_rrule|0|c|0
   3|events_household_start_at_utc_idx|0|c|0
   4|idx_events_household_active|0|c|1
   5|events_household_updated_idx|0|c|0
   6|sqlite_autoindex_events_1|1|pk|0
   ```
2. **Guard Demo (Fail) — CLI exits non-zero**
   ```
   $ cargo run --manifest-path src-tauri/Cargo.toml --bin migrate -- --db /tmp/guard_fail.LQvx.sqlite check
   {"timestamp":"…","event":"events_index_check","has_start_at_utc":true,"has_end_at_utc":true}
   Database: /tmp/guard_fail.LQvx.sqlite
   Households with events missing UTC fields:
     h1: start_at_utc missing 1, end_at_utc missing 0, total 1
   Error: Backfill required: 1 events missing UTC values. Run backfill --apply before continuing.

   $ echo $?
   1
   ```
3. **Guard Demo (Pass) — CLI exits zero**
   ```
   $ cargo run --manifest-path src-tauri/Cargo.toml --bin migrate -- --db /tmp/guard_fail.LQvx.sqlite check
   {"timestamp":"…","event":"events_index_check","has_start_at_utc":true,"has_end_at_utc":true}
   Database: /tmp/guard_fail.LQvx.sqlite
   All events have UTC timestamps. Backfill guard OK.

   $ echo $?
   0
   ```
4. **Idempotency Proof**
   ```
   $ cargo run --manifest-path src-tauri/Cargo.toml --bin migrate -- --db /tmp/events_before.iFFp.sqlite up
   Nothing to apply.
   ```
5. **Error Copy**
   > Backfill required: 1 events missing UTC values. Run backfill --apply before continuing.
6. **Config Note**
   - Run the guard manually with `cargo run --bin migrate -- check`.
   - Dev-only bypass: set `ARKLOWDUN_SKIP_BACKFILL_GUARD=1` (ignored in release builds) when iterating locally.

## Rollback Plan
- Dropping the new indexes is safe via `DROP INDEX IF EXISTS …`; no schema data loss.
- Migration guard logic can be disabled by reverting the startup check.
- Document how to bypass guard temporarily in dev builds (env flag), but not in production.

------
https://chatgpt.com/codex/tasks/task_e_68cc5c063430832ab2d64b394f03069f