### PR TITLE
test(recurrence): add RRULE matrix across core fields and timezones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,32 @@ jobs:
           name: time-invariants-logs-${{ runner.os }}
           path: test-results/*.log
 
+  gate_rrule_matrix:
+    name: gate/rrule-matrix
+    runs-on: ubuntu-latest
+    needs: [lint, unit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            sqlite3
+      - name: Run RRULE matrix tests
+        run: |
+          set -euxo pipefail
+          cargo test --locked --manifest-path src-tauri/Cargo.toml --test rrule_matrix -- --nocapture
+
   gate_time_invariants_tests_macos:
     name: gate/time-invariants-tests (macOS)
     runs-on: macos-latest

--- a/docs/recurrence-matrix.md
+++ b/docs/recurrence-matrix.md
@@ -1,0 +1,71 @@
+# RRULE Recurrence Matrix
+
+The recurrence matrix tests (`tests/rrule_matrix.rs`) exercise the event
+expansion engine across the core RRULE fields defined in [RFC 5545,
+section 3.3.10](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10).
+Each scenario seeds a series into an in-memory database, expands
+`events_list_range`, and compares the results to deterministic snapshots
+under `tests/rrule_snapshots/`.
+
+## Scenario Coverage
+
+| Scenario | Timezone | RRULE Fields | Notes |
+| --- | --- | --- | --- |
+| `daily_london_dst` | Europe/London | `FREQ=DAILY;COUNT=5` | Spring DST forward; validates UTC shift while preserving wall-clock start. |
+| `weekly_new_york_byday` | America/New_York | `FREQ=WEEKLY;INTERVAL=2;BYDAY=SU;UNTIL=20241117T063000Z` | Fall DST back; ambiguous hour resolves to earlier offset per policy. |
+| `monthly_tokyo_bymonthday` | Asia/Tokyo | `FREQ=MONTHLY;INTERVAL=1;COUNT=6;BYMONTHDAY=10,20;BYHOUR=9;BYMINUTE=30` | No DST region; exercises BYMONTHDAY + BYHOUR/BYMINUTE combinations. |
+| `yearly_london_leap` | Europe/London | `FREQ=YEARLY;COUNT=4;BYMONTH=2;BYMONTHDAY=29` | Leap-day annual recurrence; verifies skipping non-leap years. |
+
+The snapshot metadata records the timezone database revision so drift
+from tzdb upgrades is obvious in review. All scenarios assert that a
+second expansion produces an identical vector to confirm deterministic
+ordering.
+
+## Updating Snapshots
+
+```bash
+# Regenerate all snapshots (writes into tests/rrule_snapshots/)
+UPDATE_RRULE_SNAPSHOTS=1 cargo test --locked \
+  --manifest-path src-tauri/Cargo.toml --test rrule_matrix -- --nocapture
+
+# Verify without touching snapshot files
+cargo test --locked --manifest-path src-tauri/Cargo.toml \
+  --test rrule_matrix -- --nocapture
+```
+
+Snapshots are committed to version control. When behaviour legitimately
+changes, regenerate them with the environment variable above and commit
+the diff alongside the code change.
+
+## Fixture Example
+
+The daily London fixture spans the 2024 spring-forward change. The
+snapshot (`tests/rrule_snapshots/daily_london_dst.json`) captures the
+offset jump:
+
+```json
+{
+  "timezone": "Europe/London",
+  "rrule": "FREQ=DAILY;COUNT=5",
+  "instances": [
+    { "local_start": "2024-03-29T22:15:00+00:00" },
+    { "local_start": "2024-03-30T22:15:00+00:00" },
+    { "local_start": "2024-03-31T22:15:00+01:00" }
+  ]
+}
+```
+
+## Snapshot Drift Example
+
+Intentionally editing a snapshot triggers a diff in the gate. For
+example, bumping the first local time to `22:30` yields the following
+failure (excerpt):
+
+```
+snapshot mismatch for daily_london_dst at tests/rrule_snapshots/daily_london_dst.json
+-      "local_start": "2024-03-29T22:30:00+00:00",
++      "local_start": "2024-03-29T22:15:00+00:00",
+```
+
+CI job `gate/rrule-matrix` runs the suite on every pull request so any
+unexpected drift is caught automatically.

--- a/src-tauri/tests/rrule_matrix.rs
+++ b/src-tauri/tests/rrule_matrix.rs
@@ -1,0 +1,355 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use arklowdun_lib::{commands, migrate};
+use chrono::{DateTime, LocalResult, NaiveDateTime, Offset, SecondsFormat, TimeZone, Utc};
+use chrono_tz::Tz;
+#[cfg(chrono_tz_has_iana_version)]
+use chrono_tz::IANA_TZDB_VERSION;
+use serde::{Deserialize, Serialize};
+use similar::TextDiff;
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    SqlitePool,
+};
+
+#[derive(Debug, Clone)]
+struct Scenario {
+    name: &'static str,
+    description: &'static str,
+    timezone: &'static str,
+    local_start: &'static str,
+    local_end: &'static str,
+    rrule: &'static str,
+    range_start_utc: &'static str,
+    range_end_utc: &'static str,
+}
+
+impl Scenario {
+    fn tz(&self) -> Tz {
+        self.timezone
+            .parse()
+            .unwrap_or_else(|_| panic!("unknown timezone: {}", self.timezone))
+    }
+
+    fn event_id(&self) -> String {
+        format!("series-{}", self.name)
+    }
+
+    fn household_id(&self) -> String {
+        format!("HH-{}", self.name)
+    }
+
+    fn snapshot_path(&self) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/rrule_snapshots")
+            .join(format!("{}.json", self.name))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SnapshotData {
+    scenario: String,
+    description: String,
+    timezone: String,
+    tzdb: String,
+    dtstart_local: String,
+    dtend_local: String,
+    rrule: String,
+    range_start_utc: String,
+    range_end_utc: String,
+    expected_count: usize,
+    instances: Vec<InstanceRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct InstanceRecord {
+    index: usize,
+    id: String,
+    start_utc: String,
+    end_utc: String,
+    local_start: String,
+    local_end: String,
+    weekday: String,
+    offset_seconds: i32,
+    duration_minutes: i64,
+}
+
+static SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "daily_london_dst",
+        description: "Daily 22:15 meeting spanning the Europe/London spring DST change",
+        timezone: "Europe/London",
+        local_start: "2024-03-29T22:15",
+        local_end: "2024-03-29T23:00",
+        rrule: "FREQ=DAILY;COUNT=5",
+        range_start_utc: "2024-03-29T00:00:00Z",
+        range_end_utc: "2024-04-04T00:00:00Z",
+    },
+    Scenario {
+        name: "weekly_new_york_byday",
+        description: "Bi-weekly Sunday 01:30 event across the America/New_York fall DST transition",
+        timezone: "America/New_York",
+        local_start: "2024-10-20T01:30",
+        local_end: "2024-10-20T02:30",
+        rrule: "FREQ=WEEKLY;INTERVAL=2;BYDAY=SU;UNTIL=20241117T063000Z",
+        range_start_utc: "2024-10-01T00:00:00Z",
+        range_end_utc: "2024-11-30T00:00:00Z",
+    },
+    Scenario {
+        name: "monthly_tokyo_bymonthday",
+        description: "Monthly series on the 10th and 20th in Asia/Tokyo exercising BYMONTHDAY/BYHOUR/BYMINUTE",
+        timezone: "Asia/Tokyo",
+        local_start: "2024-01-10T09:30",
+        local_end: "2024-01-10T11:00",
+        rrule: "FREQ=MONTHLY;INTERVAL=1;COUNT=6;BYMONTHDAY=10,20;BYHOUR=9;BYMINUTE=30",
+        range_start_utc: "2023-12-31T15:00:00Z",
+        range_end_utc: "2024-03-31T23:59:59Z",
+    },
+    Scenario {
+        name: "yearly_london_leap",
+        description: "Leap day tradition anchored to 29 February using BYMONTH/BYMONTHDAY",
+        timezone: "Europe/London",
+        local_start: "2024-02-29T08:00",
+        local_end: "2024-02-29T10:00",
+        rrule: "FREQ=YEARLY;COUNT=4;BYMONTH=2;BYMONTHDAY=29",
+        range_start_utc: "2024-01-01T00:00:00Z",
+        range_end_utc: "2036-03-02T00:00:00Z",
+    },
+];
+
+#[tokio::test]
+async fn rrule_matrix_matches_snapshots() -> Result<()> {
+    for scenario in SCENARIOS {
+        run_scenario(scenario).await?;
+    }
+    Ok(())
+}
+
+async fn run_scenario(scenario: &Scenario) -> Result<()> {
+    let pool = setup_pool().await?;
+    seed_event(&pool, scenario).await?;
+
+    let range_start = parse_utc(scenario.range_start_utc)?;
+    let range_end = parse_utc(scenario.range_end_utc)?;
+
+    let household_id = scenario.household_id();
+    let first = commands::events_list_range_command(&pool, &household_id, range_start, range_end)
+        .await
+        .with_context(|| format!("expand recurrence for {}", scenario.name))?;
+    let second = commands::events_list_range_command(&pool, &household_id, range_start, range_end)
+        .await
+        .with_context(|| format!("second expansion for {}", scenario.name))?;
+    assert_eq!(first.len(), second.len(), "{} count drift", scenario.name);
+
+    let tz = scenario.tz();
+    let first_records = records_from_instances(&first, &tz)?;
+    let second_records = records_from_instances(&second, &tz)?;
+    assert_eq!(
+        first_records, second_records,
+        "{} ordering drift",
+        scenario.name
+    );
+
+    let snapshot = SnapshotData {
+        scenario: scenario.name.to_string(),
+        description: scenario.description.to_string(),
+        timezone: scenario.timezone.to_string(),
+        tzdb: tzdb_label(),
+        dtstart_local: scenario.local_start.to_string(),
+        dtend_local: scenario.local_end.to_string(),
+        rrule: scenario.rrule.to_string(),
+        range_start_utc: scenario.range_start_utc.to_string(),
+        range_end_utc: scenario.range_end_utc.to_string(),
+        expected_count: first_records.len(),
+        instances: first_records,
+    };
+
+    compare_with_snapshot(&snapshot, &scenario.snapshot_path())
+        .with_context(|| format!("compare snapshot for {}", scenario.name))?;
+
+    Ok(())
+}
+
+fn chrono_tz_version() -> &'static str {
+    option_env!("CHRONO_TZ_CRATE_VERSION").unwrap_or("unknown")
+}
+
+#[cfg(chrono_tz_has_iana_version)]
+fn tzdb_revision() -> Option<&'static str> {
+    Some(IANA_TZDB_VERSION)
+}
+
+#[cfg(not(chrono_tz_has_iana_version))]
+fn tzdb_revision() -> Option<&'static str> {
+    None
+}
+
+fn tzdb_label() -> String {
+    match tzdb_revision() {
+        Some(rev) => format!("{rev} (chrono-tz {})", chrono_tz_version()),
+        None => format!("chrono-tz {}", chrono_tz_version()),
+    }
+}
+
+fn parse_local_naive(s: &str) -> Result<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M"))
+        .with_context(|| format!("parse local naive datetime: {s}"))
+}
+
+fn resolve_local(tz: &Tz, naive: NaiveDateTime) -> DateTime<Tz> {
+    match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(first, _second) => first,
+        LocalResult::None => tz
+            .offset_from_utc_datetime(&naive)
+            .fix()
+            .from_utc_datetime(&naive)
+            .with_timezone(tz),
+    }
+}
+
+fn parse_utc(s: &str) -> Result<i64> {
+    Ok(DateTime::parse_from_rfc3339(s)
+        .with_context(|| format!("parse utc instant: {s}"))?
+        .with_timezone(&Utc)
+        .timestamp_millis())
+}
+
+async fn setup_pool() -> Result<SqlitePool> {
+    let opts = SqliteConnectOptions::new()
+        .filename(":memory:")
+        .create_if_missing(true)
+        .foreign_keys(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(opts)
+        .await
+        .context("connect sqlite memory pool")?;
+    migrate::apply_migrations(&pool)
+        .await
+        .context("apply migrations")?;
+    Ok(pool)
+}
+
+async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
+    let tz = scenario.tz();
+    let start_local = resolve_local(&tz, parse_local_naive(scenario.local_start)?);
+    let end_local = resolve_local(&tz, parse_local_naive(scenario.local_end)?);
+    let start_at = start_local.naive_local().and_utc().timestamp_millis();
+    let end_at = end_local.naive_local().and_utc().timestamp_millis();
+    let start_at_utc = start_local.with_timezone(&Utc).timestamp_millis();
+    let end_at_utc = end_local.with_timezone(&Utc).timestamp_millis();
+
+    sqlx::query(
+        "INSERT INTO household (id, name, tz, created_at, updated_at, deleted_at) VALUES (?1, ?2, ?3, 0, 0, NULL)",
+    )
+    .bind(&scenario.household_id())
+    .bind(format!("Fixture household {}", scenario.name))
+    .bind(scenario.timezone)
+    .execute(pool)
+    .await
+    .with_context(|| format!("insert household for {}", scenario.name))?;
+
+    sqlx::query(
+        "INSERT INTO events (id, household_id, title, start_at, end_at, tz, start_at_utc, end_at_utc, rrule, exdates, reminder, created_at, updated_at, deleted_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL, 0, 0, NULL)",
+    )
+    .bind(&scenario.event_id())
+    .bind(&scenario.household_id())
+    .bind(format!("Scenario {}", scenario.name))
+    .bind(start_at)
+    .bind(end_at)
+    .bind(scenario.timezone)
+    .bind(start_at_utc)
+    .bind(end_at_utc)
+    .bind(scenario.rrule)
+    .execute(pool)
+    .await
+    .with_context(|| format!("insert event for {}", scenario.name))?;
+
+    Ok(())
+}
+
+fn records_from_instances(
+    instances: &[arklowdun_lib::Event],
+    tz: &Tz,
+) -> Result<Vec<InstanceRecord>> {
+    let mut out = Vec::with_capacity(instances.len());
+    for (index, instance) in instances.iter().enumerate() {
+        let start_utc = DateTime::<Utc>::from_timestamp_millis(instance.start_at)
+            .with_context(|| format!("instance {} missing start", instance.id))?;
+        let end_ms = instance
+            .end_at
+            .or(instance.end_at_utc)
+            .with_context(|| format!("instance {} missing end", instance.id))?;
+        let end_utc = DateTime::<Utc>::from_timestamp_millis(end_ms)
+            .with_context(|| format!("instance {} invalid end", instance.id))?;
+
+        if let Some(instance_tz) = &instance.tz {
+            assert_eq!(
+                instance_tz,
+                tz.name(),
+                "instance tz drift for {}",
+                instance.id
+            );
+        }
+
+        let local_start = start_utc.with_timezone(tz);
+        let local_end = end_utc.with_timezone(tz);
+        let offset_seconds = local_start.offset().fix().local_minus_utc();
+        let duration_minutes = (end_utc.timestamp_millis() - start_utc.timestamp_millis()) / 60_000;
+
+        out.push(InstanceRecord {
+            index,
+            id: instance.id.clone(),
+            start_utc: start_utc.to_rfc3339_opts(SecondsFormat::Secs, true),
+            end_utc: end_utc.to_rfc3339_opts(SecondsFormat::Secs, true),
+            local_start: local_start.format("%Y-%m-%dT%H:%M:%S%:z").to_string(),
+            local_end: local_end.format("%Y-%m-%dT%H:%M:%S%:z").to_string(),
+            weekday: local_start.format("%A").to_string(),
+            offset_seconds,
+            duration_minutes,
+        });
+    }
+
+    Ok(out)
+}
+
+fn compare_with_snapshot(snapshot: &SnapshotData, path: &Path) -> Result<()> {
+    let actual = serde_json::to_string_pretty(snapshot)?;
+    if std::env::var_os("UPDATE_RRULE_SNAPSHOTS").is_some() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create snapshot dir {parent:?}"))?;
+        }
+        fs::write(path, &actual).with_context(|| format!("write snapshot {}", path.display()))?;
+        return Ok(());
+    }
+
+    let expected =
+        fs::read_to_string(path).with_context(|| format!("read snapshot {}", path.display()))?;
+    if expected != actual {
+        let diff = TextDiff::from_lines(&expected, &actual)
+            .iter_all_changes()
+            .map(|change| {
+                let marker = match change.tag() {
+                    similar::ChangeTag::Delete => '-',
+                    similar::ChangeTag::Insert => '+',
+                    similar::ChangeTag::Equal => ' ',
+                };
+                format!("{marker}{}", change.value())
+            })
+            .collect::<String>();
+        anyhow::bail!(
+            "snapshot mismatch for {} at {}\n{}",
+            snapshot.scenario,
+            path.display(),
+            diff
+        );
+    }
+
+    Ok(())
+}

--- a/tests/rrule_snapshots/daily_london_dst.json
+++ b/tests/rrule_snapshots/daily_london_dst.json
@@ -1,0 +1,69 @@
+{
+  "scenario": "daily_london_dst",
+  "description": "Daily 22:15 meeting spanning the Europe/London spring DST change",
+  "timezone": "Europe/London",
+  "tzdb": "2025b (chrono-tz 0.10.4)",
+  "dtstart_local": "2024-03-29T22:15",
+  "dtend_local": "2024-03-29T23:00",
+  "rrule": "FREQ=DAILY;COUNT=5",
+  "range_start_utc": "2024-03-29T00:00:00Z",
+  "range_end_utc": "2024-04-04T00:00:00Z",
+  "expected_count": 5,
+  "instances": [
+    {
+      "index": 0,
+      "id": "series-daily_london_dst::1711750500000",
+      "start_utc": "2024-03-29T22:15:00Z",
+      "end_utc": "2024-03-29T23:00:00Z",
+      "local_start": "2024-03-29T22:15:00+00:00",
+      "local_end": "2024-03-29T23:00:00+00:00",
+      "weekday": "Friday",
+      "offset_seconds": 0,
+      "duration_minutes": 45
+    },
+    {
+      "index": 1,
+      "id": "series-daily_london_dst::1711836900000",
+      "start_utc": "2024-03-30T22:15:00Z",
+      "end_utc": "2024-03-30T23:00:00Z",
+      "local_start": "2024-03-30T22:15:00+00:00",
+      "local_end": "2024-03-30T23:00:00+00:00",
+      "weekday": "Saturday",
+      "offset_seconds": 0,
+      "duration_minutes": 45
+    },
+    {
+      "index": 2,
+      "id": "series-daily_london_dst::1711919700000",
+      "start_utc": "2024-03-31T21:15:00Z",
+      "end_utc": "2024-03-31T22:00:00Z",
+      "local_start": "2024-03-31T22:15:00+01:00",
+      "local_end": "2024-03-31T23:00:00+01:00",
+      "weekday": "Sunday",
+      "offset_seconds": 3600,
+      "duration_minutes": 45
+    },
+    {
+      "index": 3,
+      "id": "series-daily_london_dst::1712006100000",
+      "start_utc": "2024-04-01T21:15:00Z",
+      "end_utc": "2024-04-01T22:00:00Z",
+      "local_start": "2024-04-01T22:15:00+01:00",
+      "local_end": "2024-04-01T23:00:00+01:00",
+      "weekday": "Monday",
+      "offset_seconds": 3600,
+      "duration_minutes": 45
+    },
+    {
+      "index": 4,
+      "id": "series-daily_london_dst::1712092500000",
+      "start_utc": "2024-04-02T21:15:00Z",
+      "end_utc": "2024-04-02T22:00:00Z",
+      "local_start": "2024-04-02T22:15:00+01:00",
+      "local_end": "2024-04-02T23:00:00+01:00",
+      "weekday": "Tuesday",
+      "offset_seconds": 3600,
+      "duration_minutes": 45
+    }
+  ]
+}

--- a/tests/rrule_snapshots/monthly_tokyo_bymonthday.json
+++ b/tests/rrule_snapshots/monthly_tokyo_bymonthday.json
@@ -1,0 +1,80 @@
+{
+  "scenario": "monthly_tokyo_bymonthday",
+  "description": "Monthly series on the 10th and 20th in Asia/Tokyo exercising BYMONTHDAY/BYHOUR/BYMINUTE",
+  "timezone": "Asia/Tokyo",
+  "tzdb": "2025b (chrono-tz 0.10.4)",
+  "dtstart_local": "2024-01-10T09:30",
+  "dtend_local": "2024-01-10T11:00",
+  "rrule": "FREQ=MONTHLY;INTERVAL=1;COUNT=6;BYMONTHDAY=10,20;BYHOUR=9;BYMINUTE=30",
+  "range_start_utc": "2023-12-31T15:00:00Z",
+  "range_end_utc": "2024-03-31T23:59:59Z",
+  "expected_count": 6,
+  "instances": [
+    {
+      "index": 0,
+      "id": "series-monthly_tokyo_bymonthday::1704846600000",
+      "start_utc": "2024-01-10T00:30:00Z",
+      "end_utc": "2024-01-10T02:00:00Z",
+      "local_start": "2024-01-10T09:30:00+09:00",
+      "local_end": "2024-01-10T11:00:00+09:00",
+      "weekday": "Wednesday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    },
+    {
+      "index": 1,
+      "id": "series-monthly_tokyo_bymonthday::1705710600000",
+      "start_utc": "2024-01-20T00:30:00Z",
+      "end_utc": "2024-01-20T02:00:00Z",
+      "local_start": "2024-01-20T09:30:00+09:00",
+      "local_end": "2024-01-20T11:00:00+09:00",
+      "weekday": "Saturday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    },
+    {
+      "index": 2,
+      "id": "series-monthly_tokyo_bymonthday::1707525000000",
+      "start_utc": "2024-02-10T00:30:00Z",
+      "end_utc": "2024-02-10T02:00:00Z",
+      "local_start": "2024-02-10T09:30:00+09:00",
+      "local_end": "2024-02-10T11:00:00+09:00",
+      "weekday": "Saturday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    },
+    {
+      "index": 3,
+      "id": "series-monthly_tokyo_bymonthday::1708389000000",
+      "start_utc": "2024-02-20T00:30:00Z",
+      "end_utc": "2024-02-20T02:00:00Z",
+      "local_start": "2024-02-20T09:30:00+09:00",
+      "local_end": "2024-02-20T11:00:00+09:00",
+      "weekday": "Tuesday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    },
+    {
+      "index": 4,
+      "id": "series-monthly_tokyo_bymonthday::1710030600000",
+      "start_utc": "2024-03-10T00:30:00Z",
+      "end_utc": "2024-03-10T02:00:00Z",
+      "local_start": "2024-03-10T09:30:00+09:00",
+      "local_end": "2024-03-10T11:00:00+09:00",
+      "weekday": "Sunday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    },
+    {
+      "index": 5,
+      "id": "series-monthly_tokyo_bymonthday::1710894600000",
+      "start_utc": "2024-03-20T00:30:00Z",
+      "end_utc": "2024-03-20T02:00:00Z",
+      "local_start": "2024-03-20T09:30:00+09:00",
+      "local_end": "2024-03-20T11:00:00+09:00",
+      "weekday": "Wednesday",
+      "offset_seconds": 32400,
+      "duration_minutes": 90
+    }
+  ]
+}

--- a/tests/rrule_snapshots/weekly_new_york_byday.json
+++ b/tests/rrule_snapshots/weekly_new_york_byday.json
@@ -1,0 +1,47 @@
+{
+  "scenario": "weekly_new_york_byday",
+  "description": "Bi-weekly Sunday 01:30 event across the America/New_York fall DST transition",
+  "timezone": "America/New_York",
+  "tzdb": "2025b (chrono-tz 0.10.4)",
+  "dtstart_local": "2024-10-20T01:30",
+  "dtend_local": "2024-10-20T02:30",
+  "rrule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=SU;UNTIL=20241117T063000Z",
+  "range_start_utc": "2024-10-01T00:00:00Z",
+  "range_end_utc": "2024-11-30T00:00:00Z",
+  "expected_count": 3,
+  "instances": [
+    {
+      "index": 0,
+      "id": "series-weekly_new_york_byday::1729402200000",
+      "start_utc": "2024-10-20T05:30:00Z",
+      "end_utc": "2024-10-20T06:30:00Z",
+      "local_start": "2024-10-20T01:30:00-04:00",
+      "local_end": "2024-10-20T02:30:00-04:00",
+      "weekday": "Sunday",
+      "offset_seconds": -14400,
+      "duration_minutes": 60
+    },
+    {
+      "index": 1,
+      "id": "series-weekly_new_york_byday::1730611800000",
+      "start_utc": "2024-11-03T05:30:00Z",
+      "end_utc": "2024-11-03T06:30:00Z",
+      "local_start": "2024-11-03T01:30:00-04:00",
+      "local_end": "2024-11-03T01:30:00-05:00",
+      "weekday": "Sunday",
+      "offset_seconds": -14400,
+      "duration_minutes": 60
+    },
+    {
+      "index": 2,
+      "id": "series-weekly_new_york_byday::1731825000000",
+      "start_utc": "2024-11-17T06:30:00Z",
+      "end_utc": "2024-11-17T07:30:00Z",
+      "local_start": "2024-11-17T01:30:00-05:00",
+      "local_end": "2024-11-17T02:30:00-05:00",
+      "weekday": "Sunday",
+      "offset_seconds": -18000,
+      "duration_minutes": 60
+    }
+  ]
+}

--- a/tests/rrule_snapshots/yearly_london_leap.json
+++ b/tests/rrule_snapshots/yearly_london_leap.json
@@ -1,0 +1,58 @@
+{
+  "scenario": "yearly_london_leap",
+  "description": "Leap day tradition anchored to 29 February using BYMONTH/BYMONTHDAY",
+  "timezone": "Europe/London",
+  "tzdb": "2025b (chrono-tz 0.10.4)",
+  "dtstart_local": "2024-02-29T08:00",
+  "dtend_local": "2024-02-29T10:00",
+  "rrule": "FREQ=YEARLY;COUNT=4;BYMONTH=2;BYMONTHDAY=29",
+  "range_start_utc": "2024-01-01T00:00:00Z",
+  "range_end_utc": "2036-03-02T00:00:00Z",
+  "expected_count": 4,
+  "instances": [
+    {
+      "index": 0,
+      "id": "series-yearly_london_leap::1709193600000",
+      "start_utc": "2024-02-29T08:00:00Z",
+      "end_utc": "2024-02-29T10:00:00Z",
+      "local_start": "2024-02-29T08:00:00+00:00",
+      "local_end": "2024-02-29T10:00:00+00:00",
+      "weekday": "Thursday",
+      "offset_seconds": 0,
+      "duration_minutes": 120
+    },
+    {
+      "index": 1,
+      "id": "series-yearly_london_leap::1835424000000",
+      "start_utc": "2028-02-29T08:00:00Z",
+      "end_utc": "2028-02-29T10:00:00Z",
+      "local_start": "2028-02-29T08:00:00+00:00",
+      "local_end": "2028-02-29T10:00:00+00:00",
+      "weekday": "Tuesday",
+      "offset_seconds": 0,
+      "duration_minutes": 120
+    },
+    {
+      "index": 2,
+      "id": "series-yearly_london_leap::1961654400000",
+      "start_utc": "2032-02-29T08:00:00Z",
+      "end_utc": "2032-02-29T10:00:00Z",
+      "local_start": "2032-02-29T08:00:00+00:00",
+      "local_end": "2032-02-29T10:00:00+00:00",
+      "weekday": "Sunday",
+      "offset_seconds": 0,
+      "duration_minutes": 120
+    },
+    {
+      "index": 3,
+      "id": "series-yearly_london_leap::2087884800000",
+      "start_utc": "2036-02-29T08:00:00Z",
+      "end_utc": "2036-02-29T10:00:00Z",
+      "local_start": "2036-02-29T08:00:00+00:00",
+      "local_end": "2036-02-29T10:00:00+00:00",
+      "weekday": "Friday",
+      "offset_seconds": 0,
+      "duration_minutes": 120
+    }
+  ]
+}


### PR DESCRIPTION
Objective:
- Add automated coverage for RRULE expansion across core fields, DST transitions, and multiple timezones.

Scope:
- Introduced `tests/rrule_matrix.rs` with reusable scenario harnesses and snapshot assertions.
- Added deterministic snapshots under `tests/rrule_snapshots/` for London, New York, and Tokyo scenarios (including DST and leap year cases).
- Documented the matrix, update workflow, and failure mode in `docs/recurrence-matrix.md`.
- Wired a new CI job `gate/rrule-matrix` to run the suite on every PR.

Non-Goals:
- No RRULE engine changes or EXDATE/RDATE handling.
- No per-series cap enforcement (PR-8) or truncation UX (PR-13).

Acceptance Criteria:
- Scenarios cover DAILY/WEEKLY/MONTHLY/YEARLY with INTERVAL, COUNT, UNTIL, BYDAY, BYMONTH, BYMONTHDAY, BYHOUR, and BYMINUTE.
- Snapshot comparison ensures deterministic ordering and counts across runs.
- DST spring forward/backward and leap year behaviour captured in snapshots.
- CI will fail on snapshot drift via the new gate job.

Evidence:
- Fixture example (`tests/rrule_snapshots/daily_london_dst.json`) demonstrates the London spring-forward shift.
- Snapshots for weekly New York, monthly Tokyo, and yearly leap-day scenarios show expected behaviour.
- Passing test run: `cargo test --locked --manifest-path src-tauri/Cargo.toml --test rrule_matrix -- --nocapture`. {408dfc†L1-L5}
- Failure example after mutating a snapshot: {e4303a†L1-L42}

Rollback:
- Delete `tests/rrule_matrix.rs`, `tests/rrule_snapshots/`, `docs/recurrence-matrix.md`, and the `gate/rrule-matrix` job from CI.


------
https://chatgpt.com/codex/tasks/task_e_68ce63b593f0832a94361d308c085ef4