### PR TITLE
docs(rdate): document exclusion of RDATE support from v1

### DIFF
--- a/docs/rdate-policy.md
+++ b/docs/rdate-policy.md
@@ -1,0 +1,31 @@
+# RDATE Support Policy
+
+## Definition
+
+`RDATE` is the **Recurrence Date** property defined in [RFC 5545, section 3.8.5.2](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.5.2).
+It allows calendar producers to append explicit date or date-time instances to a recurring series outside of the `RRULE` pattern.
+The property accepts multiple value types (DATE, DATE-TIME, PERIOD) and inherits timezone or UTC rules from its context.
+
+## v1 Scope Stance
+
+Arklowdun **does not implement or expose `RDATE` handling in v1**.
+The recurrence expansion engine, IPC surface, and test fixtures ignore inbound `RDATE` data.
+Contributors must **not** rely on implicit support—the feature is intentionally excluded and **not covered by automated tests**.
+Any work that introduces `RDATE` logic must be deferred to a post-v1 milestone.
+
+## Rationale for Exclusion
+
+- **Implementation complexity:** Supporting all three `RDATE` value forms requires parser extensions, storage changes, and IPC shape updates.
+- **Low immediate need:** Current product requirements revolve around rule-based recurrences (`RRULE`) and exclusion dates (`EXDATE`); no tracked user stories demand manual inclusions.
+- **Resource prioritisation:** Engineering effort is focused on stabilising the v1 beta gate items (RRULE matrix, EXDATE path, timezone correctness). Diverting cycles to `RDATE` would slip those commitments.
+
+## Future Considerations
+
+When `RDATE` becomes a priority, plan dedicated work that includes:
+
+1. **Focused design + implementation PRs** that add parser/storage support and document behavioural expectations.
+2. **Expanded recurrence matrix coverage** with scenarios mirroring manual inclusions and timezone edge cases.
+3. **Migration planning** for persisted data, including snapshot updates and forward/backfill strategies.
+4. **QA instrumentation** (matrix tests, manual checklists) to exercise combinations with `EXDATE`, truncation caps, and IPC consumers.
+
+Until that roadmap is approved, any mention of `RDATE` in issues, PRs, or code comments should link back to this policy to avoid ambiguity about v1 scope.

--- a/docs/recurrence-matrix.md
+++ b/docs/recurrence-matrix.md
@@ -7,6 +7,10 @@ Each scenario seeds a series into an in-memory database, expands
 `events_list_range`, and compares the results to deterministic snapshots
 under `tests/rrule_snapshots/`.
 
+> **Note:** `RDATE` scenarios are intentionally excluded from this suite.
+> See [`docs/rdate-policy.md`](./rdate-policy.md) for the v1 policy and
+> future planning guidance.
+
 ## Scenario Coverage
 
 | Scenario | Timezone | RRULE Fields | Notes |

--- a/docs/v1-beta-gate.md
+++ b/docs/v1-beta-gate.md
@@ -67,10 +67,12 @@ The app ships to **closed beta testers** only when this gate is complete.
 ## Checklist
 
 - [x] Frontend structure & UX coherence — Calendar/Notes/Settings now built from UI primitives; ESLint guard prevents raw controls in views.
-- [ ] Timekeeping correctness  
-- [ ] Data safety & recovery  
-- [ ] Licensing & compliance  
-- [ ] Platform security & distribution  
+- [ ] Timekeeping correctness[^rdate-policy]
+- [ ] Data safety & recovery
+- [ ] Licensing & compliance
+- [ ] Platform security & distribution
+
+[^rdate-policy]: `RDATE` support is explicitly deferred until after v1. Refer to [`docs/rdate-policy.md`](./rdate-policy.md) for the full scope rationale and follow-up plan.
 
 ---
 
@@ -87,7 +89,7 @@ Here’s a tight, repo-ready enforcement pack. Drop these files in and turn the 
 ## Linked Focus Area
 Tick EXACTLY ONE. PRs without a tick are auto-failed by CI.
 
-- [x] Frontend structure & UX coherence  
+- [x] Frontend structure & UX coherence
   Evidence: [`ci.yml`](../.github/workflows/ci.yml), [`CalendarView.ts`](../src/CalendarView.ts), [`NotesView.ts`](../src/NotesView.ts), [`SettingsView.ts`](../src/SettingsView.ts), [`panes-primitives.spec.ts`](../tests/ui/panes-primitives.spec.ts)
 - [ ] Timekeeping correctness
 - [ ] Data safety & recovery


### PR DESCRIPTION
## Objective
- Capture the v1 stance that `RDATE` handling is deferred and document guidance for future work.

## Scope
- Add `/docs/rdate-policy.md` with definition, v1 exclusion statement, rationale, and future work guidance.
- Cross-link the policy from `/docs/recurrence-matrix.md` and the v1 gate checklist.
- Audit existing references to ensure no code comments imply undocumented `RDATE` behaviour.

## Non-Goals
- No changes to the recurrence expansion engine, IPC surface, or storage.
- No new fixtures, migrations, or automated tests.

## Acceptance Criteria
- ✅ New policy doc created and linked from related documentation.
- ✅ Recurrence matrix doc and v1 beta gate explicitly note `RDATE` exclusion.
- ✅ No code logic or tests modified; only documentation updates made.

## Evidence
- Policy doc: `/docs/rdate-policy.md`.
- Recurrence matrix note and link to policy.
- V1 gate checklist footnote referencing the policy.
- `rg -i "rdate"` confirms only documentation mentions remain.

## Rollback Plan
- Delete `/docs/rdate-policy.md`.
- Remove the cross-references in `/docs/recurrence-matrix.md` and `/docs/v1-beta-gate.md`.


------
https://chatgpt.com/codex/tasks/task_e_68cea3887e20832a8c270d893a588274