### PR TITLE
feat(recurrence-ux): add truncation banner for recurrence limits

### DIFF
--- a/docs/recurrence-limits.md
+++ b/docs/recurrence-limits.md
@@ -22,13 +22,16 @@ Whenever either cap prevents additional instances from being returned, the IPC p
 
 The flag is `false` when the full result set fit within the limits. Backwards compatibility is preserved because the `items` array still contains fully hydrated `Event` objects.
 
-## UI Expectations
+## Truncation Banner UX
 
-When `truncated` is `true`, the calendar view displays an accessible banner with the copy:
+When `truncated` is `true`, calendar and other recurrence-driven surfaces render the shared `TruncationBanner` primitive above their list content. The component:
 
-> “This list was shortened to the first N results.”
+- Announces “This list was shortened to the first _N_ results.” with the list size formatted using the viewer’s locale.
+- Exposes `role="status"` and `aria-live="polite"` so screen readers announce the banner as soon as it appears.
+- Ships with a keyboard-focusable “Close” button that hides the banner until the next truncated payload is fetched. A fresh payload (indicated by a new timestamp token) re-enables the message so the truncation state is not missed.
+- Collapses automatically when a subsequent fetch returns the full, untruncated dataset.
 
-The banner uses an `aria-live="polite"` region and includes a keyboard-focusable dismiss button. The message refreshes (and the banner is re-announced) whenever a new truncated payload is received. When results fall back under the caps the banner is hidden automatically.
+The primitive lives in `src/ui/TruncationBanner.ts` and is available for any list that needs to surface truncation.
 
 ## Operational Notes
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1458,23 +1458,6 @@ footer a.footer__settings {
 }
 
 .calendar__panel { padding: var(--space-4); }
-.calendar__truncation {
-  margin-bottom: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-accent);
-  background: var(--color-accent-soft);
-  color: var(--color-text);
-  border-radius: var(--radius-base);
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.calendar__truncation-message {
-  flex: 1;
-}
-.calendar__truncation-dismiss {
-  margin-left: auto;
-}
 
 .calendar__table {
   width: 100%;
@@ -1770,6 +1753,27 @@ mark.search-hit {
   font-size: 0.85rem;
   white-space: pre-wrap;
   overflow-x: auto;
+}
+
+.truncation-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+  border-radius: var(--radius-base);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.truncation-banner__message {
+  flex: 1 1 200px;
+}
+
+.truncation-banner__dismiss {
+  margin-left: auto;
 }
 
 .loading {

--- a/src/ui/TruncationBanner.ts
+++ b/src/ui/TruncationBanner.ts
@@ -1,0 +1,88 @@
+import createButton from '@ui/Button';
+
+export interface TruncationBannerProps {
+  count: number;
+  hidden?: boolean;
+  onDismiss?: () => void;
+  closeLabel?: string;
+  closeAriaLabel?: string;
+  className?: string;
+}
+
+export type TruncationBannerElement = HTMLDivElement & {
+  update: (next: Partial<TruncationBannerProps>) => void;
+};
+
+function applyClassName(el: HTMLElement, base: string, className?: string): void {
+  el.className = base;
+  if (!className) return;
+  for (const token of className.split(/\s+/)) {
+    if (token) el.classList.add(token);
+  }
+}
+
+function formatCount(count: number): string {
+  if (!Number.isFinite(count)) return '0';
+  const safe = Math.max(0, Math.trunc(count));
+  return safe.toLocaleString();
+}
+
+export function createTruncationBanner(
+  props: TruncationBannerProps,
+): TruncationBannerElement {
+  const root = document.createElement('div') as TruncationBannerElement;
+  root.dataset.ui = 'truncation-banner';
+  root.setAttribute('role', 'status');
+  root.setAttribute('aria-live', 'polite');
+
+  const message = document.createElement('span');
+  message.className = 'truncation-banner__message';
+
+  const dismissHandler = (event: MouseEvent) => {
+    event.preventDefault();
+    currentOnDismiss?.();
+  };
+
+  const closeButton = createButton({
+    label: props.closeLabel ?? 'Close',
+    variant: 'ghost',
+    size: 'sm',
+    className: 'truncation-banner__dismiss',
+    ariaLabel: props.closeAriaLabel ?? 'Close truncation message',
+    onClick: dismissHandler,
+  });
+
+  root.append(message, closeButton);
+
+  let currentCount = props.count;
+  let currentHidden = props.hidden ?? false;
+  let currentOnDismiss = props.onDismiss ?? null;
+  let currentClassName = props.className;
+  let currentCloseLabel = props.closeLabel ?? 'Close';
+  let currentCloseAriaLabel = props.closeAriaLabel ?? 'Close truncation message';
+
+  const sync = () => {
+    message.textContent = `This list was shortened to the first ${formatCount(currentCount)} results.`;
+    root.hidden = currentHidden;
+    applyClassName(root, 'truncation-banner', currentClassName);
+    closeButton.update({ label: currentCloseLabel, ariaLabel: currentCloseAriaLabel });
+  };
+
+  sync();
+
+  root.update = (next: Partial<TruncationBannerProps>) => {
+    if (next.count !== undefined) currentCount = next.count;
+    if (next.hidden !== undefined) currentHidden = next.hidden;
+    if (next.onDismiss !== undefined) currentOnDismiss = next.onDismiss ?? null;
+    if (next.className !== undefined) currentClassName = next.className;
+    if (next.closeLabel !== undefined) currentCloseLabel = next.closeLabel ?? 'Close';
+    if (next.closeAriaLabel !== undefined) {
+      currentCloseAriaLabel = next.closeAriaLabel ?? 'Close truncation message';
+    }
+    sync();
+  };
+
+  return root;
+}
+
+export default createTruncationBanner;

--- a/tests/a11y/truncation-banner.spec.ts
+++ b/tests/a11y/truncation-banner.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+import { formatViolations } from './helpers';
+
+async function showTruncatedBanner(
+  page: Page,
+  options: { count: number; ts: number },
+) {
+  await page.evaluate(async ({ count, ts }) => {
+    const { actions } = await import('/src/store/index.ts');
+    const now = Date.now();
+    const items = Array.from({ length: count }, (_, index) => ({
+      id: `event-${ts}-${index}`,
+      household_id: 'playwright-household',
+      title: `Event ${index + 1}`,
+      start_at: now + index * 60_000,
+      end_at: now + index * 60_000 + 30_000,
+      start_at_utc: now + index * 60_000,
+      end_at_utc: now + index * 60_000 + 30_000,
+      created_at: now,
+      updated_at: now,
+    }));
+    actions.events.updateSnapshot({
+      items,
+      ts,
+      window: { start: now - 86_400_000, end: now + 86_400_000 },
+      source: 'playwright-truncation-a11y',
+      truncated: true,
+    });
+  }, options);
+}
+
+test.describe('Truncation banner accessibility', () => {
+  test('banner announces via status region and passes axe-core scan', async ({ page }) => {
+    await page.goto('/#/calendar');
+    await page.waitForSelector('main[role="main"]');
+
+    const ts = Date.now() + 5_000;
+    await showTruncatedBanner(page, { count: 600, ts });
+
+    const banner = page.locator('[data-ui="truncation-banner"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('role', 'status');
+    await expect(banner).toHaveAttribute('aria-live', 'polite');
+
+    const results = await new AxeBuilder({ page })
+      .exclude('.sidebar a.active > span')
+      .include('[data-ui="truncation-banner"]')
+      .withTags(['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+});

--- a/tests/truncation-banner.test.ts
+++ b/tests/truncation-banner.test.ts
@@ -1,0 +1,61 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import createTruncationBanner from '@ui/TruncationBanner';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+(globalThis as any).window = dom.window as unknown as typeof globalThis & Window;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+
+function nextTick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('TruncationBanner renders message and toggles visibility', async () => {
+  const banner = createTruncationBanner({ count: 500, hidden: true });
+
+  assert.equal(banner.dataset.ui, 'truncation-banner');
+  assert.equal(banner.getAttribute('role'), 'status');
+  assert.equal(banner.getAttribute('aria-live'), 'polite');
+  assert.equal(banner.hidden, true);
+
+  const message = banner.querySelector('.truncation-banner__message');
+  if (!message) throw new Error('missing message region');
+  const formatted = (500).toLocaleString();
+  assert.equal(
+    message.textContent,
+    `This list was shortened to the first ${formatted} results.`,
+  );
+
+  banner.update({ count: 10_000, hidden: false });
+  assert.equal(banner.hidden, false);
+  const updated = (10_000).toLocaleString();
+  assert.equal(
+    message.textContent,
+    `This list was shortened to the first ${updated} results.`,
+  );
+
+  await nextTick();
+});
+
+test('TruncationBanner calls onDismiss when Close is pressed', async () => {
+  let dismissed = 0;
+  const banner = createTruncationBanner({
+    count: 600,
+    onDismiss: () => {
+      dismissed += 1;
+      banner.update({ hidden: true });
+    },
+  });
+
+  const closeButton = banner.querySelector('button');
+  if (!closeButton) throw new Error('missing close button');
+  assert.equal(banner.hidden, false);
+
+  closeButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  await nextTick();
+
+  assert.equal(dismissed, 1);
+  assert.equal(banner.hidden, true);
+});

--- a/tests/ui/truncation-banner.spec.ts
+++ b/tests/ui/truncation-banner.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+async function updateCalendarSnapshot(
+  page: Page,
+  options: { count: number; truncated: boolean; ts: number },
+) {
+  await page.evaluate(async ({ count, truncated, ts }) => {
+    const { actions } = await import('/src/store/index.ts');
+    const now = Date.now();
+    const items = Array.from({ length: count }, (_, index) => ({
+      id: `event-${ts}-${index}`,
+      household_id: 'playwright-household',
+      title: `Event ${index + 1}`,
+      start_at: now + index * 60_000,
+      end_at: now + index * 60_000 + 30_000,
+      start_at_utc: now + index * 60_000,
+      end_at_utc: now + index * 60_000 + 30_000,
+      created_at: now,
+      updated_at: now,
+    }));
+    actions.events.updateSnapshot({
+      items,
+      ts,
+      window: { start: now - 86_400_000, end: now + 86_400_000 },
+      source: 'playwright-truncation-test',
+      truncated,
+    });
+  }, options);
+}
+
+test.describe('Truncation banner', () => {
+  test('calendar only shows banner when results are truncated', async ({ page }) => {
+    await page.goto('/#/calendar');
+    await page.waitForSelector('.calendar');
+
+    const banner = page.locator('[data-ui="truncation-banner"]');
+    await expect(banner).toBeHidden();
+
+    const baselineTs = Date.now();
+    await updateCalendarSnapshot(page, {
+      count: 200,
+      truncated: false,
+      ts: baselineTs,
+    });
+    await expect(banner).toBeHidden();
+
+    const truncatedTs = baselineTs + 1_000;
+    await updateCalendarSnapshot(page, {
+      count: 600,
+      truncated: true,
+      ts: truncatedTs,
+    });
+
+    await expect(banner).toBeVisible();
+    const formatted = await page.evaluate((value) => value.toLocaleString(), 600);
+    await expect(banner).toContainText(`first ${formatted} results`);
+
+    const screenshotPath = test.info().outputPath('truncation-banner.png');
+    await page.screenshot({ path: screenshotPath });
+    const artifactDir = join(process.cwd(), 'test-results');
+    await fs.mkdir(artifactDir, { recursive: true });
+    await fs.copyFile(screenshotPath, join(artifactDir, 'truncation-banner.png'));
+
+    await banner.locator('button').click();
+    await expect(banner).toBeHidden();
+
+    await updateCalendarSnapshot(page, {
+      count: 600,
+      truncated: true,
+      ts: truncatedTs,
+    });
+    await expect(banner).toBeHidden();
+
+    await updateCalendarSnapshot(page, {
+      count: 600,
+      truncated: true,
+      ts: truncatedTs + 1,
+    });
+    await expect(banner).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Objective
- Surface a clear, accessible banner whenever recurrence queries are truncated so users understand why items are missing.

## Scope
- Add a shared `TruncationBanner` primitive with localized messaging, status role, and keyboard-dismissable Close button.
- Replace the Calendar view’s bespoke notice with the new primitive while preserving dismissal tokens and localized counts.
- Introduce shared styling tokens for the info banner and document the UX with updated notes in `recurrence-limits.md`.
- Extend coverage with unit, Playwright, and axe-core tests to guard rendering, conditional display (200 vs 600 items), and accessibility attributes.

## Non-Goals
- No changes to the recurrence expansion limits or IPC payload structure.
- No new user preferences for hiding truncation notices beyond the per-fetch dismissal token.

## Acceptance Criteria
- `TruncationBanner` exists under `src/ui` with accessible semantics and dismissal control.
- Calendar renders the banner only when `truncated: true`, displays the formatted count, and resets visibility on new payloads.
- Dismissal persists until a new truncated payload arrives, and the banner hides once full results are returned.
- Documentation in `docs/recurrence-limits.md` reflects the UX, copy, and accessibility notes.
- Automated tests cover component behavior, calendar integration (200 vs 600 events and dismissal), and axe-core accessibility checks.

## Evidence
- Unit coverage: `npm run test`.
- Conditional + dismissal coverage: `npm run test:e2e`.
- Accessibility scan: `npm run test:a11y`.

## Rollback
- Remove `TruncationBanner`, associated styles, and test coverage.
- Restore the prior Calendar truncation notice implementation.
- Delete the documentation updates.


------
https://chatgpt.com/codex/tasks/task_e_68ceaac4eb5c832a91a036b7a625166b