### PR TITLE
perf(backfill): add throughput benchmark harness and publish baseline results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,47 @@ jobs:
           name: time-invariants-logs-${{ runner.os }}
           path: test-results/*.log
 
+  gate_backfill_bench_smoke:
+    name: gate/backfill-bench-smoke
+    runs-on: ubuntu-latest
+    needs: [lint, unit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            python3 \
+            make \
+            g++ \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            sqlite3
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Generate benchmark fixtures
+        run: |
+          set -euxo pipefail
+          node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts --rows 1000
+      - name: Run backfill benchmark smoke test
+        working-directory: src-tauri
+        run: |
+          set -euxo pipefail
+          cargo run --locked --bin time -- backfill-bench --rows 1000 --chunk-size 500 --progress-interval 0
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ docs/samples/*.zip
  
 # fixtures
 fixtures/**/*.db
+fixtures/**/*.sqlite3
+backfill_bench_*.sqlite3

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See the [Arklowdun Master Plan](docs/master-plan.md) for the high-level strategi
 - `npm run check-all` — run local guard checks.
 - `scripts/check_migrations.sh` — verify numbering/pairing (prints OK or first error)
 - `scripts/renumber_migrations.sh -n|--apply` — dry-run/apply contiguous renumbering
+- `(cd src-tauri && cargo run --locked --bin time -- backfill-bench --rows 10000 --chunk-size 500 --progress-interval 0)` — run the timezone backfill benchmark harness (see [`docs/backfill-performance.md`](docs/backfill-performance.md)).
 
 Recommended IDE: VS Code with Tauri and rust-analyzer extensions.
 

--- a/docs/backfill-performance.md
+++ b/docs/backfill-performance.md
@@ -1,0 +1,83 @@
+# Timezone Backfill Throughput Baseline
+
+Fixtures are **not** committed; run the generator first.
+
+## Environment
+- **Date:** 2025-09-20T20:48:03Z (UTC)
+- **Host:** GitHub Codespaces container
+- **CPU:** Intel(R) Xeon(R) Platinum 8272CL @ 2.60GHz (5 vCPU)
+- **Memory:** 9.9 GiB RAM (0 GiB swap)
+- **Operating system:** Ubuntu 24.04.2 LTS (noble)
+- **Binary:** `cargo run --locked --bin time`
+
+## Methodology
+- Benchmarks execute the timezone backfill via the new `time backfill-bench` subcommand.
+- Run the generator script to create `.sqlite3` fixtures before benchmarking.
+- Fixtures live under `fixtures/time/backfill/backfill-<rows>.sqlite3`. A temporary working copy of each fixture is created automatically for every run.
+- Unless otherwise noted the benchmark was invoked as:
+  ```sh
+  cargo run --locked --bin time -- backfill-bench --rows <N> --chunk-size 500 --progress-interval 0
+  ```
+  (`--progress-interval 0` disables extra progress logs; the runtime clamps it to the default 1 s interval internally.)
+- Metrics reported by the CLI include elapsed wall-clock time, rows scanned/updated/skipped, rows-per-second throughput, and per-chunk timings (count, average, p95, maximum, and raw CSV rows).
+
+## Results
+| Run | Dataset | Rows | Chunk size | Elapsed (s) | Throughput (rows/s) | Avg chunk (ms) | p95 chunk (ms) | Max chunk (ms) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Smoke | backfill-1k.sqlite3 | 1,000 | 500 | 0.169 | 5,917.16 | 83.50 | 107.35 | 110 |
+| Baseline A | backfill-10k.sqlite3 | 10,000 | 500 | 1.518 | 6,587.62 | 74.80 | 89.70 | 141 |
+| Baseline B | backfill-10k.sqlite3 | 10,000 | 500 | 1.484 | 6,738.54 | 72.95 | 83.15 | 86 |
+| Baseline | backfill-100k.sqlite3 | 100,000 | 500 | 47.663 | 2,098.06 | 236.96 | 377.15 | 775 |
+
+### Repeatability
+Two successive 10k runs (Baseline A/B) differed by 2.3%, well inside the ±10% repeatability goal.
+
+### Variance snapshot (100k fixture)
+Per-chunk CSV emitted by the harness highlights steady-state performance and outliers:
+```
+chunk_index,scanned,updated,skipped,elapsed_ms
+1,500,500,0,362
+2,500,500,0,380
+3,500,500,0,414
+4,500,500,0,367
+5,500,500,0,380
+6,500,500,0,357
+7,500,500,0,404
+8,500,500,0,360
+9,500,500,0,384
+10,500,500,0,349
+...
+73,500,500,0,335
+74,500,500,0,293
+75,500,500,0,775  # peak chunk (checkpoint flush)
+76,500,500,0,277
+77,500,500,0,268
+78,500,500,0,236
+79,500,500,0,252
+80,500,500,0,212
+...
+199,500,500,0,126
+200,500,500,0,90
+```
+
+## Observations
+- All runs scanned and updated every candidate row; zero rows were skipped across the fixture datasets.
+- Throughput stays flat between 1k and 10k fixtures (~6.6k rows/sec) but drops to ~2.1k rows/sec on the 100k dataset as WAL checkpoints and chunk serialization dominate.
+- The 100k run shows a single 775 ms chunk (chunk 75) attributable to SQLite checkpoint work; most other chunks stay below 400 ms.
+- The harness copies fixtures into a temporary file for isolation—rerunning benchmarks resets the working database automatically.
+
+## Reproducing locally
+1. Ensure Rust (stable toolchain) and Node dependencies for Tauri are installed.
+2. Generate the desired fixtures:
+   ```sh
+   node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts --rows 1000
+   node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts --rows 10000
+   node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts --rows 100000
+   ```
+   (Adjust `--rows` as needed; fixtures default to a deterministic Mulberry32 seed of 42.)
+3. From the repository root run the desired benchmark. Examples:
+   ```sh
+   (cd src-tauri && cargo run --locked --bin time -- backfill-bench --rows 10000 --chunk-size 500 --progress-interval 0)
+   (cd src-tauri && cargo run --locked --bin time -- backfill-bench --rows 100000 --chunk-size 500 --progress-interval 0)
+   ```
+4. Inspect stdout for the benchmark summary and the per-chunk CSV rows. The `--keep-db` flag preserves the working database for post-run inspection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.20.5",
-        "typescript": "~5.6.2",
+        "typescript": "^5.6.2",
         "vite": "^6.0.3",
         "vitest": "^1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "bench:gen": "node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts",
+    "bench:smoke": "cd src-tauri && cargo run --locked --bin time -- backfill-bench --rows 1000 --chunk-size 500 --progress-interval 0",
     "migrate:checksum": "node --loader ts-node/esm scripts/migrate-checksum.ts",
     "migrate:batch1": "node --loader ts-node/esm src/tools/migrate-batch1.ts",
     "check:household": "bash scripts/check-household-scope.sh",
@@ -78,7 +80,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.20.5",
-    "typescript": "~5.6.2",
+    "typescript": "^5.6.2",
     "vite": "^6.0.3",
     "vitest": "^1.6.0"
   }

--- a/scripts/bench/generate_backfill_fixture.ts
+++ b/scripts/bench/generate_backfill_fixture.ts
@@ -1,0 +1,239 @@
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const DEFAULT_SEED = 42;
+const DEFAULT_ROWS = 10_000;
+const DEFAULT_HOUSEHOLD_ID = "bench_hh";
+const DEFAULT_HOUSEHOLD_TZ = "America/New_York";
+
+interface Options {
+  rows: number;
+  output: string;
+  seed: number;
+  household: string;
+  tz: string;
+}
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  const opts: Options = {
+    rows: DEFAULT_ROWS,
+    output: "",
+    seed: DEFAULT_SEED,
+    household: DEFAULT_HOUSEHOLD_ID,
+    tz: DEFAULT_HOUSEHOLD_TZ,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--rows":
+        opts.rows = Number.parseInt(args[++i] ?? "", 10);
+        if (!Number.isFinite(opts.rows) || opts.rows <= 0) {
+          throw new Error("--rows must be a positive integer");
+        }
+        break;
+      case "--output":
+        opts.output = args[++i] ?? "";
+        break;
+      case "--seed":
+        opts.seed = Number.parseInt(args[++i] ?? "", 10);
+        if (!Number.isFinite(opts.seed)) {
+          throw new Error("--seed must be an integer");
+        }
+        break;
+      case "--household":
+        opts.household = args[++i] ?? DEFAULT_HOUSEHOLD_ID;
+        break;
+      case "--tz":
+        opts.tz = args[++i] ?? DEFAULT_HOUSEHOLD_TZ;
+        break;
+      case "--help":
+      case "-h":
+        console.log(
+          "Usage: generate_backfill_fixture.ts [options]\n" +
+            "  --rows N         Number of events to generate (default 10000)\n" +
+            "  --output PATH    Destination sqlite file (default fixtures/time/backfill/backfill-<rows>.sqlite3)\n" +
+            "  --seed N         PRNG seed (default 42)\n" +
+            "  --household ID   Household id to seed (default bench_hh)\n" +
+            "  --tz NAME        Household fallback timezone (default America/New_York)\n"
+        );
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!opts.output) {
+    const suffix = opts.rows >= 1000 && opts.rows % 1000 === 0 ? `${opts.rows / 1000}k` : `${opts.rows}`;
+    opts.output = path.join("fixtures", "time", "backfill", `backfill-${suffix}.sqlite3`);
+  }
+
+  opts.output = path.resolve(opts.output);
+  return opts;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomInt(rand: () => number, min: number, max: number): number {
+  return Math.floor(rand() * (max - min + 1)) + min;
+}
+
+function alignToMidnight(ms: number): number {
+  return Math.floor(ms / DAY_MS) * DAY_MS;
+}
+
+function prepareDatabase(dest: string) {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest);
+  }
+
+  const db = new Database(dest);
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  return db;
+}
+
+function createSchema(db: Database.Database, householdId: string, householdTz: string) {
+  db.exec(`
+    BEGIN;
+    DROP TABLE IF EXISTS events;
+    DROP TABLE IF EXISTS household;
+    CREATE TABLE household (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      tz TEXT,
+      created_at INTEGER,
+      updated_at INTEGER,
+      deleted_at INTEGER
+    );
+    CREATE TABLE events (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      start_at INTEGER NOT NULL,
+      end_at INTEGER,
+      tz TEXT,
+      household_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER,
+      start_at_utc INTEGER,
+      end_at_utc INTEGER,
+      rrule TEXT,
+      exdates TEXT,
+      FOREIGN KEY(household_id) REFERENCES household(id)
+    );
+    CREATE INDEX IF NOT EXISTS events_household_start_idx ON events(household_id, start_at);
+    COMMIT;
+  `);
+
+  const now = Date.UTC(2024, 0, 1);
+  const insertHousehold = db.prepare(
+    `INSERT INTO household (id, name, tz, created_at, updated_at, deleted_at)
+     VALUES (@id, @name, @tz, @created_at, @updated_at, NULL)`
+  );
+  insertHousehold.run({
+    id: householdId,
+    name: "Benchmark Household",
+    tz: householdTz,
+    created_at: now - DAY_MS,
+    updated_at: now - DAY_MS / 2,
+  });
+}
+
+function generateEvents(db: Database.Database, opts: Options) {
+  const rand = mulberry32(opts.seed);
+  const base = Date.UTC(2024, 0, 15);
+  const tzPool: (string | null)[] = [
+    "UTC",
+    "Europe/London",
+    "Europe/Paris",
+    "America/Los_Angeles",
+    "America/New_York",
+    "Asia/Tokyo",
+    null,
+  ];
+
+  const insert = db.prepare(
+    `INSERT INTO events (
+      id, title, start_at, end_at, tz, household_id,
+      created_at, updated_at, deleted_at, start_at_utc, end_at_utc, rrule, exdates
+    ) VALUES (
+      @id, @title, @start_at, @end_at, @tz, @household_id,
+      @created_at, @updated_at, NULL, NULL, NULL, NULL, NULL
+    )`
+  );
+
+  const txn = db.transaction((count: number) => {
+    for (let i = 0; i < count; i++) {
+      const ticket = rand();
+      const id = `evt_${(i + 1).toString().padStart(7, "0")}`;
+      const tz = tzPool[Math.floor(rand() * tzPool.length)] ?? null;
+      const daySpread = randomInt(rand, -180, 180);
+      const startBase = base + daySpread * DAY_MS;
+
+      let startAt: number;
+      let endAt: number | null;
+      let title: string;
+
+      if (ticket < 0.3) {
+        // All-day event anchored to midnight
+        startAt = alignToMidnight(startBase);
+        const daySpan = randomInt(rand, 1, 3);
+        endAt = startAt + daySpan * DAY_MS;
+        title = `All-day block ${(i % 8) + 1}`;
+      } else {
+        // Timed event with 45-180 minute duration, occasionally open-ended
+        const minuteOffset = randomInt(rand, 0, DAY_MS - HOUR_MS);
+        startAt = startBase + minuteOffset;
+        const durationMinutes = randomInt(rand, 45, 180);
+        endAt = rand() < 0.12 ? null : startAt + durationMinutes * 60_000;
+        title = `Timed session ${(i % 10) + 1}`;
+      }
+
+      insert.run({
+        id,
+        title,
+        start_at: Math.trunc(startAt),
+        end_at: endAt === null ? null : Math.trunc(endAt),
+        tz,
+        household_id: opts.household,
+        created_at: startAt - HOUR_MS,
+        updated_at: startAt - HOUR_MS / 2,
+      });
+    }
+  });
+
+  txn(opts.rows);
+}
+
+function main() {
+  const opts = parseArgs();
+  const db = prepareDatabase(opts.output);
+  try {
+    createSchema(db, opts.household, opts.tz);
+    generateEvents(db, opts);
+  } finally {
+    db.close();
+  }
+
+  console.log(
+    `Generated ${opts.rows.toLocaleString()} events at ${opts.output} (seed=${opts.seed}, household=${opts.household})`
+  );
+}
+
+main();

--- a/src-tauri/scripts/time_backfill.rs
+++ b/src-tauri/scripts/time_backfill.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Context, Result};
 use arklowdun_lib::{
     events_tz_backfill::{
-        run_events_backfill, BackfillControl, BackfillOptions, BackfillProgress, BackfillStatus,
-        BackfillSummary, MAX_CHUNK_SIZE, MAX_PROGRESS_INTERVAL_MS, MIN_CHUNK_SIZE,
-        MIN_PROGRESS_INTERVAL_MS,
+        run_events_backfill, BackfillChunkStats, BackfillControl, BackfillOptions,
+        BackfillProgress, BackfillStatus, BackfillSummary, MAX_CHUNK_SIZE,
+        MAX_PROGRESS_INTERVAL_MS, MIN_CHUNK_SIZE, MIN_PROGRESS_INTERVAL_MS,
     },
     time_invariants, AppError,
 };
@@ -14,10 +14,12 @@ use sqlx::{
     ConnectOptions, SqlitePool,
 };
 use std::{
+    fs,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Instant,
 };
+use tempfile::{Builder, NamedTempFile};
 use tokio::signal;
 use tracing::info;
 
@@ -32,6 +34,8 @@ struct Cli {
 enum Command {
     #[command(about = "Run the timezone backfill with progress reporting")]
     Backfill(BackfillArgs),
+    #[command(about = "Run throughput benchmarks against fixture datasets")]
+    BackfillBench(BenchArgs),
     #[command(about = "Check wall-clock invariants between local and UTC timestamps")]
     Invariants(InvariantArgs),
 }
@@ -67,6 +71,36 @@ struct BackfillArgs {
 }
 
 #[derive(Args)]
+struct BenchArgs {
+    #[arg(long, value_name = "ROWS", default_value_t = 10_000)]
+    rows: usize,
+
+    #[arg(long, value_name = "PATH")]
+    fixture: Option<PathBuf>,
+
+    #[arg(long, value_name = "PATH")]
+    db: Option<PathBuf>,
+
+    #[arg(long, value_name = "N", default_value_t = 500)]
+    chunk_size: usize,
+
+    #[arg(long)]
+    dry_run: bool,
+
+    #[arg(long, value_name = "TZ")]
+    default_tz: Option<String>,
+
+    #[arg(long, value_name = "HOUSEHOLD")]
+    household: Option<String>,
+
+    #[arg(long)]
+    keep_db: bool,
+
+    #[arg(long, value_name = "MS")]
+    progress_interval: Option<u64>,
+}
+
+#[derive(Args)]
 struct InvariantArgs {
     #[arg(long, value_name = "PATH")]
     db: Option<PathBuf>,
@@ -88,6 +122,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Backfill(args) => run_backfill(args).await?,
+        Command::BackfillBench(args) => run_backfill_bench(args).await?,
         Command::Invariants(args) => run_invariants(args).await?,
     }
 
@@ -105,7 +140,9 @@ async fn run_backfill(args: BackfillArgs) -> Result<()> {
     }
 
     if let Some(interval) = args.progress_interval {
-        if !(MIN_PROGRESS_INTERVAL_MS..=MAX_PROGRESS_INTERVAL_MS).contains(&interval) {
+        if interval != 0
+            && !(MIN_PROGRESS_INTERVAL_MS..=MAX_PROGRESS_INTERVAL_MS).contains(&interval)
+        {
             anyhow::bail!(
                 "Progress interval must be between {MIN_PROGRESS_INTERVAL_MS} and {MAX_PROGRESS_INTERVAL_MS} milliseconds."
             );
@@ -151,6 +188,7 @@ async fn run_backfill(args: BackfillArgs) -> Result<()> {
         args.log_dir.clone(),
         Some(control.clone()),
         Some(progress_cb),
+        None,
     );
 
     tokio::pin!(backfill_future);
@@ -184,6 +222,241 @@ async fn run_backfill(args: BackfillArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn run_backfill_bench(args: BenchArgs) -> Result<()> {
+    let BenchArgs {
+        rows,
+        fixture,
+        db,
+        chunk_size,
+        dry_run,
+        default_tz,
+        household,
+        keep_db,
+        progress_interval,
+    } = args;
+
+    if !(MIN_CHUNK_SIZE..=MAX_CHUNK_SIZE).contains(&chunk_size) {
+        anyhow::bail!(
+            "Chunk size must be between {MIN_CHUNK_SIZE} and {MAX_CHUNK_SIZE} rows per batch."
+        );
+    }
+
+    if let Some(interval) = progress_interval {
+        if interval != 0
+            && !(MIN_PROGRESS_INTERVAL_MS..=MAX_PROGRESS_INTERVAL_MS).contains(&interval)
+        {
+            anyhow::bail!(
+                "Progress interval must be between {MIN_PROGRESS_INTERVAL_MS} and {MAX_PROGRESS_INTERVAL_MS} milliseconds."
+            );
+        }
+    }
+
+    let fixture_path = resolve_fixture_path(rows, fixture)?;
+    let (work_db_path, mut temp_db) = copy_fixture_to_work(&fixture_path, db.as_deref())?;
+    let pool = open_pool(&work_db_path).await?;
+
+    let household_id = if let Some(id) = household {
+        id
+    } else {
+        sqlx::query_scalar::<_, String>("SELECT id FROM household ORDER BY id LIMIT 1")
+            .fetch_optional(&pool)
+            .await
+            .with_context(|| format!("load household id from {}", work_db_path.display()))?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Fixture {} does not contain any household rows",
+                    fixture_path.display()
+                )
+            })?
+    };
+
+    let chunk_samples: Arc<Mutex<Vec<BackfillChunkStats>>> = Arc::new(Mutex::new(Vec::new()));
+    let chunk_capture = chunk_samples.clone();
+    let chunk_observer: Arc<dyn Fn(BackfillChunkStats) + Send + Sync> = Arc::new(move |chunk| {
+        if let Ok(mut guard) = chunk_capture.lock() {
+            guard.push(chunk);
+        }
+    });
+
+    let progress_ms = progress_interval.unwrap_or(0);
+
+    let summary = run_events_backfill(
+        &pool,
+        BackfillOptions {
+            household_id: household_id.clone(),
+            default_tz: default_tz.clone(),
+            chunk_size,
+            progress_interval_ms: progress_ms,
+            dry_run,
+            reset_checkpoint: true,
+        },
+        None,
+        None,
+        None,
+        Some(chunk_observer),
+    )
+    .await
+    .map_err(|err| anyhow!(format_cli_error(&err)))?;
+
+    pool.close().await;
+
+    let mut chunks = chunk_samples
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    chunks.sort_by_key(|c| c.chunk_index);
+
+    let chunk_count = chunks.len();
+    let chunk_times: Vec<u64> = chunks.iter().map(|c| c.elapsed_ms).collect();
+    let avg_chunk_ms = if chunk_count == 0 {
+        0.0
+    } else {
+        chunk_times.iter().sum::<u64>() as f64 / chunk_count as f64
+    };
+    let p95_chunk_ms = percentile_ms(&chunk_times, 95.0);
+    let max_chunk_ms = chunk_times.iter().copied().max().unwrap_or(0);
+    let throughput = if summary.elapsed_ms == 0 {
+        0.0
+    } else {
+        summary.total_scanned as f64 / (summary.elapsed_ms as f64 / 1000.0)
+    };
+
+    println!("Benchmark summary");
+    println!("  Fixture:        {}", fixture_path.display());
+    println!("  Working copy:   {}", work_db_path.display());
+    println!("  Household:      {}", household_id);
+    println!("  Requested rows: {}", rows);
+    println!("  Chunk size:     {}", chunk_size);
+    println!("  Dry run:        {}", dry_run);
+    println!("  Progress ms:    {}", progress_ms);
+    println!("  Scanned:        {}", summary.total_scanned);
+    println!("  Updated:        {}", summary.total_updated);
+    println!("  Skipped:        {}", summary.total_skipped);
+    println!(
+        "  Elapsed:        {:.3}s",
+        summary.elapsed_ms as f64 / 1000.0
+    );
+    println!("  Throughput:     {:.2} rows/sec", throughput);
+    println!("  Chunks:         {}", chunk_count);
+    println!("  Avg chunk:      {:.2} ms", avg_chunk_ms);
+    if let Some(p95) = p95_chunk_ms {
+        println!("  p95 chunk:      {:.2} ms", p95);
+    }
+    println!("  Max chunk:      {} ms", max_chunk_ms);
+
+    println!("\nchunk_index,scanned,updated,skipped,elapsed_ms");
+    for chunk in &chunks {
+        println!(
+            "{},{},{},{},{}",
+            chunk.chunk_index, chunk.scanned, chunk.updated, chunk.skipped, chunk.elapsed_ms
+        );
+    }
+
+    if keep_db {
+        if let Some(temp) = temp_db.take() {
+            let (_file, path) = temp.keep().with_context(|| {
+                format!("persist benchmark database at {}", work_db_path.display())
+            })?;
+            eprintln!("Kept working database at {}", path.display());
+        } else if let Some(dest) = &db {
+            eprintln!("Working database retained at {}", dest.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn dataset_suffix(rows: usize) -> String {
+    if rows >= 1_000 && rows % 1_000 == 0 {
+        format!("{}k", rows / 1_000)
+    } else {
+        rows.to_string()
+    }
+}
+
+fn default_fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("fixtures")
+        .join("time")
+        .join("backfill")
+}
+
+fn resolve_fixture_path(rows: usize, explicit: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(path) = explicit {
+        let candidate = path.canonicalize().unwrap_or(path.clone());
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+        anyhow::bail!("Fixture override {} does not exist", path.display());
+    }
+
+    let candidate =
+        default_fixture_dir().join(format!("backfill-{}.sqlite3", dataset_suffix(rows)));
+    if candidate.exists() {
+        return Ok(candidate.canonicalize().unwrap_or(candidate));
+    }
+    anyhow::bail!(
+        "No fixture available for {rows} rows at {}. Run `node --loader ts-node/esm scripts/bench/generate_backfill_fixture.ts --rows {rows}` or provide --fixture to supply a database.",
+        candidate.display()
+    );
+}
+
+fn copy_fixture_to_work(
+    fixture: &Path,
+    override_path: Option<&Path>,
+) -> Result<(PathBuf, Option<NamedTempFile>)> {
+    if let Some(dest) = override_path {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create directory {}", parent.display()))?;
+        }
+        fs::copy(fixture, dest)
+            .with_context(|| format!("copy fixture {} to {}", fixture.display(), dest.display()))?;
+        return Ok((dest.to_path_buf(), None));
+    }
+
+    let temp = Builder::new()
+        .prefix("backfill_bench_")
+        .suffix(".sqlite3")
+        .tempfile()
+        .context("create temporary benchmark database")?;
+    fs::copy(fixture, temp.path()).with_context(|| {
+        format!(
+            "copy fixture {} to {}",
+            fixture.display(),
+            temp.path().display()
+        )
+    })?;
+    Ok((temp.path().to_path_buf(), Some(temp)))
+}
+
+fn percentile_ms(samples: &[u64], percentile: f64) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+
+    if percentile <= 0.0 {
+        return samples.iter().copied().min().map(|v| v as f64);
+    }
+    if percentile >= 100.0 {
+        return samples.iter().copied().max().map(|v| v as f64);
+    }
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let rank = percentile / 100.0 * (sorted.len() - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        return Some(sorted[lower] as f64);
+    }
+    let lower_val = sorted[lower] as f64;
+    let upper_val = sorted[upper] as f64;
+    let weight = rank - lower as f64;
+    Some(lower_val + (upper_val - lower_val) * weight)
 }
 
 fn emit_summary_event(summary: &BackfillSummary) {


### PR DESCRIPTION
## Objective
- Introduce a repeatable timezone backfill benchmark so we can measure throughput and catch regressions.

## Scope
- Extend the `time` CLI with a `backfill-bench` subcommand that runs against deterministic SQLite fixtures, captures per-chunk metrics, and prints summarized throughput statistics.
- Capture benchmark baselines for the 1k smoke dataset plus the 10k and 100k fixtures and publish them under `docs/backfill-performance.md`.
- Wire the new harness into CI with a lightweight smoke test.
- Generate benchmark fixtures on demand via `scripts/bench/generate_backfill_fixture.ts`, ignore tracked `.sqlite3` databases, and ensure docs/CI instruct running the generator before benchmarking.

## Non-Goals
- No behavioural changes to the backfill algorithm beyond emitting chunk-level metrics.
- No recurrence expansion benchmarking (tracked separately).

## Acceptance Criteria
- ✅ `cargo run --locked --bin time -- backfill-bench --rows 1000 --chunk-size 500 --progress-interval 0 --keep-db`
  - Throughput 5,917 rows/sec, average chunk 83.50 ms. 【logs: chunk_index summary + csv】
- ✅ `cargo run --locked --bin time -- backfill-bench --rows 10000 --chunk-size 500 --progress-interval 0`
  - Run A: Throughput 6,588 rows/sec, average chunk 74.80 ms. 【logs: chunk_index summary】
  - Run B: Throughput 6,739 rows/sec, average chunk 72.95 ms. 【logs: chunk_index summary】
- ✅ `cargo run --locked --bin time -- backfill-bench --rows 100000 --chunk-size 500 --progress-interval 0`
  - Throughput 2,098 rows/sec, average chunk 236.96 ms, max chunk 775 ms (chunk 75). 【logs: chunk_index summary + csv excerpt】
- ✅ Chunk observer emits per-chunk metrics; CLI prints CSV rows for variance inspection.
- ✅ Baselines, hardware context, and reproduction notes documented in `docs/backfill-performance.md`.
- ✅ Added `gate/backfill-bench-smoke` job to `.github/workflows/ci.yml` to run the 1k benchmark on CI.
- ✅ CI and documentation instruct developers to run the fixture generator before benchmarking; `.gitignore` prevents committing generated `.sqlite3` assets.

## Evidence
- CLI outputs for the 1k, 10k, and 100k runs (see terminal logs above for throughput and chunk CSV samples).
- `docs/backfill-performance.md` contains hardware specs, result table, variance snapshot, and reproduction instructions.
- Deterministic fixtures generated via `scripts/bench/generate_backfill_fixture.ts` (Mulberry32 seeded with 42) and stored in `fixtures/time/backfill/`.
- `gate/backfill-bench-smoke` CI job runs `cargo run --locked --bin time -- backfill-bench --rows 1000 --chunk-size 500 --progress-interval 0` after generating the fixtures.

## Rollback Plan
- Remove the `backfill-bench` command and chunk observer wiring from the CLI/backfill modules.
- Delete the benchmark fixtures, generator script, CI job, and `docs/backfill-performance.md`.


------
https://chatgpt.com/codex/tasks/task_e_68cf0b3051a8832a9ccc55e58d7b56b4