### PR TITLE
feat(guard): enrich migration guard readiness telemetry

### DIFF
--- a/docs/ops/backfill-guard.md
+++ b/docs/ops/backfill-guard.md
@@ -1,0 +1,57 @@
+# Backfill Guard Telemetry
+
+The backfill guard blocks migrations and application startup whenever events are
+missing canonical UTC timestamps.  This guard is the preflight check that must
+stay green before PR-20 can drop the legacy wall-clock columns.
+
+## When the guard fails
+
+The guard emits a readiness snapshot before returning an error.  Expect to see
+logs in this shape when pending rows exist:
+
+```
+INFO  arklowdun backfill_guard_status ready=false total_missing=3 \
+      missing_start_total=2 missing_end_total=1 households_with_pending=2 \
+      pending="hh-a (start_at_utc missing 2); hh-b (end_at_utc missing 1)" \
+      pending_additional=0
+ERROR arklowdun backfill_guard_blocked total_missing=3 \
+      missing_start_total=2 missing_end_total=1 \
+      message="Backfill required: 3 events missing UTC values (2 events missing start_at_utc, 1 event missing end_at_utc). Affected households: hh-a (start_at_utc missing 2); hh-b (end_at_utc missing 1). Run backfill --apply before continuing."
+```
+
+The CLI helper prints the same breakdown and exits non-zero:
+
+```
+cargo run --bin migrate -- check --db dev.sqlite
+  …
+Households with events missing UTC fields:
+  hh-a: start_at_utc missing 2, end_at_utc missing 0, total 2
+  hh-b: start_at_utc missing 0, end_at_utc missing 1, total 1
+Backfill required: 3 events missing UTC values (2 events missing start_at_utc, 1 event missing end_at_utc). Affected households: hh-a (start_at_utc missing 2); hh-b (end_at_utc missing 1). Run backfill --apply before continuing.
+```
+
+## When the guard passes
+
+A clean database still emits a readiness line (with `ready=true`) so monitoring
+can confirm the guard ran:
+
+```
+INFO  arklowdun backfill_guard_status ready=true total_missing=0 \
+      missing_start_total=0 missing_end_total=0 households_with_pending=0 \
+      pending="" pending_additional=0
+```
+
+No additional logs are emitted and the command exits with status 0.
+
+## Interpreting the fields
+
+- `ready` — `true` when every event has `start_at_utc` and, if an end exists,
+  `end_at_utc`.
+- `missing_start_total` / `missing_end_total` — aggregate counts
+  of missing fields across all households.
+- `pending` — a truncated (top five) list of households with outstanding rows.
+- `pending_additional` — number of extra households beyond the ones listed.
+
+Operators should clear every household listed in the log or CLI output before
+re-running `backfill --apply`.  Once the guard reports `ready=true`, PR-20’s
+schema changes can safely land.

--- a/src-tauri/scripts/migrate.rs
+++ b/src-tauri/scripts/migrate.rs
@@ -366,7 +366,7 @@ async fn guard_check(db: &Path) -> Result<()> {
         );
     }
 
-    let message = migration_guard::format_guard_failure(status.total_missing);
+    let message = migration_guard::format_guard_failure(&status);
     Err(anyhow!(message))
 }
 

--- a/src-tauri/src/time_shadow.rs
+++ b/src-tauri/src/time_shadow.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-use chrono::{LocalResult, NaiveDateTime, TimeZone, Utc, Offset};
+use chrono::{LocalResult, NaiveDateTime, Offset, TimeZone, Utc};
 use chrono_tz::Tz as ChronoTz;
 use sqlx::{Row, SqlitePool};
 

--- a/src-tauri/tests/migration_guard.rs
+++ b/src-tauri/tests/migration_guard.rs
@@ -31,15 +31,29 @@ async fn guard_detects_pending_events() -> Result<()> {
     .execute(&pool)
     .await?;
 
+    sqlx::query(
+        "INSERT INTO events (id, title, start_at, start_at_utc, end_at, household_id, created_at, updated_at)
+         VALUES ('evt_end', 'Test End', 0, 0, 60000, 'hh', 0, 0)",
+    )
+    .execute(&pool)
+    .await?;
+
     migration_guard::ensure_events_indexes(&pool).await?;
     let status = migration_guard::check_events_backfill(&pool).await?;
-    assert_eq!(status.total_missing, 1);
+    assert_eq!(status.total_missing, 2);
+    assert_eq!(status.total_missing_start_at_utc, 1);
+    assert_eq!(status.total_missing_end_at_utc, 1);
     assert_eq!(status.households.len(), 1);
+    let household = &status.households[0];
+    assert_eq!(household.missing_start_at_utc, 1);
+    assert_eq!(household.missing_end_at_utc, 1);
+    assert_eq!(household.missing_total, 2);
 
+    let expected_message = migration_guard::format_guard_failure(&status);
     let err = migration_guard::enforce_events_backfill_guard(&pool)
         .await
         .expect_err("guard should block when UTC values missing");
-    assert_eq!(err.to_string(), migration_guard::format_guard_failure(1));
+    assert_eq!(err.to_string(), expected_message);
     Ok(())
 }
 
@@ -57,5 +71,8 @@ async fn guard_allows_clean_database() -> Result<()> {
     migration_guard::ensure_events_indexes(&pool).await?;
     let status = migration_guard::enforce_events_backfill_guard(&pool).await?;
     assert_eq!(status.total_missing, 0);
+    assert_eq!(status.total_missing_start_at_utc, 0);
+    assert_eq!(status.total_missing_end_at_utc, 0);
+    assert!(status.is_ready());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- extend the backfill guard status to track start/end UTC deficits and emit readiness logs with household breakdowns
- surface actionable guard failures with targeted messaging in both the runtime guard and the migrate CLI
- capture the expected log output for operators in docs/ops/backfill-guard.md

## Testing
- cargo test --test migration_guard *(fails: missing glib-2.0 system library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cff24270e8832a8f2f1285881d13e8