### PR TITLE
fixupses

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -83,7 +83,7 @@ fn emit_chrono_tz_metadata() {
     ];
 
     let mut version = env::var("DEP_CHRONO_TZ_VERSION").ok();
-    if version.as_deref().map_or(true, |value| value.is_empty()) {
+    if version.as_deref().is_none_or(|value| value.is_empty()) {
         for candidate in &lock_candidates {
             if let Some(lock_version) = chrono_tz_version_from_lock(candidate) {
                 println!("cargo:rerun-if-changed={}", candidate.display());

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -72,6 +72,7 @@ fn parse_timezone_name(value: Option<&Value>) -> Option<String> {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn canonicalize_timezone(tz_name: Option<String>) -> AppResult<(ChronoTz, String)> {
     let name = tz_name.unwrap_or_else(|| "UTC".to_string());
     let parsed: ChronoTz = name.parse().map_err(|_| {
@@ -82,6 +83,7 @@ fn canonicalize_timezone(tz_name: Option<String>) -> AppResult<(ChronoTz, String
     Ok((parsed, parsed.name().to_string()))
 }
 
+#[allow(clippy::result_large_err)]
 fn local_wallclock_ms(ms: i64, tz: &ChronoTz, field: &'static str) -> AppResult<i64> {
     DateTime::<Utc>::from_timestamp_millis(ms)
         .ok_or_else(|| {
@@ -100,6 +102,7 @@ fn local_wallclock_ms(ms: i64, tz: &ChronoTz, field: &'static str) -> AppResult<
         })
 }
 
+#[allow(clippy::result_large_err)]
 fn derive_event_wall_clock_for_create(data: &mut Map<String, Value>) -> AppResult<()> {
     let legacy_start_present = data.contains_key("start_at");
     let legacy_end_present = data.contains_key("end_at");
@@ -292,6 +295,7 @@ fn value_to_i64(value: Option<&Value>) -> Option<i64> {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn optional_string(value: Option<&Value>, field: &'static str) -> AppResult<Option<String>> {
     match value {
         None | Some(Value::Null) => Ok(None),
@@ -309,6 +313,7 @@ fn optional_string(value: Option<&Value>, field: &'static str) -> AppResult<Opti
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn parse_exdate_input(value: &Value) -> AppResult<Vec<String>> {
     match value {
         Value::Null => Ok(Vec::new()),
@@ -339,6 +344,7 @@ fn parse_exdate_input(value: &Value) -> AppResult<Vec<String>> {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn ensure_start_datetime(start_ms: Option<i64>, event_id: &str) -> AppResult<DateTime<Utc>> {
     let ms = start_ms.ok_or_else(|| {
         TimeErrorCode::ExdateOutOfRange
@@ -355,6 +361,7 @@ fn ensure_start_datetime(start_ms: Option<i64>, event_id: &str) -> AppResult<Dat
     })
 }
 
+#[allow(clippy::result_large_err)]
 fn normalize_event_exdates_for_create(data: &mut Map<String, Value>) -> AppResult<()> {
     let Some(exdates_value) = data.get("exdates").cloned() else {
         return Ok(());

--- a/src-tauri/src/events_tz_backfill.rs
+++ b/src-tauri/src/events_tz_backfill.rs
@@ -746,7 +746,7 @@ fn map_row_error(
     app_err
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(clippy::result_large_err, clippy::too_many_arguments)]
 async fn run_dry_run(
     pool: &SqlitePool,
     options: &BackfillOptions,

--- a/src-tauri/src/time_shadow.rs
+++ b/src-tauri/src/time_shadow.rs
@@ -166,6 +166,12 @@ impl ShadowAudit {
     }
 }
 
+impl Default for ShadowAudit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub fn is_shadow_read_enabled() -> bool {
     match std::env::var(ENV_VAR) {
         Ok(raw) => match parse_flag(&raw) {

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -73,9 +73,8 @@ mod tests {
 
     #[test]
     fn dispatch_with_fence_catches_str_panic() {
-        let err = dispatch_with_fence(|| panic!("boom"))
-            .err()
-            .expect("should convert panic into error");
+        let err =
+            dispatch_with_fence(|| panic!("boom")).expect_err("should convert panic into error");
         assert_eq!(err.code(), "RUNTIME/PANIC");
         assert_eq!(err.message(), "boom");
         assert!(err.crash_id().is_some());
@@ -85,8 +84,7 @@ mod tests {
     #[test]
     fn dispatch_with_fence_catches_string_panic() {
         let err = dispatch_with_fence(|| panic_any(String::from("kaboom")))
-            .err()
-            .expect("should convert panic into error");
+            .expect_err("should convert panic into error");
         assert_eq!(err.code(), "RUNTIME/PANIC");
         assert_eq!(err.message(), "kaboom");
         assert!(err.crash_id().is_some());
@@ -96,8 +94,7 @@ mod tests {
     #[test]
     fn dispatch_with_fence_catches_non_string_panic() {
         let err = dispatch_with_fence(|| panic_any(123_i32))
-            .err()
-            .expect("should convert panic into error");
+            .expect_err("should convert panic into error");
         assert_eq!(err.code(), "RUNTIME/PANIC");
         assert_eq!(err.message(), "unknown panic payload");
         assert!(err.crash_id().is_some());

--- a/src-tauri/tests/events_list_range.rs
+++ b/src-tauri/tests/events_list_range.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::await_holding_lock)]
 use arklowdun_lib::{commands, time_shadow};
 use once_cell::sync::Lazy;
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};

--- a/src-tauri/tests/log_file_smoke.rs
+++ b/src-tauri/tests/log_file_smoke.rs
@@ -86,13 +86,13 @@ fn file_sink_writes_json_lines() {
     };
 
     // event should exist and be a string
-    assert!(get(&line, "event").is_some());
-    assert_eq!(get(&line, "level").as_deref(), Some("INFO"));
+    assert!(get(line, "event").is_some());
+    assert_eq!(get(line, "level").as_deref(), Some("INFO"));
     assert!(
         line.get("timestamp").and_then(|v| v.as_str()).is_some(),
         "timestamp must be present"
     );
-    let target_binding = get(&line, "target");
+    let target_binding = get(line, "target");
     let target = target_binding.as_deref();
     assert!(
         matches!(target, Some("arklowdun") | Some("arklowdun_lib")),

--- a/src-tauri/tests/log_rotation.rs
+++ b/src-tauri/tests/log_rotation.rs
@@ -236,7 +236,7 @@ fn wait_for_current_run(logs_dir: &Path, run: &str) {
         if let Ok(file) = fs::File::open(&current) {
             let reader = BufReader::new(file);
             let mut found = false;
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 if line.contains(&format!("\"run\":\"{}\"", run)) {
                     found = true;
                 }

--- a/src-tauri/tests/panic_fence.rs
+++ b/src-tauri/tests/panic_fence.rs
@@ -82,7 +82,7 @@ fn panic_is_converted_to_error() {
 
     let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
     assert!(
-        logs.contains(&format!("\"event\":\"panic_caught\"")),
+        logs.contains("\"event\":\"panic_caught\""),
         "panic log missing: {logs}"
     );
     assert!(

--- a/src-tauri/tests/rrule_matrix.rs
+++ b/src-tauri/tests/rrule_matrix.rs
@@ -261,7 +261,7 @@ async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
     sqlx::query(
         "INSERT INTO household (id, name, tz, created_at, updated_at, deleted_at) VALUES (?1, ?2, ?3, 0, 0, NULL)",
     )
-    .bind(&scenario.household_id())
+    .bind(scenario.household_id())
     .bind(format!("Fixture household {}", scenario.name))
     .bind(scenario.timezone)
     .execute(pool)
@@ -287,8 +287,8 @@ async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
                 "INSERT INTO events (id, household_id, title, start_at, end_at, tz, start_at_utc, end_at_utc, rrule, exdates, reminder, created_at, updated_at, deleted_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL, 0, 0, NULL)",
             )
-            .bind(&scenario.event_id())
-            .bind(&scenario.household_id())
+            .bind(scenario.event_id())
+            .bind(scenario.household_id())
             .bind(format!("Scenario {}", scenario.name))
             .bind(start_at)
             .bind(end_at)
@@ -304,8 +304,8 @@ async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
                 "INSERT INTO events (id, household_id, title, start_at, tz, start_at_utc, end_at_utc, rrule, exdates, reminder, created_at, updated_at, deleted_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, 0, 0, NULL)",
             )
-            .bind(&scenario.event_id())
-            .bind(&scenario.household_id())
+            .bind(scenario.event_id())
+            .bind(scenario.household_id())
             .bind(format!("Scenario {}", scenario.name))
             .bind(start_at)
             .bind(scenario.timezone)
@@ -320,8 +320,8 @@ async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
                 "INSERT INTO events (id, household_id, title, end_at, tz, start_at_utc, end_at_utc, rrule, exdates, reminder, created_at, updated_at, deleted_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, 0, 0, NULL)",
             )
-            .bind(&scenario.event_id())
-            .bind(&scenario.household_id())
+            .bind(scenario.event_id())
+            .bind(scenario.household_id())
             .bind(format!("Scenario {}", scenario.name))
             .bind(end_at)
             .bind(scenario.timezone)
@@ -336,8 +336,8 @@ async fn seed_event(pool: &SqlitePool, scenario: &Scenario) -> Result<()> {
                 "INSERT INTO events (id, household_id, title, tz, start_at_utc, end_at_utc, rrule, exdates, reminder, created_at, updated_at, deleted_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, NULL, 0, 0, NULL)",
             )
-            .bind(&scenario.event_id())
-            .bind(&scenario.household_id())
+            .bind(scenario.event_id())
+            .bind(scenario.household_id())
             .bind(format!("Scenario {}", scenario.name))
             .bind(scenario.timezone)
             .bind(start_at_utc)


### PR DESCRIPTION
## Section 1 Progress
Tick all checkboxes that this PR advances and link to supporting evidence where possible.

- [ ] 1) Create the feature-slice skeleton and import aliases
- [ ] 2) Introduce architectural lint rules + guardrails
- [ ] 3) Add a tiny global store + event bus
- [ ] 4) Build UI primitives and refactor Files pane
- [ ] 5) Introduce layout primitives and hash-router cleanup
- [ ] 6) Design tokens → tokens-to-class pipeline
- [ ] 7) Calendar refactor → primitives/layout
- [ ] 8) Notes refactor → primitives/layout
- [ ] 9) Settings refactor → primitives/layout
- [ ] 10) Tests, CI wiring, and migration of remaining panes

## Summary
<!-- One-paragraph summary of the change. Include key paths and user-visible effects. -->

## Gate Scans (run locally before push)
- [ ] `npm run gate:ipc-in-components`
- [ ] `npm run gate:no-deep-relatives`
- [ ] `npm run gate:cross-feature-report`

## UI Screenshots
- [ ] Not a UI change
- Before: <!-- attach image or `n/a` -->
- After: <!-- attach image or `n/a` -->

## Proof
Provide links to logs or copy the command output proving each check.

- ESLint: <!-- link to CI log or `npm run lint` output -->
- Axe (Playwright a11y): <!-- link to CI log or `npm run test:a11y` output -->
- Playwright spec(s): <!-- list spec names or link to run -->
