### PR TITLE
fix(guard): relax ensure_db_writable state bound

### DIFF
--- a/src-tauri/src/ipc/guard.rs
+++ b/src-tauri/src/ipc/guard.rs
@@ -30,6 +30,7 @@ pub const DB_UNHEALTHY_CLI_HINT: &str = "Run 'arklowdun db status' or repair.";
 pub const DB_UNHEALTHY_EXIT_CODE: i32 = 2;
 
 #[must_use = "Database health must be checked before executing a mutation"]
+#[derive(Debug)]
 pub struct DbWriteGuard {
     _private: (),
 }
@@ -46,10 +47,9 @@ impl DbWriteGuard {
 /// [`DbHealthReport`] attached so callers can surface detailed diagnostics to the UI.
 #[allow(clippy::result_large_err)]
 #[must_use = "Database health must be checked before executing a mutation"]
-pub fn ensure_db_writable<S>(state: &S) -> AppResult<DbWriteGuard>
-where
-    S: Deref<Target = AppState>,
-{
+pub fn ensure_db_writable(
+    state: &(impl Deref<Target = AppState> + ?Sized),
+) -> AppResult<DbWriteGuard> {
     let report = state
         .db_health
         .lock()


### PR DESCRIPTION
## Summary
- update `ensure_db_writable` to accept any `Deref<Target = AppState>` reference, resolving IDE inference issues without changing behavior
- derive `Debug` for `DbWriteGuard` to keep analyzer hints from appearing in future diagnostics

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml --test db_status_cli
- cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
- npm run typecheck
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3acf64c00832aa78d494c85cb74c4