### PR TITLE
feat: add cargo licensing inventory pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,12 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - name: Generate npm license inventory
+      - name: Generate cross-ecosystem license inventory
         run: npm run licensing:inventory
-      - name: Upload inventory artifact
+      - name: Upload inventory artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: licensing-npm-inventory
-          path: artifacts/licensing/npm-inventory.json
+          name: licensing-inventory
+          path: artifacts/licensing
+          if-no-files-found: error
 

--- a/fixtures/licensing/Cargo.lock.fixture
+++ b/fixtures/licensing/Cargo.lock.fixture
@@ -1,0 +1,35 @@
+version = 3
+
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = [
+  "serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "git-crate 0.2.0 (git+https://github.com/example/git-crate?rev=abcdef#abcdef)",
+  "local-dep 0.3.0",
+  "missing-license 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
+]
+
+[[package]]
+name = "serde"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "sha-serde"
+features = ["derive"]
+
+[[package]]
+name = "git-crate"
+version = "0.2.0"
+source = "git+https://github.com/example/git-crate?rev=abcdef#abcdef"
+
+[[package]]
+name = "local-dep"
+version = "0.3.0"
+source = "path+file:///workspace/Arklowdun/crates/local-dep"
+checksum = "sha-local"
+
+[[package]]
+name = "missing-license"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "sha-missing"

--- a/fixtures/licensing/cargo-inventory.json
+++ b/fixtures/licensing/cargo-inventory.json
@@ -1,0 +1,114 @@
+{
+  "generatedAt": "2024-01-01T00:00:00.000Z",
+  "source": {
+    "type": "cargo",
+    "lockfile": "fixtures/licensing/Cargo.lock.fixture",
+    "metadata": "fixtures/licensing/cargo-metadata.json"
+  },
+  "dependencies": [
+    {
+      "name": "git-crate",
+      "version": "0.2.0",
+      "dependencyType": "direct",
+      "licenses": ["Apache-2.0"],
+      "resolved": "git+https://github.com/example/git-crate?rev=abcdef#abcdef",
+      "checksum": "UNKNOWN",
+      "source": {
+        "type": "git",
+        "location": "git+https://github.com/example/git-crate?rev=abcdef#abcdef"
+      },
+      "provenance": [
+        {
+          "ecosystem": "cargo",
+          "dependencyType": "direct",
+          "resolved": "git+https://github.com/example/git-crate?rev=abcdef#abcdef",
+          "checksum": "UNKNOWN",
+          "source": {
+            "type": "git",
+            "location": "git+https://github.com/example/git-crate?rev=abcdef#abcdef"
+          }
+        }
+      ]
+    },
+    {
+      "name": "local-dep",
+      "version": "0.3.0",
+      "dependencyType": "direct",
+      "licenses": ["UNKNOWN"],
+      "resolved": "path+file:///workspace/Arklowdun/crates/local-dep",
+      "checksum": "sha-local",
+      "source": {
+        "type": "path",
+        "location": "crates/local-dep/Cargo.toml"
+      },
+      "notes": "license metadata unavailable in cargo metadata; See license file at /workspace/Arklowdun/crates/local-dep/LICENSE",
+      "provenance": [
+        {
+          "ecosystem": "cargo",
+          "dependencyType": "direct",
+          "resolved": "path+file:///workspace/Arklowdun/crates/local-dep",
+          "checksum": "sha-local",
+          "source": {
+            "type": "path",
+            "location": "crates/local-dep/Cargo.toml"
+          }
+        }
+      ]
+    },
+    {
+      "name": "missing-license",
+      "version": "0.4.0",
+      "dependencyType": "direct",
+      "licenses": ["UNKNOWN"],
+      "resolved": "https://github.com/rust-lang/crates.io-index#missing-license@0.4.0",
+      "checksum": "sha-missing",
+      "source": {
+        "type": "registry",
+        "location": "registry+https://github.com/rust-lang/crates.io-index",
+        "registry": "https://github.com/rust-lang/crates.io-index"
+      },
+      "notes": "license metadata unavailable in cargo metadata",
+      "provenance": [
+        {
+          "ecosystem": "cargo",
+          "dependencyType": "direct",
+          "resolved": "https://github.com/rust-lang/crates.io-index#missing-license@0.4.0",
+          "checksum": "sha-missing",
+          "source": {
+            "type": "registry",
+            "location": "registry+https://github.com/rust-lang/crates.io-index",
+            "registry": "https://github.com/rust-lang/crates.io-index"
+          }
+        }
+      ]
+    },
+    {
+      "name": "serde",
+      "version": "1.0.0",
+      "dependencyType": "direct",
+      "licenses": ["MIT", "Apache-2.0"],
+      "resolved": "https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+      "checksum": "sha-serde",
+      "source": {
+        "type": "registry",
+        "location": "registry+https://github.com/rust-lang/crates.io-index",
+        "registry": "https://github.com/rust-lang/crates.io-index"
+      },
+      "features": ["derive"],
+      "provenance": [
+        {
+          "ecosystem": "cargo",
+          "dependencyType": "direct",
+          "resolved": "https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+          "checksum": "sha-serde",
+          "source": {
+            "type": "registry",
+            "location": "registry+https://github.com/rust-lang/crates.io-index",
+            "registry": "https://github.com/rust-lang/crates.io-index"
+          },
+          "features": ["derive"]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/licensing/cargo-metadata.json
+++ b/fixtures/licensing/cargo-metadata.json
@@ -1,0 +1,99 @@
+{
+  "packages": [
+    {
+      "id": "path+file:///workspace/Arklowdun/app#app@0.1.0",
+      "name": "app",
+      "version": "0.1.0",
+      "license": "MIT",
+      "license_file": null,
+      "source": null,
+      "manifest_path": "/workspace/Arklowdun/app/Cargo.toml",
+      "description": "Fixture workspace application",
+      "repository": null
+    },
+    {
+      "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+      "name": "serde",
+      "version": "1.0.0",
+      "license": "MIT OR Apache-2.0",
+      "license_file": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "manifest_path": "/registry/serde/Cargo.toml",
+      "description": null,
+      "repository": "https://github.com/serde-rs/serde"
+    },
+    {
+      "id": "git+https://github.com/example/git-crate?rev=abcdef#git-crate@0.2.0",
+      "name": "git-crate",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "license_file": null,
+      "source": "git+https://github.com/example/git-crate?rev=abcdef#abcdef",
+      "manifest_path": "/tmp/git-crate/Cargo.toml",
+      "description": "Git dependency fixture",
+      "repository": "https://github.com/example/git-crate"
+    },
+    {
+      "id": "path+file:///workspace/Arklowdun/crates/local-dep#local-dep@0.3.0",
+      "name": "local-dep",
+      "version": "0.3.0",
+      "license": null,
+      "license_file": "/workspace/Arklowdun/crates/local-dep/LICENSE",
+      "source": "path+file:///workspace/Arklowdun/crates/local-dep",
+      "manifest_path": "/workspace/Arklowdun/crates/local-dep/Cargo.toml",
+      "description": null,
+      "repository": null
+    },
+    {
+      "id": "registry+https://github.com/rust-lang/crates.io-index#missing-license@0.4.0",
+      "name": "missing-license",
+      "version": "0.4.0",
+      "license": null,
+      "license_file": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "manifest_path": "/registry/missing-license/Cargo.toml",
+      "description": "Deliberately missing license",
+      "repository": null
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "id": "path+file:///workspace/Arklowdun/app#app@0.1.0",
+        "deps": [
+          {
+            "name": "serde",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+            "dep_kinds": [
+              { "kind": null }
+            ]
+          },
+          {
+            "name": "git-crate",
+            "pkg": "git+https://github.com/example/git-crate?rev=abcdef#git-crate@0.2.0",
+            "dep_kinds": [
+              { "kind": "build" }
+            ]
+          },
+          {
+            "name": "local-dep",
+            "pkg": "path+file:///workspace/Arklowdun/crates/local-dep#local-dep@0.3.0",
+            "dep_kinds": [
+              { "kind": null }
+            ]
+          },
+          {
+            "name": "missing-license",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#missing-license@0.4.0",
+            "dep_kinds": [
+              { "kind": null }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "workspace_members": [
+    "path+file:///workspace/Arklowdun/app#app@0.1.0"
+  ]
+}

--- a/fixtures/licensing/npm-inventory.json
+++ b/fixtures/licensing/npm-inventory.json
@@ -1,82 +1,131 @@
 {
   "generatedAt": "2024-01-01T00:00:00.000Z",
   "source": {
-    "packageManager": "npm",
+    "type": "npm",
     "lockfile": "fixtures/licensing/package-lock.fixture.json"
   },
   "dependencies": [
     {
       "name": "alpha",
       "version": "1.0.1",
+      "dependencyType": "direct",
+      "licenses": ["MIT"],
       "resolved": "https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz",
       "checksum": "sha512-alpha",
-      "dependencyType": "direct",
-      "licenses": [
-        "MIT"
-      ],
       "source": {
         "type": "npm",
         "location": "https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz"
-      }
+      },
+      "provenance": [
+        {
+          "ecosystem": "npm",
+          "dependencyType": "direct",
+          "resolved": "https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz",
+          "checksum": "sha512-alpha",
+          "source": {
+            "type": "npm",
+            "location": "https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz"
+          }
+        }
+      ]
     },
     {
       "name": "bravo",
       "version": "2.1.0",
+      "dependencyType": "direct",
+      "licenses": ["Apache-2.0", "BSD-3-Clause"],
       "resolved": "https://registry.npmjs.org/bravo/-/bravo-2.1.0.tgz",
       "checksum": "sha512-bravo",
-      "dependencyType": "direct",
-      "licenses": [
-        "Apache-2.0",
-        "BSD-3-Clause"
-      ],
       "source": {
         "type": "npm",
         "location": "https://registry.npmjs.org/bravo/-/bravo-2.1.0.tgz"
       },
-      "notes": "bravo@2.1.0 is deprecated: security fixes available in 2.2.0"
+      "notes": "bravo@2.1.0 is deprecated: security fixes available in 2.2.0",
+      "provenance": [
+        {
+          "ecosystem": "npm",
+          "dependencyType": "direct",
+          "resolved": "https://registry.npmjs.org/bravo/-/bravo-2.1.0.tgz",
+          "checksum": "sha512-bravo",
+          "source": {
+            "type": "npm",
+            "location": "https://registry.npmjs.org/bravo/-/bravo-2.1.0.tgz"
+          }
+        }
+      ]
     },
     {
       "name": "charlie",
       "version": "3.0.0",
+      "dependencyType": "direct",
+      "licenses": ["UNKNOWN"],
       "resolved": "https://registry.npmjs.org/charlie/-/charlie-3.0.0.tgz",
       "checksum": "sha512-charlie",
-      "dependencyType": "direct",
-      "licenses": [
-        "UNKNOWN"
-      ],
       "source": {
         "type": "npm",
         "location": "https://registry.npmjs.org/charlie/-/charlie-3.0.0.tgz"
       },
-      "notes": "license metadata unavailable in lockfile"
+      "notes": "license metadata unavailable in lockfile",
+      "provenance": [
+        {
+          "ecosystem": "npm",
+          "dependencyType": "direct",
+          "resolved": "https://registry.npmjs.org/charlie/-/charlie-3.0.0.tgz",
+          "checksum": "sha512-charlie",
+          "source": {
+            "type": "npm",
+            "location": "https://registry.npmjs.org/charlie/-/charlie-3.0.0.tgz"
+          }
+        }
+      ]
     },
     {
       "name": "delta",
       "version": "4.5.6",
+      "dependencyType": "indirect",
+      "licenses": ["ISC"],
       "resolved": "https://registry.npmjs.org/delta/-/delta-4.5.6.tgz",
       "checksum": "sha512-delta",
-      "dependencyType": "indirect",
-      "licenses": [
-        "ISC"
-      ],
       "source": {
         "type": "npm",
         "location": "https://registry.npmjs.org/delta/-/delta-4.5.6.tgz"
-      }
+      },
+      "provenance": [
+        {
+          "ecosystem": "npm",
+          "dependencyType": "indirect",
+          "resolved": "https://registry.npmjs.org/delta/-/delta-4.5.6.tgz",
+          "checksum": "sha512-delta",
+          "source": {
+            "type": "npm",
+            "location": "https://registry.npmjs.org/delta/-/delta-4.5.6.tgz"
+          }
+        }
+      ]
     },
     {
       "name": "echo",
       "version": "7.8.9",
+      "dependencyType": "indirect",
+      "licenses": ["GPL-2.0-or-later WITH Autoconf-exception-3.0"],
       "resolved": "https://registry.npmjs.org/echo/-/echo-7.8.9.tgz",
       "checksum": "sha512-echo",
-      "dependencyType": "indirect",
-      "licenses": [
-        "GPL-2.0-or-later WITH Autoconf-exception-3.0"
-      ],
       "source": {
         "type": "npm",
         "location": "https://registry.npmjs.org/echo/-/echo-7.8.9.tgz"
-      }
+      },
+      "provenance": [
+        {
+          "ecosystem": "npm",
+          "dependencyType": "indirect",
+          "resolved": "https://registry.npmjs.org/echo/-/echo-7.8.9.tgz",
+          "checksum": "sha512-echo",
+          "source": {
+            "type": "npm",
+            "location": "https://registry.npmjs.org/echo/-/echo-7.8.9.tgz"
+          }
+        }
+      ]
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
+        "@iarna/toml": "^2.2.5",
         "@playwright/test": "^1.49.0",
         "@tauri-apps/cli": "^2.8.3",
         "@types/better-sqlite3": "^7.6.13",
@@ -42,7 +43,8 @@
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
         "vite": "^6.0.3",
-        "vitest": "^1.6.0"
+        "vitest": "^1.6.0",
+        "yaml": "^2.8.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -877,6 +879,13 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -9222,6 +9231,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gate:query-perf-smoke": "node scripts/ci/query-perf-smoke.mjs",
     "perf:query:local": "node scripts/ci/query-perf-local.mjs",
     "gate:scan": "npm run gate:ipc-in-components && npm run gate:no-deep-relatives && npm run gate:cross-feature-report",
-    "licensing:inventory": "tsx scripts/licensing/npm-inventory.ts",
+    "licensing:inventory": "tsx scripts/licensing/pipeline.ts",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:structure": "node scripts/guards/structure-lint.mjs",
     "check": "npm run typecheck && echo TS OK && npm run lint && npm run guard:invoke && npm run guard:ui-colors && npm run guard:db-writes && npm run guard:recovery-strings && npm run lint:structure",
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",
+    "@iarna/toml": "^2.2.5",
     "@playwright/test": "^1.49.0",
     "@tauri-apps/cli": "^2.8.3",
     "@types/better-sqlite3": "^7.6.13",
@@ -95,6 +96,7 @@
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vite": "^6.0.3",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "yaml": "^2.8.1"
   }
 }

--- a/schema/licensing-inventory.schema.json
+++ b/schema/licensing-inventory.schema.json
@@ -10,19 +10,49 @@
       "format": "date-time"
     },
     "source": {
-      "type": "object",
-      "required": ["packageManager", "lockfile"],
-      "additionalProperties": false,
-      "properties": {
-        "packageManager": {
-          "type": "string",
-          "enum": ["npm"]
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "lockfile"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "npm" },
+            "lockfile": { "type": "string", "minLength": 1 }
+          }
         },
-        "lockfile": {
-          "type": "string",
-          "minLength": 1
+        {
+          "type": "object",
+          "required": ["type", "lockfile", "metadata"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "cargo" },
+            "lockfile": { "type": "string", "minLength": 1 },
+            "metadata": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "inputs"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "aggregate" },
+            "inputs": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["type", "path"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["npm", "cargo"] },
+                  "path": { "type": "string", "minLength": 1 }
+                }
+              },
+              "uniqueItems": true
+            }
+          }
         }
-      }
+      ]
     },
     "dependencies": {
       "type": "array",
@@ -32,38 +62,17 @@
         "required": [
           "name",
           "version",
-          "resolved",
-          "checksum",
           "dependencyType",
           "licenses",
-          "source"
+          "resolved",
+          "checksum",
+          "source",
+          "provenance"
         ],
         "additionalProperties": false,
         "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1
-          },
-          "version": {
-            "type": "string",
-            "minLength": 1
-          },
-          "resolved": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "string",
-                "enum": ["UNKNOWN"]
-              }
-            ]
-          },
-          "checksum": {
-            "type": "string",
-            "minLength": 1
-          },
+          "name": { "type": "string", "minLength": 1 },
+          "version": { "type": "string", "minLength": 1 },
           "dependencyType": {
             "type": "string",
             "enum": ["direct", "indirect"]
@@ -77,6 +86,8 @@
             },
             "uniqueItems": true
           },
+          "resolved": { "type": "string", "minLength": 1 },
+          "checksum": { "type": "string", "minLength": 1 },
           "source": {
             "type": "object",
             "required": ["type", "location"],
@@ -84,16 +95,54 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["npm", "git", "manual"]
+                "enum": ["npm", "git", "manual", "registry", "path", "aggregate"]
               },
-              "location": {
-                "type": "string",
-                "minLength": 1
-              }
+              "location": { "type": "string", "minLength": 1 },
+              "registry": { "type": "string" }
             }
           },
-          "notes": {
-            "type": "string"
+          "features": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "notes": { "type": "string" },
+          "provenance": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["ecosystem", "dependencyType", "resolved", "checksum", "source"],
+              "additionalProperties": false,
+              "properties": {
+                "ecosystem": { "type": "string", "enum": ["npm", "cargo"] },
+                "dependencyType": {
+                  "type": "string",
+                  "enum": ["direct", "indirect"]
+                },
+                "resolved": { "type": "string", "minLength": 1 },
+                "checksum": { "type": "string", "minLength": 1 },
+                "source": {
+                  "type": "object",
+                  "required": ["type", "location"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["npm", "git", "manual", "registry", "path", "aggregate"]
+                    },
+                    "location": { "type": "string", "minLength": 1 },
+                    "registry": { "type": "string" }
+                  }
+                },
+                "features": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "uniqueItems": true
+                },
+                "notes": { "type": "string" }
+              }
+            }
           }
         }
       },

--- a/scripts/licensing/README.md
+++ b/scripts/licensing/README.md
@@ -1,7 +1,9 @@
 # Licensing Inventory Pipeline
 
-The licensing inventory pipeline normalises dependency metadata from npm lockfiles
-into a shared schema that downstream gates can reason about.
+The licensing inventory pipeline normalises dependency metadata from both npm
+and Cargo lockfiles into a shared schema that downstream compliance gates can
+reason about. The orchestrator produces ecosystem-specific reports as well as a
+unified view that deduplicates packages crossing the JavaScript/Rust boundary.
 
 ## Usage
 
@@ -9,47 +11,69 @@ into a shared schema that downstream gates can reason about.
 npm run licensing:inventory
 ```
 
-The command reads the root `package-lock.json`, validates the output against
-`schema/licensing-inventory.schema.json`, and writes the machine-readable
-inventory to `artifacts/licensing/npm-inventory.json`. The CLI exits with status
-`2` whenever warnings (for example, missing licenses) are detected so that CI
-surfaces actionable follow-up immediately.
+The command runs the following steps:
+
+1. Parse `package-lock.json` to build `artifacts/licensing/npm-inventory.json`.
+2. Parse `src-tauri/Cargo.lock` (plus `cargo metadata`) to build
+   `artifacts/licensing/cargo-inventory.json`.
+3. Merge both inventories into `artifacts/licensing/full-inventory.json`,
+   reconciling license data and recording provenance for each ecosystem.
+
+All inventories are validated against `schema/licensing-inventory.schema.json`.
+The CLI exits with status `2` whenever warnings (for example, missing licenses
+or unparsable SPDX expressions) are detected so that CI surfaces actionable
+follow-up immediately.
 
 ### Options
 
-The CLI accepts a small number of flags when invoked via `tsx` or `node`:
+The pipeline accepts a small number of flags when invoked via `tsx` or `node`:
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--lockfile` / `-l` | Path to an npm `package-lock.json` | `./package-lock.json` |
-| `--output` / `-o` | Output path for the generated inventory | `./artifacts/licensing/npm-inventory.json` |
+| `--npm-lockfile` | Path to an npm `package-lock.json` | `./package-lock.json` |
+| `--cargo-lockfile` | Path to the workspace `Cargo.lock` | `./src-tauri/Cargo.lock` |
+| `--cargo-manifest` | Path to the root `Cargo.toml` (used when invoking `cargo metadata`) | `./src-tauri/Cargo.toml` |
+| `--cargo-metadata` | Optional JSON file containing pre-recorded `cargo metadata` output | _generated on the fly_ |
 | `--schema` / `-s` | Path to the shared inventory schema | `./schema/licensing-inventory.schema.json` |
-| `--overrides` | Optional JSON file providing manual license notes or corrections | _none_ |
+| `--output` / `-o` | Directory where inventory artifacts are written | `./artifacts/licensing` |
+| `--overrides` | Optional overrides file (YAML or JSON) | `./scripts/licensing/overrides.yaml` when present |
 
-Example running against a fixture lockfile:
+Example running against the synthetic fixtures bundled with the repository:
 
 ```bash
-npx tsx scripts/licensing/npm-inventory.ts \
-  --lockfile fixtures/licensing/package-lock.fixture.json \
-  --output fixtures/licensing/npm-inventory.json
+npx tsx scripts/licensing/pipeline.ts \
+  --npm-lockfile fixtures/licensing/package-lock.fixture.json \
+  --cargo-lockfile fixtures/licensing/Cargo.lock.fixture \
+  --cargo-metadata fixtures/licensing/cargo-metadata.json \
+  --output fixtures/licensing
 ```
 
 ## Overrides
 
-When upstream packages are missing SPDX data you can provide overrides in a
-simple JSON map. Keys may be either a bare package name or the fully qualified
-`name@version` tuple. The default override file lives at
-`scripts/licensing/npm-overrides.json` and is loaded automatically when present.
+When upstream packages are missing SPDX data or disagree across ecosystems you
+can provide overrides in `scripts/licensing/overrides.yaml`. Keys may be either a
+bare package name or the fully qualified `name@version` tuple. Each entry accepts
+the following fields:
+
+- `licenses` – canonical SPDX identifiers to apply.
+- `notes` – explanatory text that will be appended to the dependency entry.
+- `ecosystems` – optional list restricting the override to specific scopes (`npm`,
+  `cargo`, or `aggregate`).
+
 Example:
 
-```json
-{
-  "left-pad": {
-    "licenses": ["MIT"],
-    "notes": "Verified manually via upstream repository"
-  }
-}
+```yaml
+dual-lib@1.2.3:
+  licenses:
+    - MIT
+    - Apache-2.0
+  ecosystems:
+    - aggregate
+  notes: Verified dual-license via upstream notice
 ```
+
+Overrides are validated during the pipeline run: entries that no longer match an
+observed dependency cause the job to fail so stale entries can be cleaned up.
 
 ## Troubleshooting
 
@@ -61,3 +85,6 @@ Example:
 - **Schema validation errors** – the CLI exits with details when the generated
   JSON does not satisfy the schema. Ensure custom tooling writes all required
   fields before consuming the artifact.
+- **Cross-ecosystem conflicts** – when npm and Cargo disagree on a dependency's
+  license, the merge step fails until an aggregate override specifies the
+  canonical license set.

--- a/scripts/licensing/cargo-inventory.ts
+++ b/scripts/licensing/cargo-inventory.ts
@@ -1,0 +1,466 @@
+import { readFile, writeFile, mkdir, access } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { parse as parseToml } from "@iarna/toml";
+import {
+  DependencyType,
+  Inventory,
+  InventoryDependency,
+  InventorySource,
+  dedupeStrings,
+  sortDependencies
+} from "./lib/utils.ts";
+import { normaliseLicenses } from "./lib/spdx.ts";
+import { loadOverrides, Overrides } from "./lib/overrides.ts";
+
+const execFileAsync = promisify(execFile);
+
+type LockPackage = {
+  name: string;
+  version: string;
+  source?: string;
+  checksum?: string;
+  dependencies?: string[];
+  features?: string[];
+};
+
+type Lockfile = {
+  package?: LockPackage[];
+};
+
+type MetadataPackage = {
+  id: string;
+  name: string;
+  version: string;
+  license?: string | null;
+  license_file?: string | null;
+  source?: string | null;
+  manifest_path?: string;
+  description?: string | null;
+  repository?: string | null;
+};
+
+type MetadataResolveNode = {
+  id: string;
+  deps?: Array<{
+    pkg: string;
+    dep_kinds?: Array<{
+      kind?: string | null;
+    }>;
+  }>;
+};
+
+type Metadata = {
+  packages: MetadataPackage[];
+  resolve?: {
+    nodes?: MetadataResolveNode[];
+  };
+  workspace_members: string[];
+};
+
+type GenerateCargoInventoryOptions = {
+  lockfilePath: string;
+  schemaPath: string;
+  projectRoot: string;
+  overrides: Overrides;
+  warn: (message: string) => void;
+  metadataPath?: string;
+  manifestPath?: string;
+};
+
+function parseLockfile(contents: string): Lockfile {
+  const parsed = parseToml(contents);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Unable to parse Cargo.lock");
+  }
+  return parsed as Lockfile;
+}
+
+function toPackageId(pkg: LockPackage): string | undefined {
+  if (!pkg.source) {
+    return undefined;
+  }
+  return `${pkg.source}#${pkg.name}@${pkg.version}`;
+}
+
+function resolveDependencyType(
+  pkgId: string | undefined,
+  directDeps: Set<string>
+): DependencyType {
+  if (pkgId && directDeps.has(pkgId)) {
+    return "direct";
+  }
+  return "indirect";
+}
+
+function buildSource(
+  pkg: LockPackage,
+  metadata: MetadataPackage | undefined,
+  projectRoot: string
+): InventorySource {
+  const source = pkg.source ?? metadata?.source ?? null;
+  if (!source) {
+    const manifest = metadata?.manifest_path;
+    if (manifest) {
+      return {
+        type: "path",
+        location: relative(projectRoot, manifest)
+      };
+    }
+    return { type: "manual", location: pkg.name };
+  }
+
+  if (source.startsWith("registry+")) {
+    return {
+      type: "registry",
+      location: source,
+      registry: source.replace(/^registry\+/, "")
+    };
+  }
+
+  if (source.startsWith("git+")) {
+    return {
+      type: "git",
+      location: source
+    };
+  }
+
+  if (source.startsWith("path+")) {
+    const manifest = metadata?.manifest_path;
+    return {
+      type: "path",
+      location: manifest ? relative(projectRoot, manifest) : source.replace(/^path\+/, "")
+    };
+  }
+
+  return {
+    type: "manual",
+    location: source
+  };
+}
+
+function extractFeatures(pkg: LockPackage): string[] | undefined {
+  if (!pkg.features || pkg.features.length === 0) {
+    return undefined;
+  }
+  return dedupeStrings(pkg.features);
+}
+
+function collectDirectDependencies(metadata: Metadata): Set<string> {
+  const direct = new Set<string>();
+  const resolveNodes = metadata.resolve?.nodes ?? [];
+  const nodeMap = new Map<string, MetadataResolveNode>();
+  for (const node of resolveNodes) {
+    nodeMap.set(node.id, node);
+  }
+
+  for (const memberId of metadata.workspace_members) {
+    const node = nodeMap.get(memberId);
+    if (!node) continue;
+    for (const dep of node.deps ?? []) {
+      const kinds = dep.dep_kinds ?? [];
+      const isDirect =
+        kinds.length === 0 ||
+        kinds.some((kind) => kind.kind === null || kind.kind === "normal" || kind.kind === "build");
+      if (isDirect) {
+        direct.add(dep.pkg);
+      }
+    }
+  }
+
+  return direct;
+}
+
+function buildMetadataMaps(metadata: Metadata) {
+  const byId = new Map<string, MetadataPackage>();
+  const byNameVersion = new Map<string, MetadataPackage>();
+  for (const pkg of metadata.packages) {
+    byId.set(pkg.id, pkg);
+    const key = `${pkg.name}@${pkg.version}`;
+    if (!byNameVersion.has(key)) {
+      byNameVersion.set(key, pkg);
+    }
+  }
+  return { byId, byNameVersion };
+}
+
+function findMetadataPackage(
+  lockPkg: LockPackage,
+  maps: ReturnType<typeof buildMetadataMaps>
+): MetadataPackage | undefined {
+  const id = toPackageId(lockPkg);
+  if (id && maps.byId.has(id)) {
+    return maps.byId.get(id);
+  }
+  const key = `${lockPkg.name}@${lockPkg.version}`;
+  return maps.byNameVersion.get(key);
+}
+
+function isWorkspaceMember(
+  metadataPkg: MetadataPackage | undefined,
+  metadata: Metadata
+): boolean {
+  if (!metadataPkg) return false;
+  return metadata.workspace_members.includes(metadataPkg.id);
+}
+
+function normaliseChecksum(value: string | undefined): string {
+  return value && value.trim().length > 0 ? value : "UNKNOWN";
+}
+
+function determineResolved(pkg: LockPackage, metadataPkg: MetadataPackage | undefined): string {
+  const source = pkg.source ?? metadataPkg?.source ?? undefined;
+  if (!source) {
+    return "UNKNOWN";
+  }
+  if (source.startsWith("registry+")) {
+    const registry = source.replace(/^registry\+/, "");
+    return `${registry}#${pkg.name}@${pkg.version}`;
+  }
+  if (source.startsWith("git+")) {
+    return source;
+  }
+  if (source.startsWith("path+")) {
+    return source;
+  }
+  return source;
+}
+
+export async function generateCargoInventory({
+  lockfilePath,
+  schemaPath,
+  projectRoot,
+  overrides,
+  warn,
+  metadataPath,
+  manifestPath
+}: GenerateCargoInventoryOptions): Promise<Inventory> {
+  const lockfileRaw = await readFile(lockfilePath, "utf8");
+  const lockfile = parseLockfile(lockfileRaw);
+  const packages = lockfile.package ?? [];
+
+  const metadataRaw = metadataPath
+    ? await readFile(metadataPath, "utf8")
+    : (
+        await execFileAsync(
+          "cargo",
+          [
+            "metadata",
+            "--format-version",
+            "1",
+            "--locked",
+            "--manifest-path",
+            manifestPath ?? lockfilePath.replace(/Cargo\\.lock$/, "Cargo.toml")
+          ],
+          { encoding: "utf8" }
+        )
+      ).stdout;
+  const metadata: Metadata = JSON.parse(metadataRaw);
+
+  const directDeps = collectDirectDependencies(metadata);
+  const metadataMaps = buildMetadataMaps(metadata);
+
+  const inventoryMap = new Map<string, InventoryDependency>();
+
+  for (const pkg of packages) {
+    const metadataPkg = findMetadataPackage(pkg, metadataMaps);
+    if (isWorkspaceMember(metadataPkg, metadata)) {
+      continue;
+    }
+
+    const name = pkg.name;
+    const version = pkg.version;
+    const key = `${name}@${version}`;
+
+    const pkgId = metadataPkg?.id ?? toPackageId(pkg);
+    const dependencyType = resolveDependencyType(pkgId, directDeps);
+
+    const override = overrides.get(name, version, "cargo");
+    const licenseSource = metadataPkg?.license ?? undefined;
+    const { licenses, missing, unparsable } = normaliseLicenses(licenseSource, override);
+    if (missing) {
+      warn(`License metadata missing for ${key}`);
+    }
+    for (const fragment of unparsable) {
+      warn(`Unable to parse license expression for ${key}: ${fragment}`);
+    }
+
+    const checksum = normaliseChecksum(pkg.checksum);
+    const resolved = determineResolved(pkg, metadataPkg);
+    const source = buildSource(pkg, metadataPkg, projectRoot);
+    const features = extractFeatures(pkg);
+
+    const notes: string[] = [];
+    if (override?.notes) {
+      notes.push(override.notes);
+    }
+    if (missing && !override?.licenses) {
+      notes.push("license metadata unavailable in cargo metadata");
+    }
+    if (metadataPkg?.license_file && !override?.licenses) {
+      notes.push(`See license file at ${metadataPkg.license_file}`);
+    }
+
+    const provenanceEntry: InventoryDependency["provenance"][number] = {
+      ecosystem: "cargo",
+      dependencyType,
+      resolved,
+      checksum,
+      source
+    };
+    if (features) {
+      provenanceEntry.features = features;
+    }
+
+    const entry: InventoryDependency = {
+      name,
+      version,
+      dependencyType,
+      licenses,
+      resolved,
+      checksum,
+      source,
+      provenance: [provenanceEntry]
+    };
+
+    if (features) {
+      entry.features = features;
+    }
+
+    if (notes.length > 0) {
+      entry.notes = notes.join("; ");
+    }
+
+    if (inventoryMap.has(key)) {
+      const existing = inventoryMap.get(key)!;
+      existing.licenses = dedupeStrings([...existing.licenses, ...entry.licenses]);
+      if (entry.dependencyType === "direct") {
+        existing.dependencyType = "direct";
+      }
+      const mergedFeatures = dedupeStrings([
+        ...(existing.features ?? []),
+        ...(entry.features ?? [])
+      ]);
+      existing.features = mergedFeatures.length > 0 ? mergedFeatures : undefined;
+      existing.provenance.push(...entry.provenance);
+      if (entry.notes) {
+        const existingNotes = existing.notes ? existing.notes.split("; ").filter(Boolean) : [];
+        existing.notes = Array.from(new Set([...existingNotes, entry.notes])).join("; ");
+      }
+      continue;
+    }
+
+    inventoryMap.set(key, entry);
+  }
+
+  const dependencies = sortDependencies(Array.from(inventoryMap.values()));
+
+  const inventory: Inventory = {
+    generatedAt: new Date().toISOString(),
+    source: {
+      type: "cargo",
+      lockfile: relative(projectRoot, lockfilePath),
+      metadata: metadataPath
+        ? relative(projectRoot, metadataPath)
+        : relative(projectRoot, manifestPath ?? lockfilePath.replace(/Cargo\\.lock$/, "Cargo.toml"))
+    },
+    dependencies
+  };
+
+  const schemaRaw = await readFile(schemaPath, "utf8");
+  const schema = JSON.parse(schemaRaw);
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  if (!validate(inventory)) {
+    const errors = validate.errors ?? [];
+    const details = errors.map((error) => `${error.instancePath} ${error.message}`).join("; ");
+    throw new Error(`Generated inventory does not satisfy schema: ${details}`);
+  }
+
+  return inventory;
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      lockfile: { type: "string", short: "l" },
+      output: { type: "string", short: "o" },
+      schema: { type: "string", short: "s" },
+      overrides: { type: "string" },
+      metadata: { type: "string" },
+      manifest: { type: "string" }
+    }
+  });
+
+  const projectRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const lockfilePath = values.lockfile
+    ? resolve(values.lockfile)
+    : join(projectRoot, "src-tauri", "Cargo.lock");
+  const schemaPath = values.schema
+    ? resolve(values.schema)
+    : join(projectRoot, "schema", "licensing-inventory.schema.json");
+  const outputPath = values.output
+    ? resolve(values.output)
+    : join(projectRoot, "artifacts", "licensing", "cargo-inventory.json");
+  const metadataPath = values.metadata ? resolve(values.metadata) : undefined;
+  const manifestPath = values.manifest ? resolve(values.manifest) : undefined;
+
+  const defaultOverridesPath = join(projectRoot, "scripts", "licensing", "overrides.yaml");
+  const overridesPath = values.overrides
+    ? resolve(values.overrides)
+    : (await fileExists(defaultOverridesPath))
+        ? defaultOverridesPath
+        : undefined;
+  const overrides = await loadOverrides(overridesPath);
+
+  const warnings: string[] = [];
+  const inventory = await generateCargoInventory({
+    lockfilePath,
+    schemaPath,
+    projectRoot,
+    overrides,
+    warn: (message) => {
+      warnings.push(message);
+      console.warn(message);
+    },
+    metadataPath,
+    manifestPath
+  });
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, JSON.stringify(inventory, null, 2) + "\n");
+
+  console.log(
+    `Wrote ${relative(projectRoot, outputPath)} with ${inventory.dependencies.length} entries.`
+  );
+
+  if (warnings.length > 0) {
+    process.exitCode = 2;
+    console.warn(
+      `${warnings.length} licensing warnings emitted. Review overrides or resolve upstream metadata.`
+    );
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/licensing/lib/merge.ts
+++ b/scripts/licensing/lib/merge.ts
@@ -1,0 +1,182 @@
+import { Overrides } from "./overrides.ts";
+import {
+  Inventory,
+  InventoryDependency,
+  InventorySource,
+  InventorySourceDescriptor,
+  dedupeStrings,
+  sortDependencies
+} from "./utils.ts";
+
+function cloneSource(source: InventorySource): InventorySource {
+  return { ...source };
+}
+
+function cloneDependency(dependency: InventoryDependency): InventoryDependency {
+  return {
+    name: dependency.name,
+    version: dependency.version,
+    dependencyType: dependency.dependencyType,
+    licenses: [...dependency.licenses],
+    resolved: dependency.resolved,
+    checksum: dependency.checksum,
+    source: cloneSource(dependency.source),
+    provenance: dependency.provenance.map((entry) => ({
+      ...entry,
+      source: cloneSource(entry.source),
+      features: entry.features ? [...entry.features] : undefined
+    })),
+    features: dependency.features ? [...dependency.features] : undefined,
+    notes: dependency.notes
+  };
+}
+
+function mergeNotes(existing: string | undefined, addition: string | undefined): string | undefined {
+  const notes = [existing, addition].filter((value): value is string => Boolean(value && value.trim()));
+  if (notes.length === 0) {
+    return existing;
+  }
+  const fragments = notes
+    .flatMap((note) => note.split(";"))
+    .map((fragment) => fragment.trim())
+    .filter(Boolean);
+  const unique = Array.from(new Set(fragments));
+  return unique.join("; ");
+}
+
+function mergeSources(
+  inventories: InventorySourceDescriptor[]
+): Array<{ type: "npm" | "cargo"; path: string }> {
+  const seen = new Set<string>();
+  const inputs: Array<{ type: "npm" | "cargo"; path: string }> = [];
+
+  for (const source of inventories) {
+    if (source.type === "npm") {
+      const key = `npm:${source.lockfile}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        inputs.push({ type: "npm", path: source.lockfile });
+      }
+    } else if (source.type === "cargo") {
+      const key = `cargo:${source.lockfile}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        inputs.push({ type: "cargo", path: source.lockfile });
+      }
+    }
+  }
+
+  return inputs;
+}
+
+type AggregatedEntry = {
+  entry: InventoryDependency;
+  ecosystems: Set<string>;
+  conflict?: {
+    existing: string[];
+    incoming: string[];
+  };
+};
+
+export function mergeInventories(
+  inventories: Inventory[],
+  overrides: Overrides
+): Inventory {
+  const aggregated = new Map<string, AggregatedEntry>();
+
+  for (const inventory of inventories) {
+    for (const dependency of inventory.dependencies) {
+      const key = `${dependency.name}@${dependency.version}`;
+      const cloned = cloneDependency(dependency);
+      const provenanceEcosystems = new Set(
+        cloned.provenance.map((entry) => entry.ecosystem)
+      );
+
+      if (!aggregated.has(key)) {
+        aggregated.set(key, {
+          entry: cloned,
+          ecosystems: provenanceEcosystems
+        });
+        continue;
+      }
+
+      const wrapper = aggregated.get(key)!;
+      const existing = wrapper.entry;
+      const beforeLicenses = new Set(existing.licenses);
+      const incomingLicenses = new Set(cloned.licenses);
+
+      existing.licenses = dedupeStrings([...existing.licenses, ...cloned.licenses]);
+      if (cloned.dependencyType === "direct") {
+        existing.dependencyType = "direct";
+      }
+
+      const mergedFeatures = dedupeStrings([
+        ...(existing.features ?? []),
+        ...(cloned.features ?? [])
+      ]);
+      existing.features = mergedFeatures.length > 0 ? mergedFeatures : undefined;
+
+      const newProvenance = cloned.provenance.map((entry) => ({
+        ...entry,
+        source: cloneSource(entry.source)
+      }));
+      existing.provenance.push(...newProvenance);
+
+      existing.notes = mergeNotes(existing.notes, cloned.notes);
+
+      for (const ecosystem of provenanceEcosystems) {
+        wrapper.ecosystems.add(ecosystem);
+      }
+
+      if (wrapper.ecosystems.size > 1) {
+        existing.resolved = "UNKNOWN";
+        existing.checksum = "UNKNOWN";
+        existing.source = { type: "aggregate", location: "multiple" };
+      }
+
+      const differenceA = Array.from(beforeLicenses).filter(
+        (license) => !incomingLicenses.has(license)
+      );
+      const differenceB = Array.from(incomingLicenses).filter(
+        (license) => !beforeLicenses.has(license)
+      );
+      if ((differenceA.length > 0 || differenceB.length > 0) && wrapper.ecosystems.size > 1) {
+        wrapper.conflict = {
+          existing: Array.from(beforeLicenses),
+          incoming: Array.from(incomingLicenses)
+        };
+      }
+    }
+  }
+
+  const dependencies: InventoryDependency[] = [];
+
+  for (const { entry, conflict } of aggregated.values()) {
+    const override = overrides.get(entry.name, entry.version, "aggregate");
+    if (conflict && !(override?.licenses && override.licenses.length > 0)) {
+      throw new Error(
+        `License conflict for ${entry.name}@${entry.version}: ${conflict.existing.join(", ")} vs ${
+          conflict.incoming
+        }. Provide an override to resolve.`
+      );
+    }
+
+    if (override?.licenses) {
+      entry.licenses = dedupeStrings(override.licenses);
+    }
+    if (override?.notes) {
+      entry.notes = mergeNotes(entry.notes, override.notes);
+    }
+
+    dependencies.push(entry);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    source: {
+      type: "aggregate",
+      inputs: mergeSources(inventories.map((inventory) => inventory.source))
+    },
+    dependencies: sortDependencies(dependencies)
+  };
+}

--- a/scripts/licensing/lib/overrides.ts
+++ b/scripts/licensing/lib/overrides.ts
@@ -1,0 +1,95 @@
+import { access, readFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { extname } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { dedupeStrings, Ecosystem } from "./utils.ts";
+
+export type OverrideScope = Exclude<Ecosystem, "aggregate"> | "aggregate";
+
+export type OverrideEntry = {
+  licenses?: string[];
+  notes?: string;
+  ecosystems?: OverrideScope[];
+};
+
+type InternalOverride = {
+  value: OverrideEntry;
+  used: boolean;
+};
+
+export class Overrides {
+  private readonly overrides = new Map<string, InternalOverride>();
+
+  constructor(initial?: Record<string, OverrideEntry>) {
+    if (!initial) {
+      return;
+    }
+
+    for (const [key, value] of Object.entries(initial)) {
+      if (!value || typeof value !== "object") {
+        throw new Error(`Override for ${key} must be an object`);
+      }
+      if (value.licenses) {
+        value.licenses = dedupeStrings(value.licenses);
+      }
+      this.overrides.set(key, { value, used: false });
+    }
+  }
+
+  get(name: string, version: string, scope: OverrideScope): OverrideEntry | undefined {
+    const exactKey = `${name}@${version}`;
+    const entry = this.overrides.get(exactKey) ?? this.overrides.get(name);
+    if (!entry) {
+      return undefined;
+    }
+
+    const ecosystems = entry.value.ecosystems;
+    if (ecosystems && ecosystems.length > 0 && !ecosystems.includes(scope)) {
+      return undefined;
+    }
+
+    entry.used = true;
+    return entry.value;
+  }
+
+  assertAllUsed(scopes: OverrideScope[]): void {
+    const activeScopes = new Set(scopes);
+    for (const [key, entry] of this.overrides) {
+      const { ecosystems } = entry.value;
+      const relevant = !ecosystems || ecosystems.some((scope) => activeScopes.has(scope));
+      if (relevant && !entry.used) {
+        throw new Error(`Override ${key} was not applied. Update overrides or remove the entry.`);
+      }
+    }
+  }
+}
+
+export async function loadOverrides(path: string | undefined): Promise<Overrides> {
+  if (!path) {
+    return new Overrides();
+  }
+
+  try {
+    await access(path, fsConstants.F_OK);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`Overrides file not found: ${path}`);
+    }
+    throw error;
+  }
+
+  const raw = await readFile(path, "utf8");
+  let parsed: any;
+  const extension = extname(path).toLowerCase();
+  if (extension === ".yaml" || extension === ".yml") {
+    parsed = parseYaml(raw);
+  } else {
+    parsed = JSON.parse(raw);
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Overrides file must contain an object map");
+  }
+
+  return new Overrides(parsed as Record<string, OverrideEntry>);
+}

--- a/scripts/licensing/lib/spdx.ts
+++ b/scripts/licensing/lib/spdx.ts
@@ -1,0 +1,71 @@
+import spdxParse from "spdx-expression-parse";
+import { dedupeStrings } from "./utils.ts";
+
+export type NormalisedLicenseResult = {
+  licenses: string[];
+  missing: boolean;
+  unparsable: string[];
+};
+
+export function normaliseLicenses(
+  raw: string | string[] | { type?: string } | Array<string | { type?: string }> | undefined,
+  override?: { licenses?: string[] }
+): NormalisedLicenseResult {
+  if (override?.licenses && override.licenses.length > 0) {
+    return {
+      licenses: dedupeStrings(override.licenses),
+      missing: false,
+      unparsable: []
+    };
+  }
+
+  if (!raw) {
+    return { licenses: ["UNKNOWN"], missing: true, unparsable: [] };
+  }
+
+  const candidates = Array.isArray(raw) ? raw : [raw];
+  const licenses: string[] = [];
+  const unparsable: string[] = [];
+
+  for (const candidate of candidates) {
+    const value = typeof candidate === "string" ? candidate.trim() : candidate?.type?.trim();
+    if (!value) {
+      continue;
+    }
+
+    try {
+      const parsed = spdxParse(value);
+      collectSpdx(parsed, licenses);
+    } catch (error) {
+      if (/^[A-Za-z0-9.+-]+$/.test(value)) {
+        licenses.push(value);
+      } else {
+        unparsable.push(value);
+      }
+    }
+  }
+
+  if (licenses.length === 0) {
+    return { licenses: ["UNKNOWN"], missing: true, unparsable };
+  }
+
+  return { licenses: dedupeStrings(licenses), missing: false, unparsable };
+}
+
+function collectSpdx(node: any, accumulator: string[]) {
+  if (!node) return;
+  if (node.license) {
+    const license = String(node.license);
+    if (node.exception) {
+      accumulator.push(`${license} WITH ${node.exception}`);
+    } else {
+      accumulator.push(license);
+    }
+    return;
+  }
+
+  if (node.left && node.right) {
+    collectSpdx(node.left, accumulator);
+    collectSpdx(node.right, accumulator);
+  }
+}

--- a/scripts/licensing/lib/utils.ts
+++ b/scripts/licensing/lib/utils.ts
@@ -1,0 +1,78 @@
+export type DependencyType = "direct" | "indirect";
+
+export type Ecosystem = "npm" | "cargo" | "aggregate";
+
+export type SourceType = "npm" | "git" | "manual" | "registry" | "path" | "aggregate";
+
+export type InventorySource = {
+  type: SourceType;
+  location: string;
+  registry?: string;
+};
+
+export type ProvenanceEntry = {
+  ecosystem: Exclude<Ecosystem, "aggregate">;
+  dependencyType: DependencyType;
+  resolved: string;
+  checksum: string;
+  source: InventorySource;
+  features?: string[];
+  notes?: string;
+};
+
+export type InventoryDependency = {
+  name: string;
+  version: string;
+  dependencyType: DependencyType;
+  licenses: string[];
+  resolved: string;
+  checksum: string;
+  source: InventorySource;
+  provenance: ProvenanceEntry[];
+  features?: string[];
+  notes?: string;
+};
+
+export type InventorySourceDescriptor =
+  | {
+      type: "npm";
+      lockfile: string;
+    }
+  | {
+      type: "cargo";
+      lockfile: string;
+      metadata: string;
+    }
+  | {
+      type: "aggregate";
+      inputs: Array<{
+        type: "npm" | "cargo";
+        path: string;
+      }>;
+    };
+
+export type Inventory = {
+  generatedAt: string;
+  source: InventorySourceDescriptor;
+  dependencies: InventoryDependency[];
+};
+
+export function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    if (!seen.has(trimmed)) {
+      seen.add(trimmed);
+      output.push(trimmed);
+    }
+  }
+  return output;
+}
+
+export function sortDependencies<T extends { name: string; version: string }>(
+  values: T[]
+): T[] {
+  return values.sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+}

--- a/scripts/licensing/npm-overrides.json
+++ b/scripts/licensing/npm-overrides.json
@@ -1,6 +1,0 @@
-{
-  "buffer-builder@0.2.0": {
-    "licenses": ["MIT"],
-    "notes": "Upstream package declares \"MIT/X11\"; normalized to MIT for reporting."
-  }
-}

--- a/scripts/licensing/overrides.yaml
+++ b/scripts/licensing/overrides.yaml
@@ -1,0 +1,4 @@
+buffer-builder@0.2.0:
+  licenses:
+    - MIT
+  notes: "Upstream package declares \"MIT/X11\"; normalized to MIT for reporting."

--- a/scripts/licensing/pipeline.ts
+++ b/scripts/licensing/pipeline.ts
@@ -1,0 +1,140 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { generateInventory as generateNpmInventory } from "./npm-inventory.ts";
+import { generateCargoInventory } from "./cargo-inventory.ts";
+import { loadOverrides } from "./lib/overrides.ts";
+import { mergeInventories } from "./lib/merge.ts";
+import { Inventory } from "./lib/utils.ts";
+import { readFile } from "node:fs/promises";
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      schema: { type: "string", short: "s" },
+      overrides: { type: "string" },
+      "npm-lockfile": { type: "string" },
+      "cargo-lockfile": { type: "string" },
+      "cargo-manifest": { type: "string" },
+      "cargo-metadata": { type: "string" },
+      output: { type: "string", short: "o" }
+    }
+  });
+
+  const projectRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const schemaPath = values.schema
+    ? resolve(values.schema)
+    : join(projectRoot, "schema", "licensing-inventory.schema.json");
+  const outputDir = values.output
+    ? resolve(values.output)
+    : join(projectRoot, "artifacts", "licensing");
+
+  const npmLockfile = values["npm-lockfile"]
+    ? resolve(values["npm-lockfile"])
+    : join(projectRoot, "package-lock.json");
+  const cargoLockfile = values["cargo-lockfile"]
+    ? resolve(values["cargo-lockfile"])
+    : join(projectRoot, "src-tauri", "Cargo.lock");
+  const cargoManifest = values["cargo-manifest"]
+    ? resolve(values["cargo-manifest"])
+    : join(projectRoot, "src-tauri", "Cargo.toml");
+  const cargoMetadata = values["cargo-metadata"]
+    ? resolve(values["cargo-metadata"])
+    : undefined;
+
+  const defaultOverridesPath = join(projectRoot, "scripts", "licensing", "overrides.yaml");
+  const overridesPath = await resolveOverridesPath(values.overrides, defaultOverridesPath);
+  const overrides = await loadOverrides(overridesPath);
+
+  const warnings: string[] = [];
+
+  const npmInventory = await generateNpmInventory({
+    lockfilePath: npmLockfile,
+    schemaPath,
+    projectRoot,
+    overrides,
+    warn: (message) => {
+      warnings.push(message);
+      console.warn(message);
+    }
+  });
+
+  const cargoInventory = await generateCargoInventory({
+    lockfilePath: cargoLockfile,
+    schemaPath,
+    projectRoot,
+    overrides,
+    warn: (message) => {
+      warnings.push(message);
+      console.warn(message);
+    },
+    manifestPath: cargoManifest,
+    metadataPath: cargoMetadata
+  });
+
+  const combined = mergeInventories([npmInventory, cargoInventory], overrides);
+
+  await mkdir(outputDir, { recursive: true });
+
+  await writeInventory(join(outputDir, "npm-inventory.json"), npmInventory, projectRoot);
+  await writeInventory(join(outputDir, "cargo-inventory.json"), cargoInventory, projectRoot);
+  await validateInventory(combined, schemaPath);
+
+  await writeInventory(join(outputDir, "full-inventory.json"), combined, projectRoot);
+
+  overrides.assertAllUsed(["npm", "cargo", "aggregate"]);
+
+  if (warnings.length > 0) {
+    process.exitCode = 2;
+    console.warn(
+      `${warnings.length} licensing warnings emitted. Review overrides or resolve upstream metadata.`
+    );
+  }
+}
+
+async function writeInventory(path: string, inventory: Inventory, projectRoot: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(inventory, null, 2) + "\n");
+  console.log(
+    `Wrote ${relative(projectRoot, path)} with ${inventory.dependencies.length} entries.`
+  );
+}
+
+async function validateInventory(inventory: Inventory, schemaPath: string) {
+  const schemaRaw = await readFile(schemaPath, "utf8");
+  const schema = JSON.parse(schemaRaw);
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  if (!validate(inventory)) {
+    const errors = validate.errors ?? [];
+    const details = errors.map((error) => `${error.instancePath} ${error.message}`).join("; ");
+    throw new Error(`Combined inventory does not satisfy schema: ${details}`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}
+
+async function resolveOverridesPath(
+  provided: string | undefined,
+  defaultPath: string
+): Promise<string | undefined> {
+  if (provided) {
+    return resolve(provided);
+  }
+  try {
+    await access(defaultPath, fsConstants.F_OK);
+    return defaultPath;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/licensing/cargo-inventory.test.ts
+++ b/tests/licensing/cargo-inventory.test.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from "node:assert";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { generateCargoInventory } from "../../scripts/licensing/cargo-inventory.ts";
+import { Overrides } from "../../scripts/licensing/lib/overrides.ts";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+function normaliseGeneratedAt<T extends { generatedAt: string }>(inventory: T) {
+  return { ...inventory, generatedAt: "2024-01-01T00:00:00.000Z" };
+}
+
+test("parses cargo fixtures", async () => {
+  const warnings: string[] = [];
+  const inventory = await generateCargoInventory({
+    lockfilePath: join(ROOT, "fixtures/licensing/Cargo.lock.fixture"),
+    schemaPath: join(ROOT, "schema/licensing-inventory.schema.json"),
+    projectRoot: ROOT,
+    overrides: new Overrides(),
+    metadataPath: join(ROOT, "fixtures/licensing/cargo-metadata.json"),
+    warn: (message) => warnings.push(message)
+  });
+
+  assert.equal(inventory.dependencies.length, 4);
+  assert.equal(warnings.length, 2);
+  assert.ok(warnings.some((message) => message.includes("local-dep@0.3.0")));
+  assert.ok(warnings.some((message) => message.includes("missing-license@0.4.0")));
+
+  const expected = JSON.parse(
+    await readFile(join(ROOT, "fixtures/licensing/cargo-inventory.json"), "utf8")
+  );
+
+  assert.deepEqual(normaliseGeneratedAt(inventory), expected);
+});

--- a/tests/licensing/full-inventory.test.ts
+++ b/tests/licensing/full-inventory.test.ts
@@ -1,0 +1,79 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { mergeInventories } from "../../scripts/licensing/lib/merge.ts";
+import { Overrides } from "../../scripts/licensing/lib/overrides.ts";
+import { Inventory } from "../../scripts/licensing/lib/utils.ts";
+
+test("requires override for conflicting licenses", () => {
+  const npmInventory: Inventory = {
+    generatedAt: "2024-01-01T00:00:00.000Z",
+    source: { type: "npm", lockfile: "package-lock.json" },
+    dependencies: [
+      {
+        name: "shared",
+        version: "1.0.0",
+        dependencyType: "direct",
+        licenses: ["MIT"],
+        resolved: "https://registry.npmjs.org/shared/-/shared-1.0.0.tgz",
+        checksum: "sha512-shared",
+        source: { type: "npm", location: "https://registry.npmjs.org/shared/-/shared-1.0.0.tgz" },
+        provenance: [
+          {
+            ecosystem: "npm",
+            dependencyType: "direct",
+            resolved: "https://registry.npmjs.org/shared/-/shared-1.0.0.tgz",
+            checksum: "sha512-shared",
+            source: { type: "npm", location: "https://registry.npmjs.org/shared/-/shared-1.0.0.tgz" }
+          }
+        ]
+      }
+    ]
+  };
+
+  const cargoInventory: Inventory = {
+    generatedAt: "2024-01-01T00:00:00.000Z",
+    source: { type: "cargo", lockfile: "Cargo.lock", metadata: "Cargo.toml" },
+    dependencies: [
+      {
+        name: "shared",
+        version: "1.0.0",
+        dependencyType: "direct",
+        licenses: ["Apache-2.0"],
+        resolved: "git+https://example.com/shared#abcdef",
+        checksum: "UNKNOWN",
+        source: { type: "git", location: "git+https://example.com/shared#abcdef" },
+        provenance: [
+          {
+            ecosystem: "cargo",
+            dependencyType: "direct",
+            resolved: "git+https://example.com/shared#abcdef",
+            checksum: "UNKNOWN",
+            source: { type: "git", location: "git+https://example.com/shared#abcdef" }
+          }
+        ]
+      }
+    ]
+  };
+
+  assert.throws(() => mergeInventories([npmInventory, cargoInventory], new Overrides()));
+
+  const overrides = new Overrides({
+    "shared@1.0.0": {
+      licenses: ["MIT", "Apache-2.0"],
+      notes: "Dual-licensed upstream component",
+      ecosystems: ["aggregate"]
+    }
+  });
+
+  const combined = mergeInventories([npmInventory, cargoInventory], overrides);
+
+  assert.equal(combined.dependencies.length, 1);
+  const shared = combined.dependencies[0];
+  assert.deepEqual(shared.licenses, ["MIT", "Apache-2.0"]);
+  assert.equal(shared.source.type, "aggregate");
+  assert.equal(shared.resolved, "UNKNOWN");
+  assert.equal(shared.checksum, "UNKNOWN");
+  assert.ok(shared.notes?.includes("Dual-licensed"));
+  assert.equal(shared.provenance.length, 2);
+  overrides.assertAllUsed(["aggregate"]);
+});


### PR DESCRIPTION
## Summary
- extend the shared licensing schema and documentation to cover npm, Cargo, and aggregate inventories with provenance metadata
- add a Cargo.lock parser, shared override/merge utilities, and an orchestrator that emits npm, cargo, and unified inventories from one run
- introduce YAML-based overrides, new fixtures/tests, and update CI to publish the combined licensing artifact

## Testing
- `node --import ./scripts/test-preload.mjs --test tests/licensing/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d6a11f529c832a8af8f5fbee15b214