### PR TITLE
feat: automate NOTICE and CREDITS generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
       - run: npm test
 
   licensing_inventory:
-    name: licensing/inventory
+    name: licensing/notice
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -273,12 +273,23 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - name: Generate cross-ecosystem license inventory
-        run: npm run licensing:inventory
+      - name: Generate licensing notices
+        run: npm run generate:notice -- --check
       - name: Upload inventory artifacts
         uses: actions/upload-artifact@v4
         with:
           name: licensing-inventory
           path: artifacts/licensing
+          if-no-files-found: error
+      - name: Upload notice bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: licensing-notice-bundle
+          path: |
+            NOTICE.md
+            CREDITS.md
+            src-tauri/resources/licenses/NOTICE.txt
+            src-tauri/resources/licenses/CREDITS.txt
+            artifacts/licensing/notice-checksums.json
           if-no-files-found: error
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,1457 @@
+# CREDITS
+
+This CREDITS file enumerates third-party components bundled with Arklowdun and acknowledges the open source community whose work makes the project possible. It was generated from the consolidated licensing inventory.
+
+## Open Source Components
+
+### 0BSD
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`tslib`](https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz) | 2.8.1 | Indirect | npm: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz |  |
+
+### 0BSD OR Apache-2.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`adler2`](https://github.com/rust-lang/crates.io-index#adler2@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@ampproject/remapping`](https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz) | 2.3.0 | Indirect | npm: https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz |  |
+| [`@humanwhocodes/config-array`](https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz) | 0.13.0 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz | Use @eslint/config-array instead |
+| [`@humanwhocodes/module-importer`](https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz |  |
+| [`@playwright/test`](https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz) | 1.55.0 | Direct | npm: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz |  |
+| [`aria-query`](https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz |  |
+| [`axobject-query`](https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz |  |
+| [`detect-libc`](https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz |  |
+| [`detect-libc`](https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz |  |
+| [`doctrine`](https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz |  |
+| [`doctrine`](https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz |  |
+| [`eslint-plugin-security`](https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz) | 2.1.1 | Direct | npm: https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz |  |
+| [`eslint-visitor-keys`](https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz) | 3.4.3 | Indirect | npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz |  |
+| [`eslint-visitor-keys`](https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz) | 4.2.1 | Indirect | npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz |  |
+| [`gethostname`](https://github.com/rust-lang/crates.io-index#gethostname@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`human-signals`](https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz |  |
+| [`playwright`](https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz) | 1.55.0 | Indirect | npm: https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz |  |
+| [`playwright-core`](https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz) | 1.55.0 | Indirect | npm: https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz |  |
+| [`rxjs`](https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz) | 7.8.2 | Indirect | npm: https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz |  |
+| [`similar`](https://github.com/rust-lang/crates.io-index#similar@2.7.0) | 2.7.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sync_wrapper`](https://github.com/rust-lang/crates.io-index#sync_wrapper@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sync_wrapper`](https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tao`](https://github.com/rust-lang/crates.io-index#tao@0.34.2) | 0.34.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tunnel-agent`](https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz) | 0.6.0 | Indirect | npm: https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz |  |
+| [`typescript`](https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz) | 5.9.2 | Direct | npm: https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz |  |
+| [`xml-name-validator`](https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz |  |
+
+### Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`linux-raw-sys`](https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.4.15) | 0.4.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`linux-raw-sys`](https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.9.4) | 0.9.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustix`](https://github.com/rust-lang/crates.io-index#rustix@0.38.44) | 0.38.44 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustix`](https://github.com/rust-lang/crates.io-index#rustix@1.0.8) | 1.0.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1) | 0.11.1+wasi-snapshot-preview1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.14.3+wasi-0.2.4) | 0.14.3+wasi-0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.9.0+wasi-snapshot-preview1) | 0.9.0+wasi-snapshot-preview1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wit-bindgen`](https://github.com/rust-lang/crates.io-index#wit-bindgen@0.45.0) | 0.45.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-2-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`rc`](https://registry.npmjs.org/rc/-/rc-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/rc/-/rc-1.2.8.tgz |  |
+| [`zerocopy`](https://github.com/rust-lang/crates.io-index#zerocopy@0.8.26) | 0.8.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerocopy-derive`](https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.26) | 0.8.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-3-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@bufbuild/protobuf`](https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz) | 2.7.0 | Indirect | npm: https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz |  |
+| [`moxcms`](https://github.com/rust-lang/crates.io-index#moxcms@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pxfm`](https://github.com/rust-lang/crates.io-index#pxfm@0.1.23) | 0.1.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-3-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`encoding_rs`](https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35) | 0.8.35 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num_enum`](https://github.com/rust-lang/crates.io-index#num_enum@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num_enum_derive`](https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSL-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`ryu`](https://github.com/rust-lang/crates.io-index#ryu@1.0.20) | 1.0.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSL-1.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`wasite`](https://github.com/rust-lang/crates.io-index#wasite@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`whoami`](https://github.com/rust-lang/crates.io-index#whoami@1.6.1) | 1.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR CC0-1.0 OR MIT-0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`dunce`](https://github.com/rust-lang/crates.io-index#dunce@1.0.5) | 1.0.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR LGPL-2.1-or-later OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`r-efi`](https://github.com/rust-lang/crates.io-index#r-efi@5.3.0) | 5.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@tauri-apps/api`](https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz) | 2.8.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz |  |
+| [`@tauri-apps/cli`](https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz) | 2.8.3 | Direct | npm: https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz |  |
+| [`@tauri-apps/cli-darwin-arm64`](https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz |  |
+| [`@tauri-apps/cli-darwin-x64`](https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm-gnueabihf`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm64-musl`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-riscv64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-x64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-x64-musl`](https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-arm64-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-ia32-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-x64-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/plugin-clipboard-manager`](https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz) | 2.3.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz |  |
+| [`@tauri-apps/plugin-dialog`](https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz) | 2.3.3 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz |  |
+| [`@tauri-apps/plugin-fs`](https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz) | 2.4.2 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz |  |
+| [`@tauri-apps/plugin-notification`](https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz) | 2.3.1 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz |  |
+| [`@tauri-apps/plugin-opener`](https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz) | 2.5.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz |  |
+| [`@tauri-apps/plugin-sql`](https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz) | 2.3.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz |  |
+| [`addr2line`](https://github.com/rust-lang/crates.io-index#addr2line@0.24.2) | 0.24.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ahash`](https://github.com/rust-lang/crates.io-index#ahash@0.8.12) | 0.8.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`allocator-api2`](https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21) | 0.2.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`android_system_properties`](https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`android-tzdata`](https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstream`](https://github.com/rust-lang/crates.io-index#anstream@0.6.20) | 0.6.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle`](https://github.com/rust-lang/crates.io-index#anstyle@1.0.11) | 1.0.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-parse`](https://github.com/rust-lang/crates.io-index#anstyle-parse@0.2.7) | 0.2.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-query`](https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.4) | 1.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-wincon`](https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.10) | 3.0.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anyhow`](https://github.com/rust-lang/crates.io-index#anyhow@1.0.99) | 1.0.99 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`arboard`](https://github.com/rust-lang/crates.io-index#arboard@3.6.1) | 3.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`assert_cmd`](https://github.com/rust-lang/crates.io-index#assert_cmd@2.0.17) | 2.0.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-broadcast`](https://github.com/rust-lang/crates.io-index#async-broadcast@0.7.2) | 0.7.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-channel`](https://github.com/rust-lang/crates.io-index#async-channel@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-executor`](https://github.com/rust-lang/crates.io-index#async-executor@1.13.3) | 1.13.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-io`](https://github.com/rust-lang/crates.io-index#async-io@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-lock`](https://github.com/rust-lang/crates.io-index#async-lock@3.4.1) | 3.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-process`](https://github.com/rust-lang/crates.io-index#async-process@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-recursion`](https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1) | 1.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-signal`](https://github.com/rust-lang/crates.io-index#async-signal@0.2.12) | 0.2.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-task`](https://github.com/rust-lang/crates.io-index#async-task@4.7.1) | 4.7.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-trait`](https://github.com/rust-lang/crates.io-index#async-trait@0.1.89) | 0.1.89 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atomic-waker`](https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`autocfg`](https://github.com/rust-lang/crates.io-index#autocfg@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`backtrace`](https://github.com/rust-lang/crates.io-index#backtrace@0.3.75) | 0.3.75 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64`](https://github.com/rust-lang/crates.io-index#base64@0.21.7) | 0.21.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64`](https://github.com/rust-lang/crates.io-index#base64@0.22.1) | 0.22.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64ct`](https://github.com/rust-lang/crates.io-index#base64ct@1.8.0) | 1.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bit-set`](https://github.com/rust-lang/crates.io-index#bit-set@0.5.3) | 0.5.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bit-vec`](https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bitflags`](https://github.com/rust-lang/crates.io-index#bitflags@1.3.2) | 1.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bitflags`](https://github.com/rust-lang/crates.io-index#bitflags@2.9.3) | 2.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`block-buffer`](https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4) | 0.10.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`blocking`](https://github.com/rust-lang/crates.io-index#blocking@1.6.2) | 1.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bstr`](https://github.com/rust-lang/crates.io-index#bstr@1.12.0) | 1.12.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bumpalo`](https://github.com/rust-lang/crates.io-index#bumpalo@3.19.0) | 3.19.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bytecount`](https://github.com/rust-lang/crates.io-index#bytecount@0.6.9) | 0.6.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`camino`](https://github.com/rust-lang/crates.io-index#camino@1.1.12) | 1.1.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cargo_toml`](https://github.com/rust-lang/crates.io-index#cargo_toml@0.22.3) | 0.22.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cargo-platform`](https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cc`](https://github.com/rust-lang/crates.io-index#cc@1.2.34) | 1.2.34 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cesu8`](https://github.com/rust-lang/crates.io-index#cesu8@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg-expr`](https://github.com/rust-lang/crates.io-index#cfg-expr@0.15.8) | 0.15.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg-if`](https://github.com/rust-lang/crates.io-index#cfg-if@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chrono`](https://github.com/rust-lang/crates.io-index#chrono@0.4.41) | 0.4.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chrono-tz`](https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4) | 0.10.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap`](https://github.com/rust-lang/crates.io-index#clap@4.5.47) | 4.5.47 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_builder`](https://github.com/rust-lang/crates.io-index#clap_builder@4.5.47) | 4.5.47 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_derive`](https://github.com/rust-lang/crates.io-index#clap_derive@4.5.47) | 4.5.47 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_lex`](https://github.com/rust-lang/crates.io-index#clap_lex@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`colorchoice`](https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`concurrent-queue`](https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`const-oid`](https://github.com/rust-lang/crates.io-index#const-oid@0.9.6) | 0.9.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cookie`](https://github.com/rust-lang/crates.io-index#cookie@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation`](https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1) | 0.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation`](https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4) | 0.9.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation-sys`](https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7) | 0.8.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-graphics`](https://github.com/rust-lang/crates.io-index#core-graphics@0.24.0) | 0.24.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-graphics-types`](https://github.com/rust-lang/crates.io-index#core-graphics-types@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cpufeatures`](https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17) | 0.2.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc`](https://github.com/rust-lang/crates.io-index#crc@3.3.0) | 3.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc-catalog`](https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc32fast`](https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-channel`](https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15) | 0.5.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-queue`](https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12) | 0.3.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-utils`](https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21) | 0.8.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crypto-common`](https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ctor`](https://github.com/rust-lang/crates.io-index#ctor@0.2.9) | 0.2.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`der`](https://github.com/rust-lang/crates.io-index#der@0.7.10) | 0.7.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`deranged`](https://github.com/rust-lang/crates.io-index#deranged@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`digest`](https://github.com/rust-lang/crates.io-index#digest@0.10.7) | 0.10.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs`](https://github.com/rust-lang/crates.io-index#dirs@5.0.1) | 5.0.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs`](https://github.com/rust-lang/crates.io-index#dirs@6.0.0) | 6.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs-sys`](https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs-sys`](https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`displaydoc`](https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5) | 0.2.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`downcast-rs`](https://github.com/rust-lang/crates.io-index#downcast-rs@1.2.1) | 1.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dpi`](https://github.com/rust-lang/crates.io-index#dpi@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dtoa`](https://github.com/rust-lang/crates.io-index#dtoa@1.0.10) | 1.0.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dyn-clone`](https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20) | 1.0.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`either`](https://github.com/rust-lang/crates.io-index#either@1.15.0) | 1.15.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`embed_plist`](https://github.com/rust-lang/crates.io-index#embed_plist@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`enumflags2`](https://github.com/rust-lang/crates.io-index#enumflags2@0.7.12) | 0.7.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`enumflags2_derive`](https://github.com/rust-lang/crates.io-index#enumflags2_derive@0.7.12) | 0.7.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`equivalent`](https://github.com/rust-lang/crates.io-index#equivalent@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`erased-serde`](https://github.com/rust-lang/crates.io-index#erased-serde@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`errno`](https://github.com/rust-lang/crates.io-index#errno@0.3.13) | 0.3.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`etcetera`](https://github.com/rust-lang/crates.io-index#etcetera@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`event-listener`](https://github.com/rust-lang/crates.io-index#event-listener@5.4.1) | 5.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`event-listener-strategy`](https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4) | 0.5.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fallible-iterator`](https://github.com/rust-lang/crates.io-index#fallible-iterator@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fallible-streaming-iterator`](https://github.com/rust-lang/crates.io-index#fallible-streaming-iterator@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fastrand`](https://github.com/rust-lang/crates.io-index#fastrand@2.3.0) | 2.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fdeflate`](https://github.com/rust-lang/crates.io-index#fdeflate@0.3.7) | 0.3.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`field-offset`](https://github.com/rust-lang/crates.io-index#field-offset@0.3.6) | 0.3.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fixedbitset`](https://github.com/rust-lang/crates.io-index#fixedbitset@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`flate2`](https://github.com/rust-lang/crates.io-index#flate2@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`flume`](https://github.com/rust-lang/crates.io-index#flume@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fnv`](https://github.com/rust-lang/crates.io-index#fnv@1.0.7) | 1.0.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types`](https://github.com/rust-lang/crates.io-index#foreign-types@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types-macros`](https://github.com/rust-lang/crates.io-index#foreign-types-macros@0.2.3) | 0.2.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types-shared`](https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`form_urlencoded`](https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fraction`](https://github.com/rust-lang/crates.io-index#fraction@0.13.1) | 0.13.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fs2`](https://github.com/rust-lang/crates.io-index#fs2@0.4.3) | 0.4.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futf`](https://github.com/rust-lang/crates.io-index#futf@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures`](https://github.com/rust-lang/crates.io-index#futures@0.3.31) | 0.3.31 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-channel`](https://github.com/rust-lang/crates.io-index#futures-channel@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-core`](https://github.com/rust-lang/crates.io-index#futures-core@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-executor`](https://github.com/rust-lang/crates.io-index#futures-executor@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-intrusive`](https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-io`](https://github.com/rust-lang/crates.io-index#futures-io@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-lite`](https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1) | 2.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-macro`](https://github.com/rust-lang/crates.io-index#futures-macro@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-sink`](https://github.com/rust-lang/crates.io-index#futures-sink@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-task`](https://github.com/rust-lang/crates.io-index#futures-task@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-util`](https://github.com/rust-lang/crates.io-index#futures-util@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fxhash`](https://github.com/rust-lang/crates.io-index#fxhash@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.1.16) | 0.1.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.2.16) | 0.2.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gimli`](https://github.com/rust-lang/crates.io-index#gimli@0.31.1) | 0.31.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glob`](https://github.com/rust-lang/crates.io-index#glob@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`half`](https://github.com/rust-lang/crates.io-index#half@2.6.0) | 2.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3) | 0.12.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5) | 0.14.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5) | 0.15.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashlink`](https://github.com/rust-lang/crates.io-index#hashlink@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashlink`](https://github.com/rust-lang/crates.io-index#hashlink@0.9.1) | 0.9.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`heck`](https://github.com/rust-lang/crates.io-index#heck@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`heck`](https://github.com/rust-lang/crates.io-index#heck@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hermit-abi`](https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hex`](https://github.com/rust-lang/crates.io-index#hex@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hkdf`](https://github.com/rust-lang/crates.io-index#hkdf@0.12.4) | 0.12.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hmac`](https://github.com/rust-lang/crates.io-index#hmac@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`home`](https://github.com/rust-lang/crates.io-index#home@0.5.11) | 0.5.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`html5ever`](https://github.com/rust-lang/crates.io-index#html5ever@0.29.1) | 0.29.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http`](https://github.com/rust-lang/crates.io-index#http@0.2.12) | 0.2.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http`](https://github.com/rust-lang/crates.io-index#http@1.3.1) | 1.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`httparse`](https://github.com/rust-lang/crates.io-index#httparse@1.10.1) | 1.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`httpdate`](https://github.com/rust-lang/crates.io-index#httpdate@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iana-time-zone`](https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.63) | 0.1.63 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iana-time-zone-haiku`](https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ident_case`](https://github.com/rust-lang/crates.io-index#ident_case@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`idna`](https://github.com/rust-lang/crates.io-index#idna@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`idna_adapter`](https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.1) | 1.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`image`](https://github.com/rust-lang/crates.io-index#image@0.25.8) | 0.25.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`indexmap`](https://github.com/rust-lang/crates.io-index#indexmap@1.9.3) | 1.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`indexmap`](https://github.com/rust-lang/crates.io-index#indexmap@2.11.0) | 2.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`io-uring`](https://github.com/rust-lang/crates.io-index#io-uring@0.7.10) | 0.7.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ipnet`](https://github.com/rust-lang/crates.io-index#ipnet@2.11.0) | 2.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iri-string`](https://github.com/rust-lang/crates.io-index#iri-string@0.7.8) | 0.7.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`is_terminal_polyfill`](https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.1) | 1.70.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`itoa`](https://github.com/rust-lang/crates.io-index#itoa@1.0.15) | 1.0.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jni`](https://github.com/rust-lang/crates.io-index#jni@0.21.1) | 0.21.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jni-sys`](https://github.com/rust-lang/crates.io-index#jni-sys@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`js-sys`](https://github.com/rust-lang/crates.io-index#js-sys@0.3.77) | 0.3.77 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`json-patch`](https://github.com/rust-lang/crates.io-index#json-patch@3.0.1) | 3.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jsonptr`](https://github.com/rust-lang/crates.io-index#jsonptr@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`keyboard-types`](https://github.com/rust-lang/crates.io-index#keyboard-types@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lazy_static`](https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libappindicator`](https://github.com/rust-lang/crates.io-index#libappindicator@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libappindicator-sys`](https://github.com/rust-lang/crates.io-index#libappindicator-sys@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libc`](https://github.com/rust-lang/crates.io-index#libc@0.2.175) | 0.2.175 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lock_api`](https://github.com/rust-lang/crates.io-index#lock_api@0.4.13) | 0.4.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`log`](https://github.com/rust-lang/crates.io-index#log@0.4.27) | 0.4.27 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mac`](https://github.com/rust-lang/crates.io-index#mac@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`markup5ever`](https://github.com/rust-lang/crates.io-index#markup5ever@0.14.1) | 0.14.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`match_token`](https://github.com/rust-lang/crates.io-index#match_token@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`md-5`](https://github.com/rust-lang/crates.io-index#md-5@0.10.6) | 0.10.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mime`](https://github.com/rust-lang/crates.io-index#mime@0.3.17) | 0.3.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`minimal-lexical`](https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`muda`](https://github.com/rust-lang/crates.io-index#muda@0.17.1) | 0.17.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk`](https://github.com/rust-lang/crates.io-index#ndk@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk-context`](https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk-sys`](https://github.com/rust-lang/crates.io-index#ndk-sys@0.6.0+11769913) | 0.6.0+11769913 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nodrop`](https://github.com/rust-lang/crates.io-index#nodrop@0.1.14) | 0.1.14 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`notify-rust`](https://github.com/rust-lang/crates.io-index#notify-rust@4.11.7) | 4.11.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num`](https://github.com/rust-lang/crates.io-index#num@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-bigint`](https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-bigint-dig`](https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.4) | 0.8.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-cmp`](https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-complex`](https://github.com/rust-lang/crates.io-index#num-complex@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-conv`](https://github.com/rust-lang/crates.io-index#num-conv@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-integer`](https://github.com/rust-lang/crates.io-index#num-integer@0.1.46) | 0.1.46 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-iter`](https://github.com/rust-lang/crates.io-index#num-iter@0.1.45) | 0.1.45 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-rational`](https://github.com/rust-lang/crates.io-index#num-rational@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-traits`](https://github.com/rust-lang/crates.io-index#num-traits@0.2.19) | 0.2.19 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`object`](https://github.com/rust-lang/crates.io-index#object@0.36.7) | 0.36.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`once_cell`](https://github.com/rust-lang/crates.io-index#once_cell@1.21.3) | 1.21.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`once_cell_polyfill`](https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.1) | 1.70.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ordered-stream`](https://github.com/rust-lang/crates.io-index#ordered-stream@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking`](https://github.com/rust-lang/crates.io-index#parking@2.2.1) | 2.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking_lot`](https://github.com/rust-lang/crates.io-index#parking_lot@0.12.4) | 0.12.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking_lot_core`](https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.11) | 0.9.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`paste`](https://github.com/rust-lang/crates.io-index#paste@1.0.15) | 1.0.15 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pathdiff`](https://github.com/rust-lang/crates.io-index#pathdiff@0.2.3) | 0.2.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pem-rfc7468`](https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`percent-encoding`](https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2) | 2.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest`](https://github.com/rust-lang/crates.io-index#pest@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_derive`](https://github.com/rust-lang/crates.io-index#pest_derive@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_generator`](https://github.com/rust-lang/crates.io-index#pest_generator@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_meta`](https://github.com/rust-lang/crates.io-index#pest_meta@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`petgraph`](https://github.com/rust-lang/crates.io-index#petgraph@0.6.5) | 0.6.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pin-project-lite`](https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.16) | 0.2.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pin-utils`](https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`piper`](https://github.com/rust-lang/crates.io-index#piper@0.2.4) | 0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkcs1`](https://github.com/rust-lang/crates.io-index#pkcs1@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkcs8`](https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2) | 0.10.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkg-config`](https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32) | 0.3.32 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`png`](https://github.com/rust-lang/crates.io-index#png@0.17.16) | 0.17.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`png`](https://github.com/rust-lang/crates.io-index#png@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`polling`](https://github.com/rust-lang/crates.io-index#polling@3.10.0) | 3.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`powerfmt`](https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ppv-lite86`](https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21) | 0.2.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates`](https://github.com/rust-lang/crates.io-index#predicates@3.1.3) | 3.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates-core`](https://github.com/rust-lang/crates.io-index#predicates-core@1.0.9) | 1.0.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates-tree`](https://github.com/rust-lang/crates.io-index#predicates-tree@1.0.12) | 1.0.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.3.1) | 1.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.3.0) | 3.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-error`](https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-error-attr`](https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-hack`](https://github.com/rust-lang/crates.io-index#proc-macro-hack@0.5.20+deprecated) | 0.5.20+deprecated | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro2`](https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.101) | 1.0.101 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quick-error`](https://github.com/rust-lang/crates.io-index#quick-error@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quote`](https://github.com/rust-lang/crates.io-index#quote@1.0.40) | 1.0.40 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.8.5) | 0.8.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.9.2) | 0.9.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.6.4) | 0.6.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.9.3) | 0.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_hc`](https://github.com/rust-lang/crates.io-index#rand_hc@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_pcg`](https://github.com/rust-lang/crates.io-index#rand_pcg@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ref-cast`](https://github.com/rust-lang/crates.io-index#ref-cast@1.0.24) | 1.0.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ref-cast-impl`](https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.24) | 1.0.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex`](https://github.com/rust-lang/crates.io-index#regex@1.11.2) | 1.11.2 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex-automata`](https://github.com/rust-lang/crates.io-index#regex-automata@0.4.10) | 0.4.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex-syntax`](https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reqwest`](https://github.com/rust-lang/crates.io-index#reqwest@0.11.27) | 0.11.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reqwest`](https://github.com/rust-lang/crates.io-index#reqwest@0.12.23) | 0.12.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rrule`](https://github.com/rust-lang/crates.io-index#rrule@0.14.0) | 0.14.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rsa`](https://github.com/rust-lang/crates.io-index#rsa@0.9.8) | 0.9.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustc_version`](https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustc-demangle`](https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.26) | 0.1.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustversion`](https://github.com/rust-lang/crates.io-index#rustversion@1.0.22) | 1.0.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`scoped-tls`](https://github.com/rust-lang/crates.io-index#scoped-tls@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`scopeguard`](https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0) | 1.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`semver`](https://github.com/rust-lang/crates.io-index#semver@1.0.26) | 1.0.26 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde`](https://github.com/rust-lang/crates.io-index#serde@1.0.219) | 1.0.219 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_derive`](https://github.com/rust-lang/crates.io-index#serde_derive@1.0.219) | 1.0.219 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_derive_internals`](https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1) | 0.29.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_json`](https://github.com/rust-lang/crates.io-index#serde_json@1.0.143) | 1.0.143 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_repr`](https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20) | 0.1.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_spanned`](https://github.com/rust-lang/crates.io-index#serde_spanned@0.6.9) | 0.6.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_spanned`](https://github.com/rust-lang/crates.io-index#serde_spanned@1.0.0) | 1.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_urlencoded`](https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1) | 0.7.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_with`](https://github.com/rust-lang/crates.io-index#serde_with@3.14.0) | 3.14.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_with_macros`](https://github.com/rust-lang/crates.io-index#serde_with_macros@3.14.0) | 3.14.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde-untagged`](https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.8) | 0.1.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serialize-to-javascript`](https://github.com/rust-lang/crates.io-index#serialize-to-javascript@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serialize-to-javascript-impl`](https://github.com/rust-lang/crates.io-index#serialize-to-javascript-impl@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`servo_arc`](https://github.com/rust-lang/crates.io-index#servo_arc@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sha1`](https://github.com/rust-lang/crates.io-index#sha1@0.10.6) | 0.10.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sha2`](https://github.com/rust-lang/crates.io-index#sha2@0.10.9) | 0.10.9 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`shlex`](https://github.com/rust-lang/crates.io-index#shlex@1.3.0) | 1.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`signal-hook-registry`](https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.6) | 1.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`signature`](https://github.com/rust-lang/crates.io-index#signature@2.2.0) | 2.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`siphasher`](https://github.com/rust-lang/crates.io-index#siphasher@0.3.11) | 0.3.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`siphasher`](https://github.com/rust-lang/crates.io-index#siphasher@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`smallvec`](https://github.com/rust-lang/crates.io-index#smallvec@1.15.1) | 1.15.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`socket2`](https://github.com/rust-lang/crates.io-index#socket2@0.5.10) | 0.5.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`socket2`](https://github.com/rust-lang/crates.io-index#socket2@0.6.0) | 0.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`softbuffer`](https://github.com/rust-lang/crates.io-index#softbuffer@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`spki`](https://github.com/rust-lang/crates.io-index#spki@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx`](https://github.com/rust-lang/crates.io-index#sqlx@0.8.6) | 0.8.6 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-core`](https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-macros`](https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-macros-core`](https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-mysql`](https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-postgres`](https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-sqlite`](https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stable_deref_trait`](https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.0) | 1.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`static_assertions`](https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`string_cache`](https://github.com/rust-lang/crates.io-index#string_cache@0.8.9) | 0.8.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`string_cache_codegen`](https://github.com/rust-lang/crates.io-index#string_cache_codegen@0.5.4) | 0.5.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stringprep`](https://github.com/rust-lang/crates.io-index#stringprep@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`swift-rs`](https://github.com/rust-lang/crates.io-index#swift-rs@1.0.7) | 1.0.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`syn`](https://github.com/rust-lang/crates.io-index#syn@1.0.109) | 1.0.109 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`syn`](https://github.com/rust-lang/crates.io-index#syn@2.0.106) | 2.0.106 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-configuration`](https://github.com/rust-lang/crates.io-index#system-configuration@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-configuration-sys`](https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-deps`](https://github.com/rust-lang/crates.io-index#system-deps@6.2.2) | 6.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tao-macros`](https://github.com/rust-lang/crates.io-index#tao-macros@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri`](https://github.com/rust-lang/crates.io-index#tauri@2.8.4) | 2.8.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-build`](https://github.com/rust-lang/crates.io-index#tauri-build@2.4.0) | 2.4.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-codegen`](https://github.com/rust-lang/crates.io-index#tauri-codegen@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-macros`](https://github.com/rust-lang/crates.io-index#tauri-macros@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin`](https://github.com/rust-lang/crates.io-index#tauri-plugin@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-clipboard-manager`](https://github.com/rust-lang/crates.io-index#tauri-plugin-clipboard-manager@2.3.0) | 2.3.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-dialog`](https://github.com/rust-lang/crates.io-index#tauri-plugin-dialog@2.3.3) | 2.3.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-fs`](https://github.com/rust-lang/crates.io-index#tauri-plugin-fs@2.4.2) | 2.4.2 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-notification`](https://github.com/rust-lang/crates.io-index#tauri-plugin-notification@2.3.1) | 2.3.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-opener`](https://github.com/rust-lang/crates.io-index#tauri-plugin-opener@2.5.0) | 2.5.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-sql`](https://github.com/rust-lang/crates.io-index#tauri-plugin-sql@2.3.0) | 2.3.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-runtime`](https://github.com/rust-lang/crates.io-index#tauri-runtime@2.8.0) | 2.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-runtime-wry`](https://github.com/rust-lang/crates.io-index#tauri-runtime-wry@2.8.1) | 2.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-utils`](https://github.com/rust-lang/crates.io-index#tauri-utils@2.7.0) | 2.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-winrt-notification`](https://github.com/rust-lang/crates.io-index#tauri-winrt-notification@0.7.2) | 0.7.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tempfile`](https://github.com/rust-lang/crates.io-index#tempfile@3.21.0) | 3.21.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tendril`](https://github.com/rust-lang/crates.io-index#tendril@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror`](https://github.com/rust-lang/crates.io-index#thiserror@1.0.69) | 1.0.69 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror`](https://github.com/rust-lang/crates.io-index#thiserror@2.0.16) | 2.0.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror-impl`](https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69) | 1.0.69 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror-impl`](https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.16) | 2.0.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thread_local`](https://github.com/rust-lang/crates.io-index#thread_local@1.1.9) | 1.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time`](https://github.com/rust-lang/crates.io-index#time@0.3.41) | 0.3.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time-core`](https://github.com/rust-lang/crates.io-index#time-core@0.1.4) | 0.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time-macros`](https://github.com/rust-lang/crates.io-index#time-macros@0.2.22) | 0.2.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml`](https://github.com/rust-lang/crates.io-index#toml@0.8.23) | 0.8.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml`](https://github.com/rust-lang/crates.io-index#toml@0.9.5) | 0.9.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_datetime`](https://github.com/rust-lang/crates.io-index#toml_datetime@0.6.11) | 0.6.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_datetime`](https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.19.15) | 0.19.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.20.7) | 0.20.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.22.27) | 0.22.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_parser`](https://github.com/rust-lang/crates.io-index#toml_parser@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_writer`](https://github.com/rust-lang/crates.io-index#toml_writer@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tray-icon`](https://github.com/rust-lang/crates.io-index#tray-icon@0.21.1) | 0.21.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`typeid`](https://github.com/rust-lang/crates.io-index#typeid@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`typenum`](https://github.com/rust-lang/crates.io-index#typenum@1.18.0) | 1.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ucd-trie`](https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7) | 0.1.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-char-property`](https://github.com/rust-lang/crates.io-index#unic-char-property@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-char-range`](https://github.com/rust-lang/crates.io-index#unic-char-range@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-common`](https://github.com/rust-lang/crates.io-index#unic-common@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-ucd-ident`](https://github.com/rust-lang/crates.io-index#unic-ucd-ident@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-ucd-version`](https://github.com/rust-lang/crates.io-index#unic-ucd-version@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-bidi`](https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18) | 0.3.18 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-normalization`](https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.24) | 0.1.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-properties`](https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-segmentation`](https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0) | 1.12.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`url`](https://github.com/rust-lang/crates.io-index#url@2.5.7) | 2.5.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf-8`](https://github.com/rust-lang/crates.io-index#utf-8@0.7.6) | 0.7.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf8_iter`](https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf8parse`](https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`uuid`](https://github.com/rust-lang/crates.io-index#uuid@1.18.0) | 1.18.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vcpkg`](https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15) | 0.2.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`version_check`](https://github.com/rust-lang/crates.io-index#version_check@0.9.5) | 0.9.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wait-timeout`](https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen`](https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-backend`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-futures`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.50) | 0.4.50 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-macro`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-macro-support`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-shared`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-streams`](https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`web-sys`](https://github.com/rust-lang/crates.io-index#web-sys@0.3.77) | 0.3.77 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`weezl`](https://github.com/rust-lang/crates.io-index#weezl@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi`](https://github.com/rust-lang/crates.io-index#winapi@0.3.9) | 0.3.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-i686-pc-windows-gnu`](https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-x86_64-pc-windows-gnu`](https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`window-vibrancy`](https://github.com/rust-lang/crates.io-index#window-vibrancy@0.6.0) | 0.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows`](https://github.com/rust-lang/crates.io-index#windows@0.61.3) | 0.61.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-collections`](https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-core`](https://github.com/rust-lang/crates.io-index#windows-core@0.61.2) | 0.61.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-future`](https://github.com/rust-lang/crates.io-index#windows-future@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-implement`](https://github.com/rust-lang/crates.io-index#windows-implement@0.60.0) | 0.60.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-interface`](https://github.com/rust-lang/crates.io-index#windows-interface@0.59.1) | 0.59.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-link`](https://github.com/rust-lang/crates.io-index#windows-link@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-numerics`](https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-result`](https://github.com/rust-lang/crates.io-index#windows-result@0.3.4) | 0.3.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-strings`](https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0) | 0.45.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.48.0) | 0.48.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0) | 0.52.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0) | 0.59.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.60.2) | 0.60.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.53.3) | 0.53.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-threading`](https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-version`](https://github.com/rust-lang/crates.io-index#windows-version@0.1.4) | 0.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wl-clipboard-rs`](https://github.com/rust-lang/crates.io-index#wl-clipboard-rs@0.9.2) | 0.9.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wry`](https://github.com/rust-lang/crates.io-index#wry@0.53.3) | 0.53.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11rb`](https://github.com/rust-lang/crates.io-index#x11rb@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11rb-protocol`](https://github.com/rust-lang/crates.io-index#x11rb-protocol@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zeroize`](https://github.com/rust-lang/crates.io-index#zeroize@1.8.1) | 1.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT OR Unicode-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`unicode-ident`](https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.18) | 1.0.18 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT OR Zlib
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`bytemuck`](https://github.com/rust-lang/crates.io-index#bytemuck@1.23.2) | 1.23.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dispatch2`](https://github.com/rust-lang/crates.io-index#dispatch2@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`miniz_oxide`](https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9) | 0.8.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-app-kit`](https://github.com/rust-lang/crates.io-index#objc2-app-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-cloud-kit`](https://github.com/rust-lang/crates.io-index#objc2-cloud-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-data`](https://github.com/rust-lang/crates.io-index#objc2-core-data@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-foundation`](https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-graphics`](https://github.com/rust-lang/crates.io-index#objc2-core-graphics@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-image`](https://github.com/rust-lang/crates.io-index#objc2-core-image@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-exception-helper`](https://github.com/rust-lang/crates.io-index#objc2-exception-helper@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-io-surface`](https://github.com/rust-lang/crates.io-index#objc2-io-surface@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-javascript-core`](https://github.com/rust-lang/crates.io-index#objc2-javascript-core@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-quartz-core`](https://github.com/rust-lang/crates.io-index#objc2-quartz-core@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-security`](https://github.com/rust-lang/crates.io-index#objc2-security@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-ui-kit`](https://github.com/rust-lang/crates.io-index#objc2-ui-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-web-kit`](https://github.com/rust-lang/crates.io-index#objc2-web-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`raw-window-handle`](https://github.com/rust-lang/crates.io-index#raw-window-handle@0.6.2) | 0.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinyvec`](https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0) | 1.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinyvec_macros`](https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zune-core`](https://github.com/rust-lang/crates.io-index#zune-core@0.4.12) | 0.4.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zune-jpeg`](https://github.com/rust-lang/crates.io-index#zune-jpeg@0.4.21) | 0.4.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 WITH LLVM-exception
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`target-lexicon`](https://github.com/rust-lang/crates.io-index#target-lexicon@0.12.16) | 0.12.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### BSD-2-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`damerau-levenshtein`](https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz |  |
+| [`entities`](https://registry.npmjs.org/entities/-/entities-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/entities/-/entities-6.0.1.tgz |  |
+| [`eslint-scope`](https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz) | 7.2.2 | Indirect | npm: https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz |  |
+| [`espree`](https://registry.npmjs.org/espree/-/espree-9.6.1.tgz) | 9.6.1 | Indirect | npm: https://registry.npmjs.org/espree/-/espree-9.6.1.tgz |  |
+| [`esrecurse`](https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz) | 4.3.0 | Indirect | npm: https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz |  |
+| [`estraverse`](https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz) | 5.3.0 | Indirect | npm: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz |  |
+| [`esutils`](https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz |  |
+| [`uri-js`](https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz) | 4.4.1 | Indirect | npm: https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz |  |
+| [`webidl-conversions`](https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz) | 7.0.0 | Indirect | npm: https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz |  |
+
+### BSD-3-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@humanwhocodes/object-schema`](https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz | Use @eslint/object-schema instead |
+| [`alloc-no-stdlib`](https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4) | 2.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`alloc-stdlib`](https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`diff`](https://registry.npmjs.org/diff/-/diff-4.0.2.tgz) | 4.0.2 | Indirect | npm: https://registry.npmjs.org/diff/-/diff-4.0.2.tgz |  |
+| [`esquery`](https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz) | 1.6.0 | Indirect | npm: https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz |  |
+| [`fast-uri`](https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz |  |
+| [`ieee754`](https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz |  |
+| [`istanbul-lib-coverage`](https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz) | 3.2.2 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz |  |
+| [`istanbul-lib-report`](https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz |  |
+| [`istanbul-lib-source-maps`](https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz) | 5.0.6 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz |  |
+| [`istanbul-reports`](https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz |  |
+| [`source-map-js`](https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz |  |
+| [`subtle`](https://github.com/rust-lang/crates.io-index#subtle@2.6.1) | 2.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tough-cookie`](https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz) | 5.1.2 | Indirect | npm: https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz |  |
+
+### BSD-3-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`brotli`](https://github.com/rust-lang/crates.io-index#brotli@8.0.2) | 8.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`brotli-decompressor`](https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0) | 5.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### BSL-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`clipboard-win`](https://github.com/rust-lang/crates.io-index#clipboard-win@5.4.1) | 5.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`error-code`](https://github.com/rust-lang/crates.io-index#error-code@3.3.2) | 3.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### CC-BY-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`spdx-exceptions`](https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz) | 2.5.0 | Indirect | npm: https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz |  |
+
+### CC-BY-4.0 OR MIT OR OFL-1.1
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@fortawesome/fontawesome-free`](https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz) | 6.7.2 | Direct | npm: https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz |  |
+
+### CC0-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`language-subtag-registry`](https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz) | 0.3.23 | Indirect | npm: https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz |  |
+| [`spdx-license-ids`](https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz) | 3.0.22 | Indirect | npm: https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz |  |
+
+### CC0-1.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`type-fest`](https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz) | 0.20.2 | Indirect | npm: https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz |  |
+
+### ISC
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@iarna/toml`](https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz) | 2.2.5 | Direct | npm: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz |  |
+| [`@ungap/structured-clone`](https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz |  |
+| [`chownr`](https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz |  |
+| [`fastq`](https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz) | 1.19.1 | Indirect | npm: https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz |  |
+| [`flatted`](https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz) | 3.3.3 | Indirect | npm: https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz |  |
+| [`fs.realpath`](https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz |  |
+| [`glob`](https://registry.npmjs.org/glob/-/glob-7.2.3.tgz) | 7.2.3 | Indirect | npm: https://registry.npmjs.org/glob/-/glob-7.2.3.tgz | Glob versions prior to v9 are no longer supported |
+| [`glob-parent`](https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz) | 5.1.2 | Indirect | npm: https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz |  |
+| [`glob-parent`](https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz) | 6.0.2 | Indirect | npm: https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz |  |
+| [`inflight`](https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz) | 1.0.6 | Indirect | npm: https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz | This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful. |
+| [`inherits`](https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz |  |
+| [`ini`](https://registry.npmjs.org/ini/-/ini-1.3.8.tgz) | 1.3.8 | Indirect | npm: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz |  |
+| [`isexe`](https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz |  |
+| [`json5`](https://github.com/rust-lang/crates.io-index#json5@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libloading`](https://github.com/rust-lang/crates.io-index#libloading@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lru-cache`](https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz) | 10.4.3 | Indirect | npm: https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz |  |
+| [`make-error`](https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz) | 1.3.6 | Indirect | npm: https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz |  |
+| [`minimatch`](https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz) | 3.1.2 | Indirect | npm: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz |  |
+| [`minimatch`](https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz) | 9.0.5 | Indirect | npm: https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz |  |
+| [`once`](https://registry.npmjs.org/once/-/once-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/once/-/once-1.4.0.tgz |  |
+| [`picocolors`](https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz |  |
+| [`rimraf`](https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz) | 3.0.2 | Indirect | npm: https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz | Rimraf versions prior to v4 are no longer supported |
+| [`saxes`](https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz |  |
+| [`semver`](https://registry.npmjs.org/semver/-/semver-6.3.1.tgz) | 6.3.1 | Indirect | npm: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz |  |
+| [`semver`](https://registry.npmjs.org/semver/-/semver-7.7.2.tgz) | 7.7.2 | Indirect | npm: https://registry.npmjs.org/semver/-/semver-7.7.2.tgz |  |
+| [`siginfo`](https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz |  |
+| [`signal-exit`](https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz |  |
+| [`test-exclude`](https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz |  |
+| [`which`](https://registry.npmjs.org/which/-/which-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/which/-/which-2.0.2.tgz |  |
+| [`wrappy`](https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz |  |
+| [`yaml`](https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz) | 2.8.1 | Direct | npm: https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz |  |
+
+### MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@asamuzakjp/css-color`](https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz |  |
+| [`@babel/helper-string-parser`](https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz) | 7.27.1 | Indirect | npm: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz |  |
+| [`@babel/helper-validator-identifier`](https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz) | 7.27.1 | Indirect | npm: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz |  |
+| [`@babel/parser`](https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz) | 7.28.4 | Indirect | npm: https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz |  |
+| [`@babel/types`](https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz) | 7.28.4 | Indirect | npm: https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz |  |
+| [`@bcoe/v8-coverage`](https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz) | 0.2.3 | Indirect | npm: https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz |  |
+| [`@cspotcode/source-map-support`](https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz) | 0.8.1 | Indirect | npm: https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz |  |
+| [`@csstools/css-calc`](https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz) | 2.1.4 | Indirect | npm: https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz |  |
+| [`@csstools/css-color-parser`](https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz |  |
+| [`@csstools/css-parser-algorithms`](https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz) | 3.0.5 | Indirect | npm: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz |  |
+| [`@csstools/css-tokenizer`](https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz) | 3.0.4 | Indirect | npm: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz |  |
+| [`@esbuild/aix-ppc64`](https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz |  |
+| [`@esbuild/aix-ppc64`](https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz |  |
+| [`@esbuild/android-arm`](https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz |  |
+| [`@esbuild/android-arm`](https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz |  |
+| [`@esbuild/android-arm64`](https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz |  |
+| [`@esbuild/android-arm64`](https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz |  |
+| [`@esbuild/android-x64`](https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz |  |
+| [`@esbuild/android-x64`](https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz |  |
+| [`@esbuild/darwin-arm64`](https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz |  |
+| [`@esbuild/darwin-arm64`](https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz |  |
+| [`@esbuild/darwin-x64`](https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz |  |
+| [`@esbuild/darwin-x64`](https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz |  |
+| [`@esbuild/freebsd-arm64`](https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz |  |
+| [`@esbuild/freebsd-arm64`](https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/freebsd-x64`](https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz |  |
+| [`@esbuild/freebsd-x64`](https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz |  |
+| [`@esbuild/linux-arm`](https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz |  |
+| [`@esbuild/linux-arm`](https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz |  |
+| [`@esbuild/linux-arm64`](https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz |  |
+| [`@esbuild/linux-arm64`](https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz |  |
+| [`@esbuild/linux-ia32`](https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz |  |
+| [`@esbuild/linux-ia32`](https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz |  |
+| [`@esbuild/linux-loong64`](https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz |  |
+| [`@esbuild/linux-loong64`](https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz |  |
+| [`@esbuild/linux-mips64el`](https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz |  |
+| [`@esbuild/linux-mips64el`](https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz |  |
+| [`@esbuild/linux-ppc64`](https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz |  |
+| [`@esbuild/linux-ppc64`](https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz |  |
+| [`@esbuild/linux-riscv64`](https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz |  |
+| [`@esbuild/linux-riscv64`](https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz |  |
+| [`@esbuild/linux-s390x`](https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz |  |
+| [`@esbuild/linux-s390x`](https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz |  |
+| [`@esbuild/linux-x64`](https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz |  |
+| [`@esbuild/linux-x64`](https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz |  |
+| [`@esbuild/netbsd-arm64`](https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/netbsd-x64`](https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz |  |
+| [`@esbuild/netbsd-x64`](https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz |  |
+| [`@esbuild/openbsd-arm64`](https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/openbsd-x64`](https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz |  |
+| [`@esbuild/openbsd-x64`](https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz |  |
+| [`@esbuild/openharmony-arm64`](https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz |  |
+| [`@esbuild/sunos-x64`](https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz |  |
+| [`@esbuild/sunos-x64`](https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz |  |
+| [`@esbuild/win32-arm64`](https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz |  |
+| [`@esbuild/win32-arm64`](https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz |  |
+| [`@esbuild/win32-ia32`](https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz |  |
+| [`@esbuild/win32-ia32`](https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz |  |
+| [`@esbuild/win32-x64`](https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz |  |
+| [`@esbuild/win32-x64`](https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz |  |
+| [`@eslint-community/eslint-utils`](https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz) | 4.9.0 | Indirect | npm: https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz |  |
+| [`@eslint-community/regexpp`](https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz) | 4.12.1 | Indirect | npm: https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz |  |
+| [`@eslint/eslintrc`](https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz) | 2.1.4 | Indirect | npm: https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz |  |
+| [`@eslint/js`](https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz) | 8.57.1 | Indirect | npm: https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz |  |
+| [`@istanbuljs/schema`](https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz) | 0.1.3 | Indirect | npm: https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz |  |
+| [`@jest/schemas`](https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz) | 29.6.3 | Indirect | npm: https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz |  |
+| [`@jridgewell/gen-mapping`](https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz) | 0.3.13 | Indirect | npm: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz |  |
+| [`@jridgewell/resolve-uri`](https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz) | 3.1.2 | Indirect | npm: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz |  |
+| [`@jridgewell/sourcemap-codec`](https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz) | 1.5.5 | Indirect | npm: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz |  |
+| [`@jridgewell/trace-mapping`](https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz) | 0.3.30 | Indirect | npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz |  |
+| [`@jridgewell/trace-mapping`](https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz) | 0.3.9 | Indirect | npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz |  |
+| [`@nodelib/fs.scandir`](https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz) | 2.1.5 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz |  |
+| [`@nodelib/fs.stat`](https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz) | 2.0.5 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz |  |
+| [`@nodelib/fs.walk`](https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz |  |
+| [`@parcel/watcher`](https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz |  |
+| [`@parcel/watcher-android-arm64`](https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-darwin-arm64`](https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-darwin-x64`](https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz |  |
+| [`@parcel/watcher-freebsd-x64`](https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm-musl`](https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm64-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm64-musl`](https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-x64-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-x64-musl`](https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-arm64`](https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-ia32`](https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-x64`](https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz |  |
+| [`@rollup/rollup-android-arm-eabi`](https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz |  |
+| [`@rollup/rollup-android-arm64`](https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-darwin-arm64`](https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-darwin-x64`](https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz |  |
+| [`@rollup/rollup-freebsd-arm64`](https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-freebsd-x64`](https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm-gnueabihf`](https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm-musleabihf`](https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-loongarch64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-ppc64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-riscv64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-riscv64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-s390x-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-x64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-x64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-openharmony-arm64`](https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-arm64-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-ia32-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-x64-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz |  |
+| [`@rtsao/scc`](https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz |  |
+| [`@sinclair/typebox`](https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz) | 0.27.8 | Indirect | npm: https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz |  |
+| [`@tsconfig/node10`](https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz) | 1.0.11 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz |  |
+| [`@tsconfig/node12`](https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz) | 1.0.11 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz |  |
+| [`@tsconfig/node14`](https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz |  |
+| [`@tsconfig/node16`](https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz |  |
+| [`@types/better-sqlite3`](https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz) | 7.6.13 | Direct | npm: https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz |  |
+| [`@types/estree`](https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz |  |
+| [`@types/jsdom`](https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz) | 21.1.7 | Direct | npm: https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz |  |
+| [`@types/json5`](https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz) | 0.0.29 | Indirect | npm: https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz |  |
+| [`@types/node`](https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz) | 24.3.0 | Indirect | npm: https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz |  |
+| [`@types/tough-cookie`](https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz) | 4.0.5 | Indirect | npm: https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz |  |
+| [`@typescript-eslint/eslint-plugin`](https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz) | 8.44.0 | Direct | npm: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz |  |
+| [`@typescript-eslint/parser`](https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz) | 8.44.0 | Direct | npm: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz |  |
+| [`@typescript-eslint/project-service`](https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz |  |
+| [`@typescript-eslint/scope-manager`](https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz |  |
+| [`@typescript-eslint/tsconfig-utils`](https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz |  |
+| [`@typescript-eslint/type-utils`](https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz |  |
+| [`@typescript-eslint/types`](https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz |  |
+| [`@typescript-eslint/typescript-estree`](https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz |  |
+| [`@typescript-eslint/utils`](https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz |  |
+| [`@typescript-eslint/visitor-keys`](https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz |  |
+| [`@vitest/coverage-v8`](https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz) | 1.6.1 | Direct | npm: https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz |  |
+| [`@vitest/expect`](https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz |  |
+| [`@vitest/runner`](https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz |  |
+| [`@vitest/snapshot`](https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz |  |
+| [`@vitest/spy`](https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz |  |
+| [`@vitest/utils`](https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz |  |
+| [`acorn`](https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz) | 8.15.0 | Indirect | npm: https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz |  |
+| [`acorn-jsx`](https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz |  |
+| [`acorn-walk`](https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz) | 8.3.4 | Indirect | npm: https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz |  |
+| [`agent-base`](https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz) | 7.1.4 | Indirect | npm: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz |  |
+| [`ajv`](https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz) | 6.12.6 | Direct | npm: https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz |  |
+| [`ajv`](https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz) | 8.17.1 | Direct | npm: https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz |  |
+| [`ajv-formats`](https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz) | 3.0.1 | Direct | npm: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz |  |
+| [`ansi-regex`](https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz) | 5.0.1 | Indirect | npm: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz |  |
+| [`ansi-styles`](https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz) | 4.3.0 | Indirect | npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz |  |
+| [`ansi-styles`](https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz) | 5.2.0 | Indirect | npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz |  |
+| [`arg`](https://registry.npmjs.org/arg/-/arg-4.1.3.tgz) | 4.1.3 | Indirect | npm: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz |  |
+| [`array-buffer-byte-length`](https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz |  |
+| [`array-includes`](https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz) | 3.1.9 | Indirect | npm: https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz |  |
+| [`array.prototype.findlastindex`](https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz) | 1.2.6 | Indirect | npm: https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz |  |
+| [`array.prototype.flat`](https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz) | 1.3.3 | Indirect | npm: https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz |  |
+| [`array.prototype.flatmap`](https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz) | 1.3.3 | Indirect | npm: https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz |  |
+| [`arraybuffer.prototype.slice`](https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz |  |
+| [`ashpd`](https://github.com/rust-lang/crates.io-index#ashpd@0.11.0) | 0.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`assertion-error`](https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz |  |
+| [`ast-types-flow`](https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz) | 0.0.8 | Indirect | npm: https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz |  |
+| [`async-function`](https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz |  |
+| [`atk`](https://github.com/rust-lang/crates.io-index#atk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atk-sys`](https://github.com/rust-lang/crates.io-index#atk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atoi`](https://github.com/rust-lang/crates.io-index#atoi@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`available-typed-arrays`](https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz |  |
+| [`balanced-match`](https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz |  |
+| [`base64-js`](https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz) | 1.5.1 | Indirect | npm: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz |  |
+| [`better-sqlite3`](https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz) | 12.2.0 | Direct | npm: https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz |  |
+| [`bindings`](https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz) | 1.5.0 | Indirect | npm: https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz |  |
+| [`bl`](https://registry.npmjs.org/bl/-/bl-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/bl/-/bl-4.1.0.tgz |  |
+| [`block2`](https://github.com/rust-lang/crates.io-index#block2@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`block2`](https://github.com/rust-lang/crates.io-index#block2@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`brace-expansion`](https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz) | 1.1.12 | Indirect | npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz |  |
+| [`brace-expansion`](https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz |  |
+| [`braces`](https://registry.npmjs.org/braces/-/braces-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz |  |
+| [`buffer`](https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz) | 5.7.1 | Indirect | npm: https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz |  |
+| [`buffer-builder`](https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz) | 0.2.0 | Indirect | npm: https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz | Upstream package declares "MIT/X11"; normalized to MIT for reporting. |
+| [`bytes`](https://github.com/rust-lang/crates.io-index#bytes@1.10.1) | 1.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cac`](https://registry.npmjs.org/cac/-/cac-6.7.14.tgz) | 6.7.14 | Indirect | npm: https://registry.npmjs.org/cac/-/cac-6.7.14.tgz |  |
+| [`cairo-rs`](https://github.com/rust-lang/crates.io-index#cairo-rs@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cairo-sys-rs`](https://github.com/rust-lang/crates.io-index#cairo-sys-rs@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`call-bind`](https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz |  |
+| [`call-bind-apply-helpers`](https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz |  |
+| [`call-bound`](https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz |  |
+| [`callsites`](https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz |  |
+| [`cargo_metadata`](https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2) | 0.19.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfb`](https://github.com/rust-lang/crates.io-index#cfb@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg_aliases`](https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chai`](https://registry.npmjs.org/chai/-/chai-4.5.0.tgz) | 4.5.0 | Indirect | npm: https://registry.npmjs.org/chai/-/chai-4.5.0.tgz |  |
+| [`chalk`](https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz) | 4.1.2 | Indirect | npm: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz |  |
+| [`check-error`](https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz |  |
+| [`chokidar`](https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz |  |
+| [`color-convert`](https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz |  |
+| [`color-name`](https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz |  |
+| [`colorjs.io`](https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz) | 0.5.2 | Indirect | npm: https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz |  |
+| [`combine`](https://github.com/rust-lang/crates.io-index#combine@4.6.7) | 4.6.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`concat-map`](https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz) | 0.0.1 | Indirect | npm: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz |  |
+| [`confbox`](https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz) | 0.1.8 | Indirect | npm: https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz |  |
+| [`convert_case`](https://github.com/rust-lang/crates.io-index#convert_case@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`create-require`](https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz |  |
+| [`cross-spawn`](https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz) | 7.0.6 | Indirect | npm: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz |  |
+| [`crunchy`](https://github.com/rust-lang/crates.io-index#crunchy@0.2.4) | 0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cssstyle`](https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz) | 4.6.0 | Indirect | npm: https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz |  |
+| [`darling`](https://github.com/rust-lang/crates.io-index#darling@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`darling_core`](https://github.com/rust-lang/crates.io-index#darling_core@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`darling_macro`](https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`data-urls`](https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz |  |
+| [`data-view-buffer`](https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz |  |
+| [`data-view-byte-length`](https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz |  |
+| [`data-view-byte-offset`](https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz |  |
+| [`debug`](https://registry.npmjs.org/debug/-/debug-3.2.7.tgz) | 3.2.7 | Indirect | npm: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz |  |
+| [`debug`](https://registry.npmjs.org/debug/-/debug-4.4.1.tgz) | 4.4.1 | Indirect | npm: https://registry.npmjs.org/debug/-/debug-4.4.1.tgz |  |
+| [`decimal.js`](https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz) | 10.6.0 | Indirect | npm: https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz |  |
+| [`decompress-response`](https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz |  |
+| [`deep-eql`](https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz) | 4.1.4 | Indirect | npm: https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz |  |
+| [`deep-extend`](https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz) | 0.6.0 | Indirect | npm: https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz |  |
+| [`deep-is`](https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz) | 0.1.4 | Indirect | npm: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz |  |
+| [`define-data-property`](https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz |  |
+| [`define-properties`](https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz |  |
+| [`derive_more`](https://github.com/rust-lang/crates.io-index#derive_more@0.99.20) | 0.99.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`diff-sequences`](https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz) | 29.6.3 | Indirect | npm: https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz |  |
+| [`difflib`](https://github.com/rust-lang/crates.io-index#difflib@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dispatch`](https://github.com/rust-lang/crates.io-index#dispatch@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dlib`](https://github.com/rust-lang/crates.io-index#dlib@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dlopen2`](https://github.com/rust-lang/crates.io-index#dlopen2@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index | License file bundled with crate (MIT License). |
+| [`dlopen2_derive`](https://github.com/rust-lang/crates.io-index#dlopen2_derive@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index | License file bundled with crate (MIT License). |
+| [`doc-comment`](https://github.com/rust-lang/crates.io-index#doc-comment@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dotenvy`](https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7) | 0.15.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dunder-proto`](https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz |  |
+| [`embed-resource`](https://github.com/rust-lang/crates.io-index#embed-resource@3.0.5) | 3.0.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`emoji-regex`](https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz) | 9.2.2 | Indirect | npm: https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz |  |
+| [`end-of-stream`](https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz) | 1.4.5 | Indirect | npm: https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz |  |
+| [`endi`](https://github.com/rust-lang/crates.io-index#endi@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`es-abstract`](https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz) | 1.24.0 | Indirect | npm: https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz |  |
+| [`es-define-property`](https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz |  |
+| [`es-errors`](https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz |  |
+| [`es-object-atoms`](https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz |  |
+| [`es-set-tostringtag`](https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz |  |
+| [`es-shim-unscopables`](https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz |  |
+| [`es-to-primitive`](https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz |  |
+| [`esbuild`](https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz |  |
+| [`esbuild`](https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz |  |
+| [`escape-string-regexp`](https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz |  |
+| [`eslint`](https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz) | 8.57.1 | Direct | npm: https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz | This version is no longer supported. Please see https://eslint.org/version-support for other options. |
+| [`eslint-import-resolver-node`](https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz) | 0.3.9 | Indirect | npm: https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz |  |
+| [`eslint-module-utils`](https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz) | 2.12.1 | Indirect | npm: https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz |  |
+| [`eslint-plugin-import`](https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz) | 2.32.0 | Direct | npm: https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz |  |
+| [`eslint-plugin-jsx-a11y`](https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz) | 6.10.2 | Direct | npm: https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz |  |
+| [`eslint-plugin-unused-imports`](https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz) | 4.2.0 | Direct | npm: https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz |  |
+| [`estree-walker`](https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz |  |
+| [`execa`](https://registry.npmjs.org/execa/-/execa-8.0.1.tgz) | 8.0.1 | Indirect | npm: https://registry.npmjs.org/execa/-/execa-8.0.1.tgz |  |
+| [`fancy-regex`](https://github.com/rust-lang/crates.io-index#fancy-regex@0.11.0) | 0.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fast-deep-equal`](https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz) | 3.1.3 | Indirect | npm: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz |  |
+| [`fast-glob`](https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz) | 3.3.3 | Indirect | npm: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz |  |
+| [`fast-json-stable-stringify`](https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz |  |
+| [`fast-levenshtein`](https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz) | 2.0.6 | Indirect | npm: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz |  |
+| [`fax`](https://github.com/rust-lang/crates.io-index#fax@0.2.6) | 0.2.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fax_derive`](https://github.com/rust-lang/crates.io-index#fax_derive@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fdir`](https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz) | 6.5.0 | Indirect | npm: https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz |  |
+| [`file-entry-cache`](https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz |  |
+| [`file-rotate`](https://github.com/rust-lang/crates.io-index#file-rotate@0.7.6) | 0.7.6 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`file-uri-to-path`](https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz |  |
+| [`fill-range`](https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz) | 7.1.1 | Indirect | npm: https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz |  |
+| [`find-up`](https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz |  |
+| [`flat-cache`](https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz |  |
+| [`for-each`](https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz) | 0.3.5 | Indirect | npm: https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz |  |
+| [`fs-constants`](https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz |  |
+| [`fsevents`](https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz) | 2.3.2 | Indirect | npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz |  |
+| [`fsevents`](https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz) | 2.3.3 | Indirect | npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz |  |
+| [`function-bind`](https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz) | 1.1.2 | Indirect | npm: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz |  |
+| [`function.prototype.name`](https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz) | 1.1.8 | Indirect | npm: https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz |  |
+| [`functions-have-names`](https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz) | 1.2.3 | Indirect | npm: https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz |  |
+| [`gdk`](https://github.com/rust-lang/crates.io-index#gdk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-pixbuf`](https://github.com/rust-lang/crates.io-index#gdk-pixbuf@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-pixbuf-sys`](https://github.com/rust-lang/crates.io-index#gdk-pixbuf-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-sys`](https://github.com/rust-lang/crates.io-index#gdk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkwayland-sys`](https://github.com/rust-lang/crates.io-index#gdkwayland-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkx11`](https://github.com/rust-lang/crates.io-index#gdkx11@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkx11-sys`](https://github.com/rust-lang/crates.io-index#gdkx11-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`generic-array`](https://github.com/rust-lang/crates.io-index#generic-array@0.14.7) | 0.14.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`get-func-name`](https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz |  |
+| [`get-intrinsic`](https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz |  |
+| [`get-proto`](https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz |  |
+| [`get-stream`](https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz) | 8.0.1 | Indirect | npm: https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz |  |
+| [`get-symbol-description`](https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz |  |
+| [`get-tsconfig`](https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz) | 4.10.1 | Indirect | npm: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz |  |
+| [`gio`](https://github.com/rust-lang/crates.io-index#gio@0.18.4) | 0.18.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gio-sys`](https://github.com/rust-lang/crates.io-index#gio-sys@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`github-from-package`](https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz) | 0.0.0 | Indirect | npm: https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz |  |
+| [`glib`](https://github.com/rust-lang/crates.io-index#glib@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glib-macros`](https://github.com/rust-lang/crates.io-index#glib-macros@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glib-sys`](https://github.com/rust-lang/crates.io-index#glib-sys@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`globals`](https://registry.npmjs.org/globals/-/globals-13.24.0.tgz) | 13.24.0 | Indirect | npm: https://registry.npmjs.org/globals/-/globals-13.24.0.tgz |  |
+| [`globalthis`](https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz |  |
+| [`gobject-sys`](https://github.com/rust-lang/crates.io-index#gobject-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gopd`](https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz |  |
+| [`graphemer`](https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz |  |
+| [`gtk`](https://github.com/rust-lang/crates.io-index#gtk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gtk-sys`](https://github.com/rust-lang/crates.io-index#gtk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gtk3-macros`](https://github.com/rust-lang/crates.io-index#gtk3-macros@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`h2`](https://github.com/rust-lang/crates.io-index#h2@0.3.27) | 0.3.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`has-bigints`](https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz |  |
+| [`has-flag`](https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz |  |
+| [`has-property-descriptors`](https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz |  |
+| [`has-proto`](https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz |  |
+| [`has-symbols`](https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz |  |
+| [`has-tostringtag`](https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz |  |
+| [`hasown`](https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz |  |
+| [`html-encoding-sniffer`](https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz |  |
+| [`html-escaper`](https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz |  |
+| [`http-body`](https://github.com/rust-lang/crates.io-index#http-body@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-body`](https://github.com/rust-lang/crates.io-index#http-body@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-body-util`](https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-proxy-agent`](https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz) | 7.0.2 | Indirect | npm: https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz |  |
+| [`https-proxy-agent`](https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz) | 7.0.6 | Indirect | npm: https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz |  |
+| [`hyper`](https://github.com/rust-lang/crates.io-index#hyper@0.14.32) | 0.14.32 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hyper`](https://github.com/rust-lang/crates.io-index#hyper@1.7.0) | 1.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hyper-util`](https://github.com/rust-lang/crates.io-index#hyper-util@0.1.16) | 0.1.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ico`](https://github.com/rust-lang/crates.io-index#ico@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iconv-lite`](https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz) | 0.6.3 | Indirect | npm: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz |  |
+| [`ignore`](https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz |  |
+| [`ignore`](https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz) | 7.0.5 | Indirect | npm: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz |  |
+| [`immutable`](https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz) | 5.1.3 | Indirect | npm: https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz |  |
+| [`import-fresh`](https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz) | 3.3.1 | Indirect | npm: https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz |  |
+| [`imurmurhash`](https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz) | 0.1.4 | Indirect | npm: https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz |  |
+| [`include_dir`](https://github.com/rust-lang/crates.io-index#include_dir@0.7.4) | 0.7.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`include_dir_macros`](https://github.com/rust-lang/crates.io-index#include_dir_macros@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`infer`](https://github.com/rust-lang/crates.io-index#infer@0.19.0) | 0.19.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`internal-slot`](https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz |  |
+| [`is-array-buffer`](https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz) | 3.0.5 | Indirect | npm: https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz |  |
+| [`is-async-function`](https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz |  |
+| [`is-bigint`](https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz |  |
+| [`is-boolean-object`](https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz) | 1.2.2 | Indirect | npm: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz |  |
+| [`is-callable`](https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz) | 1.2.7 | Indirect | npm: https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz |  |
+| [`is-core-module`](https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz) | 2.16.1 | Indirect | npm: https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz |  |
+| [`is-data-view`](https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz |  |
+| [`is-date-object`](https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz |  |
+| [`is-docker`](https://github.com/rust-lang/crates.io-index#is-docker@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`is-extglob`](https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz |  |
+| [`is-finalizationregistry`](https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz |  |
+| [`is-generator-function`](https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz |  |
+| [`is-glob`](https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz |  |
+| [`is-map`](https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz |  |
+| [`is-negative-zero`](https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz |  |
+| [`is-number`](https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz) | 7.0.0 | Indirect | npm: https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz |  |
+| [`is-number-object`](https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz |  |
+| [`is-path-inside`](https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz |  |
+| [`is-potential-custom-element-name`](https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz |  |
+| [`is-regex`](https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz |  |
+| [`is-set`](https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz |  |
+| [`is-shared-array-buffer`](https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz |  |
+| [`is-stream`](https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz |  |
+| [`is-string`](https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz |  |
+| [`is-symbol`](https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz |  |
+| [`is-typed-array`](https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz) | 1.1.15 | Indirect | npm: https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz |  |
+| [`is-weakmap`](https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz |  |
+| [`is-weakref`](https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz |  |
+| [`is-weakset`](https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz |  |
+| [`is-wsl`](https://github.com/rust-lang/crates.io-index#is-wsl@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`isarray`](https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz) | 2.0.5 | Indirect | npm: https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz |  |
+| [`iso8601`](https://github.com/rust-lang/crates.io-index#iso8601@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`javascriptcore-rs`](https://github.com/rust-lang/crates.io-index#javascriptcore-rs@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`javascriptcore-rs-sys`](https://github.com/rust-lang/crates.io-index#javascriptcore-rs-sys@1.1.1) | 1.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`js-tokens`](https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz) | 9.0.1 | Indirect | npm: https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz |  |
+| [`js-yaml`](https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz |  |
+| [`jsdom`](https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz) | 26.1.0 | Direct | npm: https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz |  |
+| [`json-buffer`](https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz |  |
+| [`json-schema-traverse`](https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz) | 0.4.1 | Indirect | npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz |  |
+| [`json-schema-traverse`](https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz |  |
+| [`json-stable-stringify-without-jsonify`](https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz |  |
+| [`json5`](https://registry.npmjs.org/json5/-/json5-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/json5/-/json5-1.0.2.tgz |  |
+| [`json5`](https://registry.npmjs.org/json5/-/json5-2.2.3.tgz) | 2.2.3 | Indirect | npm: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz |  |
+| [`jsonschema`](https://github.com/rust-lang/crates.io-index#jsonschema@0.17.1) | 0.17.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jsx-ast-utils`](https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz) | 3.3.5 | Indirect | npm: https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz |  |
+| [`keyv`](https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz) | 4.5.4 | Indirect | npm: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz |  |
+| [`kuchikiki`](https://github.com/rust-lang/crates.io-index#kuchikiki@0.8.8-speedreader) | 0.8.8-speedreader | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`language-tags`](https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz) | 1.0.9 | Indirect | npm: https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz |  |
+| [`levn`](https://registry.npmjs.org/levn/-/levn-0.4.1.tgz) | 0.4.1 | Indirect | npm: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz |  |
+| [`libm`](https://github.com/rust-lang/crates.io-index#libm@0.2.15) | 0.2.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libredox`](https://github.com/rust-lang/crates.io-index#libredox@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libsqlite3-sys`](https://github.com/rust-lang/crates.io-index#libsqlite3-sys@0.30.1) | 0.30.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`local-pkg`](https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz) | 0.5.1 | Indirect | npm: https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz |  |
+| [`locate-path`](https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz |  |
+| [`lodash.merge`](https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz) | 4.6.2 | Indirect | npm: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz |  |
+| [`loupe`](https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz) | 2.3.7 | Indirect | npm: https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz |  |
+| [`mac-notification-sys`](https://github.com/rust-lang/crates.io-index#mac-notification-sys@0.6.6) | 0.6.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`magic-string`](https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz) | 0.30.19 | Indirect | npm: https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz |  |
+| [`magicast`](https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz) | 0.3.5 | Indirect | npm: https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz |  |
+| [`make-dir`](https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz |  |
+| [`matchers`](https://github.com/rust-lang/crates.io-index#matchers@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`matches`](https://github.com/rust-lang/crates.io-index#matches@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`math-intrinsics`](https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz |  |
+| [`memoffset`](https://github.com/rust-lang/crates.io-index#memoffset@0.9.1) | 0.9.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`merge-stream`](https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz |  |
+| [`merge2`](https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz) | 1.4.1 | Indirect | npm: https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz |  |
+| [`micromatch`](https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz) | 4.0.8 | Indirect | npm: https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz |  |
+| [`mimic-fn`](https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz |  |
+| [`mimic-response`](https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz |  |
+| [`minimist`](https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz |  |
+| [`mio`](https://github.com/rust-lang/crates.io-index#mio@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mkdirp-classic`](https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz) | 0.5.3 | Indirect | npm: https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz |  |
+| [`mlly`](https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz) | 1.8.0 | Indirect | npm: https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz |  |
+| [`ms`](https://registry.npmjs.org/ms/-/ms-2.1.3.tgz) | 2.1.3 | Indirect | npm: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz |  |
+| [`nanoid`](https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz) | 3.3.11 | Indirect | npm: https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz |  |
+| [`napi-build-utils`](https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz |  |
+| [`natural-compare`](https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz |  |
+| [`new_debug_unreachable`](https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6) | 1.0.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nix`](https://github.com/rust-lang/crates.io-index#nix@0.30.1) | 0.30.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`node-abi`](https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz) | 3.75.0 | Indirect | npm: https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz |  |
+| [`node-addon-api`](https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz) | 7.1.1 | Indirect | npm: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz |  |
+| [`nom`](https://github.com/rust-lang/crates.io-index#nom@7.1.3) | 7.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nom`](https://github.com/rust-lang/crates.io-index#nom@8.0.0) | 8.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`npm-run-path`](https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz) | 5.3.0 | Indirect | npm: https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz |  |
+| [`nu-ansi-term`](https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.1) | 0.50.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nwsapi`](https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz) | 2.2.22 | Indirect | npm: https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz |  |
+| [`objc-sys`](https://github.com/rust-lang/crates.io-index#objc-sys@0.3.5) | 0.3.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2`](https://github.com/rust-lang/crates.io-index#objc2@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2`](https://github.com/rust-lang/crates.io-index#objc2@0.6.2) | 0.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-encode`](https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0) | 4.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-foundation`](https://github.com/rust-lang/crates.io-index#objc2-foundation@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-foundation`](https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-metal`](https://github.com/rust-lang/crates.io-index#objc2-metal@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-quartz-core`](https://github.com/rust-lang/crates.io-index#objc2-quartz-core@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`object-inspect`](https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz) | 1.13.4 | Indirect | npm: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz |  |
+| [`object-keys`](https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz |  |
+| [`object.assign`](https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz) | 4.1.7 | Indirect | npm: https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz |  |
+| [`object.fromentries`](https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz) | 2.0.8 | Indirect | npm: https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz |  |
+| [`object.groupby`](https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz |  |
+| [`object.values`](https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz |  |
+| [`onetime`](https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz |  |
+| [`open`](https://github.com/rust-lang/crates.io-index#open@5.3.2) | 5.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`optionator`](https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz) | 0.9.4 | Indirect | npm: https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz |  |
+| [`os_pipe`](https://github.com/rust-lang/crates.io-index#os_pipe@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`own-keys`](https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz |  |
+| [`p-limit`](https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz |  |
+| [`p-limit`](https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz |  |
+| [`p-locate`](https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz |  |
+| [`pango`](https://github.com/rust-lang/crates.io-index#pango@0.18.3) | 0.18.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pango-sys`](https://github.com/rust-lang/crates.io-index#pango-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parent-module`](https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz |  |
+| [`parse5`](https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz) | 7.3.0 | Indirect | npm: https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz |  |
+| [`path-exists`](https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz |  |
+| [`path-is-absolute`](https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz |  |
+| [`path-key`](https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz |  |
+| [`path-key`](https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz |  |
+| [`path-parse`](https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz |  |
+| [`pathe`](https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz) | 1.1.2 | Indirect | npm: https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz |  |
+| [`pathe`](https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz |  |
+| [`pathval`](https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.10.1) | 0.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_codegen`](https://github.com/rust-lang/crates.io-index#phf_codegen@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_codegen`](https://github.com/rust-lang/crates.io-index#phf_codegen@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_macros`](https://github.com/rust-lang/crates.io-index#phf_macros@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_macros`](https://github.com/rust-lang/crates.io-index#phf_macros@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`picomatch`](https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz) | 2.3.1 | Indirect | npm: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz |  |
+| [`picomatch`](https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz |  |
+| [`pkg-types`](https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz) | 1.3.1 | Indirect | npm: https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz |  |
+| [`plist`](https://github.com/rust-lang/crates.io-index#plist@1.7.4) | 1.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`possible-typed-array-names`](https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz |  |
+| [`postcss`](https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz) | 8.5.6 | Indirect | npm: https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz |  |
+| [`prebuild-install`](https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz) | 7.1.3 | Indirect | npm: https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz |  |
+| [`precomputed-hash`](https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`prelude-ls`](https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz |  |
+| [`pretty-format`](https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz) | 29.7.0 | Indirect | npm: https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz |  |
+| [`pump`](https://registry.npmjs.org/pump/-/pump-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/pump/-/pump-3.0.3.tgz |  |
+| [`punycode`](https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz) | 2.3.1 | Indirect | npm: https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz |  |
+| [`queue-microtask`](https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz) | 1.2.3 | Indirect | npm: https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz |  |
+| [`quick-xml`](https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5) | 0.37.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quick-xml`](https://github.com/rust-lang/crates.io-index#quick-xml@0.38.3) | 0.38.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`react-is`](https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz) | 18.3.1 | Indirect | npm: https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz |  |
+| [`readable-stream`](https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz) | 3.6.2 | Indirect | npm: https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz |  |
+| [`readdirp`](https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz) | 4.1.2 | Indirect | npm: https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz |  |
+| [`redox_syscall`](https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.17) | 0.5.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`redox_users`](https://github.com/rust-lang/crates.io-index#redox_users@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`redox_users`](https://github.com/rust-lang/crates.io-index#redox_users@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reflect.getprototypeof`](https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz) | 1.0.10 | Indirect | npm: https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz |  |
+| [`regexp-tree`](https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz) | 0.1.27 | Indirect | npm: https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz |  |
+| [`regexp.prototype.flags`](https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz) | 1.5.4 | Indirect | npm: https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz |  |
+| [`require-from-string`](https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz |  |
+| [`resolve`](https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz) | 1.22.10 | Indirect | npm: https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz |  |
+| [`resolve-from`](https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz |  |
+| [`resolve-pkg-maps`](https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz |  |
+| [`reusify`](https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz |  |
+| [`rfd`](https://github.com/rust-lang/crates.io-index#rfd@0.15.4) | 0.15.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rollup`](https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz |  |
+| [`rrweb-cssom`](https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz) | 0.8.0 | Indirect | npm: https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz |  |
+| [`run-parallel`](https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz |  |
+| [`rusqlite`](https://github.com/rust-lang/crates.io-index#rusqlite@0.32.1) | 0.32.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`safe-array-concat`](https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz) | 1.1.3 | Indirect | npm: https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz |  |
+| [`safe-buffer`](https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz) | 5.2.1 | Indirect | npm: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz |  |
+| [`safe-push-apply`](https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz |  |
+| [`safe-regex`](https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz |  |
+| [`safe-regex-test`](https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz |  |
+| [`safer-buffer`](https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz) | 2.1.2 | Indirect | npm: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz |  |
+| [`sass`](https://registry.npmjs.org/sass/-/sass-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass/-/sass-1.91.0.tgz |  |
+| [`sass-embedded`](https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz) | 1.91.0 | Direct | npm: https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz |  |
+| [`sass-embedded-all-unknown`](https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz |  |
+| [`sass-embedded-android-arm`](https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz |  |
+| [`sass-embedded-android-arm64`](https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz |  |
+| [`sass-embedded-android-riscv64`](https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-android-x64`](https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz |  |
+| [`sass-embedded-darwin-arm64`](https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz |  |
+| [`sass-embedded-darwin-x64`](https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz |  |
+| [`sass-embedded-linux-arm`](https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz |  |
+| [`sass-embedded-linux-arm64`](https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-arm`](https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-arm64`](https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-riscv64`](https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-x64`](https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz |  |
+| [`sass-embedded-linux-riscv64`](https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-linux-x64`](https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz |  |
+| [`sass-embedded-unknown-all`](https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz |  |
+| [`sass-embedded-win32-arm64`](https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz |  |
+| [`sass-embedded-win32-x64`](https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@0.8.22) | 0.8.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars_derive`](https://github.com/rust-lang/crates.io-index#schemars_derive@0.8.22) | 0.8.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`set-function-length`](https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz) | 1.2.2 | Indirect | npm: https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz |  |
+| [`set-function-name`](https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz |  |
+| [`set-proto`](https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz |  |
+| [`sharded-slab`](https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7) | 0.1.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`shebang-command`](https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz |  |
+| [`shebang-regex`](https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz |  |
+| [`side-channel`](https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz |  |
+| [`side-channel-list`](https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz |  |
+| [`side-channel-map`](https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz |  |
+| [`side-channel-weakmap`](https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz |  |
+| [`simd-adler32`](https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.7) | 0.3.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`simple-concat`](https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz |  |
+| [`simple-get`](https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz) | 4.0.1 | Indirect | npm: https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz |  |
+| [`slab`](https://github.com/rust-lang/crates.io-index#slab@0.4.11) | 0.4.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`soup3`](https://github.com/rust-lang/crates.io-index#soup3@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`soup3-sys`](https://github.com/rust-lang/crates.io-index#soup3-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`spdx-expression-parse`](https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz) | 4.0.0 | Direct | npm: https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz |  |
+| [`spin`](https://github.com/rust-lang/crates.io-index#spin@0.9.8) | 0.9.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stackback`](https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz) | 0.0.2 | Indirect | npm: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz |  |
+| [`std-env`](https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz) | 3.9.0 | Indirect | npm: https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz |  |
+| [`stop-iteration-iterator`](https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz |  |
+| [`string_decoder`](https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/string\_decoder/-/string\_decoder-1.3.0.tgz |  |
+| [`string.prototype.includes`](https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz |  |
+| [`string.prototype.trim`](https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz) | 1.2.10 | Indirect | npm: https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz |  |
+| [`string.prototype.trimend`](https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz) | 1.0.9 | Indirect | npm: https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz |  |
+| [`string.prototype.trimstart`](https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz |  |
+| [`strip-ansi`](https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz |  |
+| [`strip-bom`](https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz |  |
+| [`strip-final-newline`](https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz |  |
+| [`strip-json-comments`](https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz |  |
+| [`strip-json-comments`](https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz |  |
+| [`strip-literal`](https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz |  |
+| [`strsim`](https://github.com/rust-lang/crates.io-index#strsim@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`supports-color`](https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz) | 7.2.0 | Indirect | npm: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz |  |
+| [`supports-color`](https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz) | 8.1.1 | Indirect | npm: https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz |  |
+| [`supports-preserve-symlinks-flag`](https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz |  |
+| [`symbol-tree`](https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz) | 3.2.4 | Indirect | npm: https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz |  |
+| [`sync-child-process`](https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz |  |
+| [`sync-message-port`](https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz) | 1.1.3 | Indirect | npm: https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz |  |
+| [`synstructure`](https://github.com/rust-lang/crates.io-index#synstructure@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tar-fs`](https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz) | 2.1.3 | Indirect | npm: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz |  |
+| [`tar-stream`](https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz) | 2.2.0 | Indirect | npm: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz |  |
+| [`tauri-winres`](https://github.com/rust-lang/crates.io-index#tauri-winres@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`termtree`](https://github.com/rust-lang/crates.io-index#termtree@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`text-table`](https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz) | 0.2.0 | Indirect | npm: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz |  |
+| [`tiff`](https://github.com/rust-lang/crates.io-index#tiff@0.10.3) | 0.10.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinybench`](https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz) | 2.9.0 | Indirect | npm: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz |  |
+| [`tinyglobby`](https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz) | 0.2.14 | Indirect | npm: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz |  |
+| [`tinypool`](https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz) | 0.8.4 | Indirect | npm: https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz |  |
+| [`tinyspy`](https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz) | 2.2.1 | Indirect | npm: https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz |  |
+| [`tldts`](https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz) | 6.1.86 | Indirect | npm: https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz |  |
+| [`tldts-core`](https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz) | 6.1.86 | Indirect | npm: https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz |  |
+| [`to-regex-range`](https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz) | 5.0.1 | Indirect | npm: https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz |  |
+| [`tokio`](https://github.com/rust-lang/crates.io-index#tokio@1.47.1) | 1.47.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-macros`](https://github.com/rust-lang/crates.io-index#tokio-macros@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-stream`](https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.17) | 0.1.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-util`](https://github.com/rust-lang/crates.io-index#tokio-util@0.7.16) | 0.7.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower`](https://github.com/rust-lang/crates.io-index#tower@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-http`](https://github.com/rust-lang/crates.io-index#tower-http@0.6.6) | 0.6.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-layer`](https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-service`](https://github.com/rust-lang/crates.io-index#tower-service@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tr46`](https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz) | 5.1.1 | Indirect | npm: https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz |  |
+| [`tracing`](https://github.com/rust-lang/crates.io-index#tracing@0.1.41) | 0.1.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-appender`](https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.3) | 0.2.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-attributes`](https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.30) | 0.1.30 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-core`](https://github.com/rust-lang/crates.io-index#tracing-core@0.1.34) | 0.1.34 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-log`](https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0) | 0.2.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-serde`](https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-subscriber`](https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.20) | 0.3.20 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tree_magic_mini`](https://github.com/rust-lang/crates.io-index#tree_magic_mini@3.2.0) | 3.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`try-lock`](https://github.com/rust-lang/crates.io-index#try-lock@0.2.5) | 0.2.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ts-api-utils`](https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz |  |
+| [`ts-node`](https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz) | 10.9.2 | Direct | npm: https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz |  |
+| [`ts-rs`](https://github.com/rust-lang/crates.io-index#ts-rs@10.1.0) | 10.1.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ts-rs-macros`](https://github.com/rust-lang/crates.io-index#ts-rs-macros@10.1.0) | 10.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tsconfig-paths`](https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz) | 3.15.0 | Direct | npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz |  |
+| [`tsconfig-paths`](https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz) | 4.2.0 | Direct | npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz |  |
+| [`tsx`](https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz) | 4.20.5 | Direct | npm: https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz |  |
+| [`type-check`](https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz) | 0.4.0 | Indirect | npm: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz |  |
+| [`type-detect`](https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz |  |
+| [`typed-array-buffer`](https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz |  |
+| [`typed-array-byte-length`](https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz |  |
+| [`typed-array-byte-offset`](https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz |  |
+| [`typed-array-length`](https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz |  |
+| [`uds_windows`](https://github.com/rust-lang/crates.io-index#uds_windows@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ufo`](https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz |  |
+| [`unbox-primitive`](https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz |  |
+| [`undici-types`](https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz) | 7.10.0 | Indirect | npm: https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz |  |
+| [`urlpattern`](https://github.com/rust-lang/crates.io-index#urlpattern@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`util-deprecate`](https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz |  |
+| [`v8-compile-cache-lib`](https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz |  |
+| [`valuable`](https://github.com/rust-lang/crates.io-index#valuable@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`varint`](https://registry.npmjs.org/varint/-/varint-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/varint/-/varint-6.0.0.tgz |  |
+| [`version-compare`](https://github.com/rust-lang/crates.io-index#version-compare@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vite`](https://registry.npmjs.org/vite/-/vite-5.4.20.tgz) | 5.4.20 | Direct | npm: https://registry.npmjs.org/vite/-/vite-5.4.20.tgz |  |
+| [`vite`](https://registry.npmjs.org/vite/-/vite-6.3.5.tgz) | 6.3.5 | Direct | npm: https://registry.npmjs.org/vite/-/vite-6.3.5.tgz |  |
+| [`vite-node`](https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz |  |
+| [`vitest`](https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz) | 1.6.1 | Direct | npm: https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz |  |
+| [`vswhom`](https://github.com/rust-lang/crates.io-index#vswhom@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vswhom-sys`](https://github.com/rust-lang/crates.io-index#vswhom-sys@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`w3c-xmlserializer`](https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz |  |
+| [`want`](https://github.com/rust-lang/crates.io-index#want@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-backend`](https://github.com/rust-lang/crates.io-index#wayland-backend@0.3.11) | 0.3.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-client`](https://github.com/rust-lang/crates.io-index#wayland-client@0.31.11) | 0.31.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-protocols`](https://github.com/rust-lang/crates.io-index#wayland-protocols@0.32.9) | 0.32.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-protocols-wlr`](https://github.com/rust-lang/crates.io-index#wayland-protocols-wlr@0.3.9) | 0.3.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-scanner`](https://github.com/rust-lang/crates.io-index#wayland-scanner@0.31.7) | 0.31.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-sys`](https://github.com/rust-lang/crates.io-index#wayland-sys@0.31.7) | 0.31.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webkit2gtk`](https://github.com/rust-lang/crates.io-index#webkit2gtk@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webkit2gtk-sys`](https://github.com/rust-lang/crates.io-index#webkit2gtk-sys@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com`](https://github.com/rust-lang/crates.io-index#webview2-com@0.38.0) | 0.38.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com-macros`](https://github.com/rust-lang/crates.io-index#webview2-com-macros@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com-sys`](https://github.com/rust-lang/crates.io-index#webview2-com-sys@0.38.0) | 0.38.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`whatwg-encoding`](https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz |  |
+| [`whatwg-mimetype`](https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz |  |
+| [`whatwg-url`](https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz) | 14.2.0 | Indirect | npm: https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz |  |
+| [`which-boxed-primitive`](https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz |  |
+| [`which-builtin-type`](https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz |  |
+| [`which-collection`](https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz |  |
+| [`which-typed-array`](https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz) | 1.1.19 | Indirect | npm: https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz |  |
+| [`why-is-node-running`](https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz) | 2.3.0 | Indirect | npm: https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz |  |
+| [`winnow`](https://github.com/rust-lang/crates.io-index#winnow@0.5.40) | 0.5.40 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winnow`](https://github.com/rust-lang/crates.io-index#winnow@0.7.13) | 0.7.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winreg`](https://github.com/rust-lang/crates.io-index#winreg@0.50.0) | 0.50.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winreg`](https://github.com/rust-lang/crates.io-index#winreg@0.55.0) | 0.55.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`word-wrap`](https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz) | 1.2.5 | Indirect | npm: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz |  |
+| [`ws`](https://registry.npmjs.org/ws/-/ws-8.18.3.tgz) | 8.18.3 | Indirect | npm: https://registry.npmjs.org/ws/-/ws-8.18.3.tgz |  |
+| [`x11`](https://github.com/rust-lang/crates.io-index#x11@2.21.0) | 2.21.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11-dl`](https://github.com/rust-lang/crates.io-index#x11-dl@2.21.0) | 2.21.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`xmlchars`](https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz) | 2.2.0 | Indirect | npm: https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz |  |
+| [`yn`](https://registry.npmjs.org/yn/-/yn-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/yn/-/yn-3.1.1.tgz |  |
+| [`yocto-queue`](https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz) | 0.1.0 | Indirect | npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz |  |
+| [`yocto-queue`](https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz |  |
+| [`zbus`](https://github.com/rust-lang/crates.io-index#zbus@5.10.0) | 5.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zbus_macros`](https://github.com/rust-lang/crates.io-index#zbus_macros@5.10.0) | 5.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zbus_names`](https://github.com/rust-lang/crates.io-index#zbus_names@4.2.0) | 4.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant`](https://github.com/rust-lang/crates.io-index#zvariant@5.7.0) | 5.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant_derive`](https://github.com/rust-lang/crates.io-index#zvariant_derive@5.7.0) | 5.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant_utils`](https://github.com/rust-lang/crates.io-index#zvariant_utils@3.2.1) | 3.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### MIT OR Unlicense
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`aho-corasick`](https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.3) | 1.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`byteorder`](https://github.com/rust-lang/crates.io-index#byteorder@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`byteorder-lite`](https://github.com/rust-lang/crates.io-index#byteorder-lite@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`memchr`](https://github.com/rust-lang/crates.io-index#memchr@2.7.5) | 2.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`same-file`](https://github.com/rust-lang/crates.io-index#same-file@1.0.6) | 1.0.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`termcolor`](https://github.com/rust-lang/crates.io-index#termcolor@1.4.1) | 1.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`walkdir`](https://github.com/rust-lang/crates.io-index#walkdir@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-util`](https://github.com/rust-lang/crates.io-index#winapi-util@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### MIT OR WTFPL
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`expand-template`](https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz |  |
+
+### MIT-0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@csstools/color-helpers`](https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz) | 5.1.0 | Indirect | npm: https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz |  |
+
+### MPL-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@axe-core/playwright`](https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz) | 4.10.2 | Direct | npm: https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz |  |
+| [`axe-core`](https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz) | 4.10.3 | Indirect | npm: https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz |  |
+| [`cssparser`](https://github.com/rust-lang/crates.io-index#cssparser@0.29.6) | 0.29.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cssparser-macros`](https://github.com/rust-lang/crates.io-index#cssparser-macros@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dtoa-short`](https://github.com/rust-lang/crates.io-index#dtoa-short@0.3.5) | 0.3.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`option-ext`](https://github.com/rust-lang/crates.io-index#option-ext@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`selectors`](https://github.com/rust-lang/crates.io-index#selectors@0.24.0) | 0.24.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Python-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`argparse`](https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz |  |
+
+### Unicode-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`icu_collections`](https://github.com/rust-lang/crates.io-index#icu_collections@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_locale_core`](https://github.com/rust-lang/crates.io-index#icu_locale_core@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_normalizer`](https://github.com/rust-lang/crates.io-index#icu_normalizer@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_normalizer_data`](https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_properties`](https://github.com/rust-lang/crates.io-index#icu_properties@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_properties_data`](https://github.com/rust-lang/crates.io-index#icu_properties_data@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_provider`](https://github.com/rust-lang/crates.io-index#icu_provider@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`litemap`](https://github.com/rust-lang/crates.io-index#litemap@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`potential_utf`](https://github.com/rust-lang/crates.io-index#potential_utf@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinystr`](https://github.com/rust-lang/crates.io-index#tinystr@0.8.1) | 0.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`writeable`](https://github.com/rust-lang/crates.io-index#writeable@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`yoke`](https://github.com/rust-lang/crates.io-index#yoke@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`yoke-derive`](https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerofrom`](https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerofrom-derive`](https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerotrie`](https://github.com/rust-lang/crates.io-index#zerotrie@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerovec`](https://github.com/rust-lang/crates.io-index#zerovec@0.11.4) | 0.11.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerovec-derive`](https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Zlib
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`foldhash`](https://github.com/rust-lang/crates.io-index#foldhash@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Fonts and Icons
+
+Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+"Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+
+### Questions & Contact
+
+For questions about licensing or attribution, please contact the Arklowdun team at [compliance@arklowdun.local](mailto:compliance@arklowdun.local).
+
+---
+
+Generated automatically; refresh with `npm run generate:notice` whenever dependencies change.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,1457 @@
+# NOTICE
+
+This NOTICE file was generated from Arklowdun's consolidated licensing inventory. It lists the third-party components distributed with the application together with their license identifiers and provenance information.
+
+## Third-Party Components
+
+### 0BSD
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`tslib`](https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz) | 2.8.1 | Indirect | npm: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz |  |
+
+### 0BSD OR Apache-2.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`adler2`](https://github.com/rust-lang/crates.io-index#adler2@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@ampproject/remapping`](https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz) | 2.3.0 | Indirect | npm: https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz |  |
+| [`@humanwhocodes/config-array`](https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz) | 0.13.0 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz | Use @eslint/config-array instead |
+| [`@humanwhocodes/module-importer`](https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz |  |
+| [`@playwright/test`](https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz) | 1.55.0 | Direct | npm: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz |  |
+| [`aria-query`](https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz |  |
+| [`axobject-query`](https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz |  |
+| [`detect-libc`](https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz |  |
+| [`detect-libc`](https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz |  |
+| [`doctrine`](https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz |  |
+| [`doctrine`](https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz |  |
+| [`eslint-plugin-security`](https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz) | 2.1.1 | Direct | npm: https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz |  |
+| [`eslint-visitor-keys`](https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz) | 3.4.3 | Indirect | npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz |  |
+| [`eslint-visitor-keys`](https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz) | 4.2.1 | Indirect | npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz |  |
+| [`gethostname`](https://github.com/rust-lang/crates.io-index#gethostname@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`human-signals`](https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz |  |
+| [`playwright`](https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz) | 1.55.0 | Indirect | npm: https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz |  |
+| [`playwright-core`](https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz) | 1.55.0 | Indirect | npm: https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz |  |
+| [`rxjs`](https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz) | 7.8.2 | Indirect | npm: https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz |  |
+| [`similar`](https://github.com/rust-lang/crates.io-index#similar@2.7.0) | 2.7.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sync_wrapper`](https://github.com/rust-lang/crates.io-index#sync_wrapper@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sync_wrapper`](https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tao`](https://github.com/rust-lang/crates.io-index#tao@0.34.2) | 0.34.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tunnel-agent`](https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz) | 0.6.0 | Indirect | npm: https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz |  |
+| [`typescript`](https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz) | 5.9.2 | Direct | npm: https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz |  |
+| [`xml-name-validator`](https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz |  |
+
+### Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`linux-raw-sys`](https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.4.15) | 0.4.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`linux-raw-sys`](https://github.com/rust-lang/crates.io-index#linux-raw-sys@0.9.4) | 0.9.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustix`](https://github.com/rust-lang/crates.io-index#rustix@0.38.44) | 0.38.44 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustix`](https://github.com/rust-lang/crates.io-index#rustix@1.0.8) | 1.0.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.11.1+wasi-snapshot-preview1) | 0.11.1+wasi-snapshot-preview1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.14.3+wasi-0.2.4) | 0.14.3+wasi-0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasi`](https://github.com/rust-lang/crates.io-index#wasi@0.9.0+wasi-snapshot-preview1) | 0.9.0+wasi-snapshot-preview1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wit-bindgen`](https://github.com/rust-lang/crates.io-index#wit-bindgen@0.45.0) | 0.45.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-2-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`rc`](https://registry.npmjs.org/rc/-/rc-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/rc/-/rc-1.2.8.tgz |  |
+| [`zerocopy`](https://github.com/rust-lang/crates.io-index#zerocopy@0.8.26) | 0.8.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerocopy-derive`](https://github.com/rust-lang/crates.io-index#zerocopy-derive@0.8.26) | 0.8.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-3-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@bufbuild/protobuf`](https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz) | 2.7.0 | Indirect | npm: https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz |  |
+| [`moxcms`](https://github.com/rust-lang/crates.io-index#moxcms@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pxfm`](https://github.com/rust-lang/crates.io-index#pxfm@0.1.23) | 0.1.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSD-3-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`encoding_rs`](https://github.com/rust-lang/crates.io-index#encoding_rs@0.8.35) | 0.8.35 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num_enum`](https://github.com/rust-lang/crates.io-index#num_enum@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num_enum_derive`](https://github.com/rust-lang/crates.io-index#num_enum_derive@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSL-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`ryu`](https://github.com/rust-lang/crates.io-index#ryu@1.0.20) | 1.0.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR BSL-1.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`wasite`](https://github.com/rust-lang/crates.io-index#wasite@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`whoami`](https://github.com/rust-lang/crates.io-index#whoami@1.6.1) | 1.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR CC0-1.0 OR MIT-0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`dunce`](https://github.com/rust-lang/crates.io-index#dunce@1.0.5) | 1.0.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR LGPL-2.1-or-later OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`r-efi`](https://github.com/rust-lang/crates.io-index#r-efi@5.3.0) | 5.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@tauri-apps/api`](https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz) | 2.8.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz |  |
+| [`@tauri-apps/cli`](https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz) | 2.8.3 | Direct | npm: https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz |  |
+| [`@tauri-apps/cli-darwin-arm64`](https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz |  |
+| [`@tauri-apps/cli-darwin-x64`](https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm-gnueabihf`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-arm64-musl`](https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-riscv64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-x64-gnu`](https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz |  |
+| [`@tauri-apps/cli-linux-x64-musl`](https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-arm64-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-ia32-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/cli-win32-x64-msvc`](https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz) | 2.8.3 | Indirect | npm: https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz |  |
+| [`@tauri-apps/plugin-clipboard-manager`](https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz) | 2.3.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz |  |
+| [`@tauri-apps/plugin-dialog`](https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz) | 2.3.3 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz |  |
+| [`@tauri-apps/plugin-fs`](https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz) | 2.4.2 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz |  |
+| [`@tauri-apps/plugin-notification`](https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz) | 2.3.1 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz |  |
+| [`@tauri-apps/plugin-opener`](https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz) | 2.5.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz |  |
+| [`@tauri-apps/plugin-sql`](https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz) | 2.3.0 | Direct | npm: https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz |  |
+| [`addr2line`](https://github.com/rust-lang/crates.io-index#addr2line@0.24.2) | 0.24.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ahash`](https://github.com/rust-lang/crates.io-index#ahash@0.8.12) | 0.8.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`allocator-api2`](https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21) | 0.2.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`android_system_properties`](https://github.com/rust-lang/crates.io-index#android_system_properties@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`android-tzdata`](https://github.com/rust-lang/crates.io-index#android-tzdata@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstream`](https://github.com/rust-lang/crates.io-index#anstream@0.6.20) | 0.6.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle`](https://github.com/rust-lang/crates.io-index#anstyle@1.0.11) | 1.0.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-parse`](https://github.com/rust-lang/crates.io-index#anstyle-parse@0.2.7) | 0.2.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-query`](https://github.com/rust-lang/crates.io-index#anstyle-query@1.1.4) | 1.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anstyle-wincon`](https://github.com/rust-lang/crates.io-index#anstyle-wincon@3.0.10) | 3.0.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`anyhow`](https://github.com/rust-lang/crates.io-index#anyhow@1.0.99) | 1.0.99 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`arboard`](https://github.com/rust-lang/crates.io-index#arboard@3.6.1) | 3.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`assert_cmd`](https://github.com/rust-lang/crates.io-index#assert_cmd@2.0.17) | 2.0.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-broadcast`](https://github.com/rust-lang/crates.io-index#async-broadcast@0.7.2) | 0.7.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-channel`](https://github.com/rust-lang/crates.io-index#async-channel@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-executor`](https://github.com/rust-lang/crates.io-index#async-executor@1.13.3) | 1.13.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-io`](https://github.com/rust-lang/crates.io-index#async-io@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-lock`](https://github.com/rust-lang/crates.io-index#async-lock@3.4.1) | 3.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-process`](https://github.com/rust-lang/crates.io-index#async-process@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-recursion`](https://github.com/rust-lang/crates.io-index#async-recursion@1.1.1) | 1.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-signal`](https://github.com/rust-lang/crates.io-index#async-signal@0.2.12) | 0.2.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-task`](https://github.com/rust-lang/crates.io-index#async-task@4.7.1) | 4.7.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`async-trait`](https://github.com/rust-lang/crates.io-index#async-trait@0.1.89) | 0.1.89 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atomic-waker`](https://github.com/rust-lang/crates.io-index#atomic-waker@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`autocfg`](https://github.com/rust-lang/crates.io-index#autocfg@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`backtrace`](https://github.com/rust-lang/crates.io-index#backtrace@0.3.75) | 0.3.75 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64`](https://github.com/rust-lang/crates.io-index#base64@0.21.7) | 0.21.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64`](https://github.com/rust-lang/crates.io-index#base64@0.22.1) | 0.22.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`base64ct`](https://github.com/rust-lang/crates.io-index#base64ct@1.8.0) | 1.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bit-set`](https://github.com/rust-lang/crates.io-index#bit-set@0.5.3) | 0.5.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bit-vec`](https://github.com/rust-lang/crates.io-index#bit-vec@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bitflags`](https://github.com/rust-lang/crates.io-index#bitflags@1.3.2) | 1.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bitflags`](https://github.com/rust-lang/crates.io-index#bitflags@2.9.3) | 2.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`block-buffer`](https://github.com/rust-lang/crates.io-index#block-buffer@0.10.4) | 0.10.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`blocking`](https://github.com/rust-lang/crates.io-index#blocking@1.6.2) | 1.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bstr`](https://github.com/rust-lang/crates.io-index#bstr@1.12.0) | 1.12.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bumpalo`](https://github.com/rust-lang/crates.io-index#bumpalo@3.19.0) | 3.19.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`bytecount`](https://github.com/rust-lang/crates.io-index#bytecount@0.6.9) | 0.6.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`camino`](https://github.com/rust-lang/crates.io-index#camino@1.1.12) | 1.1.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cargo_toml`](https://github.com/rust-lang/crates.io-index#cargo_toml@0.22.3) | 0.22.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cargo-platform`](https://github.com/rust-lang/crates.io-index#cargo-platform@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cc`](https://github.com/rust-lang/crates.io-index#cc@1.2.34) | 1.2.34 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cesu8`](https://github.com/rust-lang/crates.io-index#cesu8@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg-expr`](https://github.com/rust-lang/crates.io-index#cfg-expr@0.15.8) | 0.15.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg-if`](https://github.com/rust-lang/crates.io-index#cfg-if@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chrono`](https://github.com/rust-lang/crates.io-index#chrono@0.4.41) | 0.4.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chrono-tz`](https://github.com/rust-lang/crates.io-index#chrono-tz@0.10.4) | 0.10.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap`](https://github.com/rust-lang/crates.io-index#clap@4.5.47) | 4.5.47 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_builder`](https://github.com/rust-lang/crates.io-index#clap_builder@4.5.47) | 4.5.47 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_derive`](https://github.com/rust-lang/crates.io-index#clap_derive@4.5.47) | 4.5.47 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`clap_lex`](https://github.com/rust-lang/crates.io-index#clap_lex@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`colorchoice`](https://github.com/rust-lang/crates.io-index#colorchoice@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`concurrent-queue`](https://github.com/rust-lang/crates.io-index#concurrent-queue@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`const-oid`](https://github.com/rust-lang/crates.io-index#const-oid@0.9.6) | 0.9.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cookie`](https://github.com/rust-lang/crates.io-index#cookie@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation`](https://github.com/rust-lang/crates.io-index#core-foundation@0.10.1) | 0.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation`](https://github.com/rust-lang/crates.io-index#core-foundation@0.9.4) | 0.9.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-foundation-sys`](https://github.com/rust-lang/crates.io-index#core-foundation-sys@0.8.7) | 0.8.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-graphics`](https://github.com/rust-lang/crates.io-index#core-graphics@0.24.0) | 0.24.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`core-graphics-types`](https://github.com/rust-lang/crates.io-index#core-graphics-types@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cpufeatures`](https://github.com/rust-lang/crates.io-index#cpufeatures@0.2.17) | 0.2.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc`](https://github.com/rust-lang/crates.io-index#crc@3.3.0) | 3.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc-catalog`](https://github.com/rust-lang/crates.io-index#crc-catalog@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crc32fast`](https://github.com/rust-lang/crates.io-index#crc32fast@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-channel`](https://github.com/rust-lang/crates.io-index#crossbeam-channel@0.5.15) | 0.5.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-queue`](https://github.com/rust-lang/crates.io-index#crossbeam-queue@0.3.12) | 0.3.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crossbeam-utils`](https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21) | 0.8.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`crypto-common`](https://github.com/rust-lang/crates.io-index#crypto-common@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ctor`](https://github.com/rust-lang/crates.io-index#ctor@0.2.9) | 0.2.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`der`](https://github.com/rust-lang/crates.io-index#der@0.7.10) | 0.7.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`deranged`](https://github.com/rust-lang/crates.io-index#deranged@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`digest`](https://github.com/rust-lang/crates.io-index#digest@0.10.7) | 0.10.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs`](https://github.com/rust-lang/crates.io-index#dirs@5.0.1) | 5.0.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs`](https://github.com/rust-lang/crates.io-index#dirs@6.0.0) | 6.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs-sys`](https://github.com/rust-lang/crates.io-index#dirs-sys@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dirs-sys`](https://github.com/rust-lang/crates.io-index#dirs-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`displaydoc`](https://github.com/rust-lang/crates.io-index#displaydoc@0.2.5) | 0.2.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`downcast-rs`](https://github.com/rust-lang/crates.io-index#downcast-rs@1.2.1) | 1.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dpi`](https://github.com/rust-lang/crates.io-index#dpi@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dtoa`](https://github.com/rust-lang/crates.io-index#dtoa@1.0.10) | 1.0.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dyn-clone`](https://github.com/rust-lang/crates.io-index#dyn-clone@1.0.20) | 1.0.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`either`](https://github.com/rust-lang/crates.io-index#either@1.15.0) | 1.15.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`embed_plist`](https://github.com/rust-lang/crates.io-index#embed_plist@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`enumflags2`](https://github.com/rust-lang/crates.io-index#enumflags2@0.7.12) | 0.7.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`enumflags2_derive`](https://github.com/rust-lang/crates.io-index#enumflags2_derive@0.7.12) | 0.7.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`equivalent`](https://github.com/rust-lang/crates.io-index#equivalent@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`erased-serde`](https://github.com/rust-lang/crates.io-index#erased-serde@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`errno`](https://github.com/rust-lang/crates.io-index#errno@0.3.13) | 0.3.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`etcetera`](https://github.com/rust-lang/crates.io-index#etcetera@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`event-listener`](https://github.com/rust-lang/crates.io-index#event-listener@5.4.1) | 5.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`event-listener-strategy`](https://github.com/rust-lang/crates.io-index#event-listener-strategy@0.5.4) | 0.5.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fallible-iterator`](https://github.com/rust-lang/crates.io-index#fallible-iterator@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fallible-streaming-iterator`](https://github.com/rust-lang/crates.io-index#fallible-streaming-iterator@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fastrand`](https://github.com/rust-lang/crates.io-index#fastrand@2.3.0) | 2.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fdeflate`](https://github.com/rust-lang/crates.io-index#fdeflate@0.3.7) | 0.3.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`field-offset`](https://github.com/rust-lang/crates.io-index#field-offset@0.3.6) | 0.3.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fixedbitset`](https://github.com/rust-lang/crates.io-index#fixedbitset@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`flate2`](https://github.com/rust-lang/crates.io-index#flate2@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`flume`](https://github.com/rust-lang/crates.io-index#flume@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fnv`](https://github.com/rust-lang/crates.io-index#fnv@1.0.7) | 1.0.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types`](https://github.com/rust-lang/crates.io-index#foreign-types@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types-macros`](https://github.com/rust-lang/crates.io-index#foreign-types-macros@0.2.3) | 0.2.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`foreign-types-shared`](https://github.com/rust-lang/crates.io-index#foreign-types-shared@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`form_urlencoded`](https://github.com/rust-lang/crates.io-index#form_urlencoded@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fraction`](https://github.com/rust-lang/crates.io-index#fraction@0.13.1) | 0.13.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fs2`](https://github.com/rust-lang/crates.io-index#fs2@0.4.3) | 0.4.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futf`](https://github.com/rust-lang/crates.io-index#futf@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures`](https://github.com/rust-lang/crates.io-index#futures@0.3.31) | 0.3.31 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-channel`](https://github.com/rust-lang/crates.io-index#futures-channel@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-core`](https://github.com/rust-lang/crates.io-index#futures-core@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-executor`](https://github.com/rust-lang/crates.io-index#futures-executor@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-intrusive`](https://github.com/rust-lang/crates.io-index#futures-intrusive@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-io`](https://github.com/rust-lang/crates.io-index#futures-io@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-lite`](https://github.com/rust-lang/crates.io-index#futures-lite@2.6.1) | 2.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-macro`](https://github.com/rust-lang/crates.io-index#futures-macro@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-sink`](https://github.com/rust-lang/crates.io-index#futures-sink@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-task`](https://github.com/rust-lang/crates.io-index#futures-task@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`futures-util`](https://github.com/rust-lang/crates.io-index#futures-util@0.3.31) | 0.3.31 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fxhash`](https://github.com/rust-lang/crates.io-index#fxhash@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.1.16) | 0.1.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.2.16) | 0.2.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`getrandom`](https://github.com/rust-lang/crates.io-index#getrandom@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gimli`](https://github.com/rust-lang/crates.io-index#gimli@0.31.1) | 0.31.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glob`](https://github.com/rust-lang/crates.io-index#glob@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`half`](https://github.com/rust-lang/crates.io-index#half@2.6.0) | 2.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.12.3) | 0.12.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.14.5) | 0.14.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashbrown`](https://github.com/rust-lang/crates.io-index#hashbrown@0.15.5) | 0.15.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashlink`](https://github.com/rust-lang/crates.io-index#hashlink@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hashlink`](https://github.com/rust-lang/crates.io-index#hashlink@0.9.1) | 0.9.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`heck`](https://github.com/rust-lang/crates.io-index#heck@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`heck`](https://github.com/rust-lang/crates.io-index#heck@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hermit-abi`](https://github.com/rust-lang/crates.io-index#hermit-abi@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hex`](https://github.com/rust-lang/crates.io-index#hex@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hkdf`](https://github.com/rust-lang/crates.io-index#hkdf@0.12.4) | 0.12.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hmac`](https://github.com/rust-lang/crates.io-index#hmac@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`home`](https://github.com/rust-lang/crates.io-index#home@0.5.11) | 0.5.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`html5ever`](https://github.com/rust-lang/crates.io-index#html5ever@0.29.1) | 0.29.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http`](https://github.com/rust-lang/crates.io-index#http@0.2.12) | 0.2.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http`](https://github.com/rust-lang/crates.io-index#http@1.3.1) | 1.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`httparse`](https://github.com/rust-lang/crates.io-index#httparse@1.10.1) | 1.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`httpdate`](https://github.com/rust-lang/crates.io-index#httpdate@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iana-time-zone`](https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.63) | 0.1.63 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iana-time-zone-haiku`](https://github.com/rust-lang/crates.io-index#iana-time-zone-haiku@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ident_case`](https://github.com/rust-lang/crates.io-index#ident_case@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`idna`](https://github.com/rust-lang/crates.io-index#idna@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`idna_adapter`](https://github.com/rust-lang/crates.io-index#idna_adapter@1.2.1) | 1.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`image`](https://github.com/rust-lang/crates.io-index#image@0.25.8) | 0.25.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`indexmap`](https://github.com/rust-lang/crates.io-index#indexmap@1.9.3) | 1.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`indexmap`](https://github.com/rust-lang/crates.io-index#indexmap@2.11.0) | 2.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`io-uring`](https://github.com/rust-lang/crates.io-index#io-uring@0.7.10) | 0.7.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ipnet`](https://github.com/rust-lang/crates.io-index#ipnet@2.11.0) | 2.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iri-string`](https://github.com/rust-lang/crates.io-index#iri-string@0.7.8) | 0.7.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`is_terminal_polyfill`](https://github.com/rust-lang/crates.io-index#is_terminal_polyfill@1.70.1) | 1.70.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`itoa`](https://github.com/rust-lang/crates.io-index#itoa@1.0.15) | 1.0.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jni`](https://github.com/rust-lang/crates.io-index#jni@0.21.1) | 0.21.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jni-sys`](https://github.com/rust-lang/crates.io-index#jni-sys@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`js-sys`](https://github.com/rust-lang/crates.io-index#js-sys@0.3.77) | 0.3.77 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`json-patch`](https://github.com/rust-lang/crates.io-index#json-patch@3.0.1) | 3.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jsonptr`](https://github.com/rust-lang/crates.io-index#jsonptr@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`keyboard-types`](https://github.com/rust-lang/crates.io-index#keyboard-types@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lazy_static`](https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libappindicator`](https://github.com/rust-lang/crates.io-index#libappindicator@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libappindicator-sys`](https://github.com/rust-lang/crates.io-index#libappindicator-sys@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libc`](https://github.com/rust-lang/crates.io-index#libc@0.2.175) | 0.2.175 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lock_api`](https://github.com/rust-lang/crates.io-index#lock_api@0.4.13) | 0.4.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`log`](https://github.com/rust-lang/crates.io-index#log@0.4.27) | 0.4.27 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mac`](https://github.com/rust-lang/crates.io-index#mac@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`markup5ever`](https://github.com/rust-lang/crates.io-index#markup5ever@0.14.1) | 0.14.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`match_token`](https://github.com/rust-lang/crates.io-index#match_token@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`md-5`](https://github.com/rust-lang/crates.io-index#md-5@0.10.6) | 0.10.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mime`](https://github.com/rust-lang/crates.io-index#mime@0.3.17) | 0.3.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`minimal-lexical`](https://github.com/rust-lang/crates.io-index#minimal-lexical@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`muda`](https://github.com/rust-lang/crates.io-index#muda@0.17.1) | 0.17.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk`](https://github.com/rust-lang/crates.io-index#ndk@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk-context`](https://github.com/rust-lang/crates.io-index#ndk-context@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ndk-sys`](https://github.com/rust-lang/crates.io-index#ndk-sys@0.6.0+11769913) | 0.6.0+11769913 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nodrop`](https://github.com/rust-lang/crates.io-index#nodrop@0.1.14) | 0.1.14 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`notify-rust`](https://github.com/rust-lang/crates.io-index#notify-rust@4.11.7) | 4.11.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num`](https://github.com/rust-lang/crates.io-index#num@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-bigint`](https://github.com/rust-lang/crates.io-index#num-bigint@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-bigint-dig`](https://github.com/rust-lang/crates.io-index#num-bigint-dig@0.8.4) | 0.8.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-cmp`](https://github.com/rust-lang/crates.io-index#num-cmp@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-complex`](https://github.com/rust-lang/crates.io-index#num-complex@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-conv`](https://github.com/rust-lang/crates.io-index#num-conv@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-integer`](https://github.com/rust-lang/crates.io-index#num-integer@0.1.46) | 0.1.46 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-iter`](https://github.com/rust-lang/crates.io-index#num-iter@0.1.45) | 0.1.45 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-rational`](https://github.com/rust-lang/crates.io-index#num-rational@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`num-traits`](https://github.com/rust-lang/crates.io-index#num-traits@0.2.19) | 0.2.19 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`object`](https://github.com/rust-lang/crates.io-index#object@0.36.7) | 0.36.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`once_cell`](https://github.com/rust-lang/crates.io-index#once_cell@1.21.3) | 1.21.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`once_cell_polyfill`](https://github.com/rust-lang/crates.io-index#once_cell_polyfill@1.70.1) | 1.70.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ordered-stream`](https://github.com/rust-lang/crates.io-index#ordered-stream@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking`](https://github.com/rust-lang/crates.io-index#parking@2.2.1) | 2.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking_lot`](https://github.com/rust-lang/crates.io-index#parking_lot@0.12.4) | 0.12.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parking_lot_core`](https://github.com/rust-lang/crates.io-index#parking_lot_core@0.9.11) | 0.9.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`paste`](https://github.com/rust-lang/crates.io-index#paste@1.0.15) | 1.0.15 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pathdiff`](https://github.com/rust-lang/crates.io-index#pathdiff@0.2.3) | 0.2.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pem-rfc7468`](https://github.com/rust-lang/crates.io-index#pem-rfc7468@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`percent-encoding`](https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2) | 2.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest`](https://github.com/rust-lang/crates.io-index#pest@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_derive`](https://github.com/rust-lang/crates.io-index#pest_derive@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_generator`](https://github.com/rust-lang/crates.io-index#pest_generator@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pest_meta`](https://github.com/rust-lang/crates.io-index#pest_meta@2.8.2) | 2.8.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`petgraph`](https://github.com/rust-lang/crates.io-index#petgraph@0.6.5) | 0.6.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pin-project-lite`](https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.16) | 0.2.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pin-utils`](https://github.com/rust-lang/crates.io-index#pin-utils@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`piper`](https://github.com/rust-lang/crates.io-index#piper@0.2.4) | 0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkcs1`](https://github.com/rust-lang/crates.io-index#pkcs1@0.7.5) | 0.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkcs8`](https://github.com/rust-lang/crates.io-index#pkcs8@0.10.2) | 0.10.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pkg-config`](https://github.com/rust-lang/crates.io-index#pkg-config@0.3.32) | 0.3.32 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`png`](https://github.com/rust-lang/crates.io-index#png@0.17.16) | 0.17.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`png`](https://github.com/rust-lang/crates.io-index#png@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`polling`](https://github.com/rust-lang/crates.io-index#polling@3.10.0) | 3.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`powerfmt`](https://github.com/rust-lang/crates.io-index#powerfmt@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ppv-lite86`](https://github.com/rust-lang/crates.io-index#ppv-lite86@0.2.21) | 0.2.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates`](https://github.com/rust-lang/crates.io-index#predicates@3.1.3) | 3.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates-core`](https://github.com/rust-lang/crates.io-index#predicates-core@1.0.9) | 1.0.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`predicates-tree`](https://github.com/rust-lang/crates.io-index#predicates-tree@1.0.12) | 1.0.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@1.3.1) | 1.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-crate`](https://github.com/rust-lang/crates.io-index#proc-macro-crate@3.3.0) | 3.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-error`](https://github.com/rust-lang/crates.io-index#proc-macro-error@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-error-attr`](https://github.com/rust-lang/crates.io-index#proc-macro-error-attr@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro-hack`](https://github.com/rust-lang/crates.io-index#proc-macro-hack@0.5.20+deprecated) | 0.5.20+deprecated | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`proc-macro2`](https://github.com/rust-lang/crates.io-index#proc-macro2@1.0.101) | 1.0.101 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quick-error`](https://github.com/rust-lang/crates.io-index#quick-error@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quote`](https://github.com/rust-lang/crates.io-index#quote@1.0.40) | 1.0.40 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.8.5) | 0.8.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand`](https://github.com/rust-lang/crates.io-index#rand@0.9.2) | 0.9.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_chacha`](https://github.com/rust-lang/crates.io-index#rand_chacha@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.6.4) | 0.6.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_core`](https://github.com/rust-lang/crates.io-index#rand_core@0.9.3) | 0.9.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_hc`](https://github.com/rust-lang/crates.io-index#rand_hc@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rand_pcg`](https://github.com/rust-lang/crates.io-index#rand_pcg@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ref-cast`](https://github.com/rust-lang/crates.io-index#ref-cast@1.0.24) | 1.0.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ref-cast-impl`](https://github.com/rust-lang/crates.io-index#ref-cast-impl@1.0.24) | 1.0.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex`](https://github.com/rust-lang/crates.io-index#regex@1.11.2) | 1.11.2 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex-automata`](https://github.com/rust-lang/crates.io-index#regex-automata@0.4.10) | 0.4.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`regex-syntax`](https://github.com/rust-lang/crates.io-index#regex-syntax@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reqwest`](https://github.com/rust-lang/crates.io-index#reqwest@0.11.27) | 0.11.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reqwest`](https://github.com/rust-lang/crates.io-index#reqwest@0.12.23) | 0.12.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rrule`](https://github.com/rust-lang/crates.io-index#rrule@0.14.0) | 0.14.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rsa`](https://github.com/rust-lang/crates.io-index#rsa@0.9.8) | 0.9.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustc_version`](https://github.com/rust-lang/crates.io-index#rustc_version@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustc-demangle`](https://github.com/rust-lang/crates.io-index#rustc-demangle@0.1.26) | 0.1.26 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rustversion`](https://github.com/rust-lang/crates.io-index#rustversion@1.0.22) | 1.0.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`scoped-tls`](https://github.com/rust-lang/crates.io-index#scoped-tls@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`scopeguard`](https://github.com/rust-lang/crates.io-index#scopeguard@1.2.0) | 1.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`semver`](https://github.com/rust-lang/crates.io-index#semver@1.0.26) | 1.0.26 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde`](https://github.com/rust-lang/crates.io-index#serde@1.0.219) | 1.0.219 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_derive`](https://github.com/rust-lang/crates.io-index#serde_derive@1.0.219) | 1.0.219 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_derive_internals`](https://github.com/rust-lang/crates.io-index#serde_derive_internals@0.29.1) | 0.29.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_json`](https://github.com/rust-lang/crates.io-index#serde_json@1.0.143) | 1.0.143 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_repr`](https://github.com/rust-lang/crates.io-index#serde_repr@0.1.20) | 0.1.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_spanned`](https://github.com/rust-lang/crates.io-index#serde_spanned@0.6.9) | 0.6.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_spanned`](https://github.com/rust-lang/crates.io-index#serde_spanned@1.0.0) | 1.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_urlencoded`](https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1) | 0.7.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_with`](https://github.com/rust-lang/crates.io-index#serde_with@3.14.0) | 3.14.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde_with_macros`](https://github.com/rust-lang/crates.io-index#serde_with_macros@3.14.0) | 3.14.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serde-untagged`](https://github.com/rust-lang/crates.io-index#serde-untagged@0.1.8) | 0.1.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serialize-to-javascript`](https://github.com/rust-lang/crates.io-index#serialize-to-javascript@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`serialize-to-javascript-impl`](https://github.com/rust-lang/crates.io-index#serialize-to-javascript-impl@0.1.2) | 0.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`servo_arc`](https://github.com/rust-lang/crates.io-index#servo_arc@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sha1`](https://github.com/rust-lang/crates.io-index#sha1@0.10.6) | 0.10.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sha2`](https://github.com/rust-lang/crates.io-index#sha2@0.10.9) | 0.10.9 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`shlex`](https://github.com/rust-lang/crates.io-index#shlex@1.3.0) | 1.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`signal-hook-registry`](https://github.com/rust-lang/crates.io-index#signal-hook-registry@1.4.6) | 1.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`signature`](https://github.com/rust-lang/crates.io-index#signature@2.2.0) | 2.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`siphasher`](https://github.com/rust-lang/crates.io-index#siphasher@0.3.11) | 0.3.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`siphasher`](https://github.com/rust-lang/crates.io-index#siphasher@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`smallvec`](https://github.com/rust-lang/crates.io-index#smallvec@1.15.1) | 1.15.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`socket2`](https://github.com/rust-lang/crates.io-index#socket2@0.5.10) | 0.5.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`socket2`](https://github.com/rust-lang/crates.io-index#socket2@0.6.0) | 0.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`softbuffer`](https://github.com/rust-lang/crates.io-index#softbuffer@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`spki`](https://github.com/rust-lang/crates.io-index#spki@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx`](https://github.com/rust-lang/crates.io-index#sqlx@0.8.6) | 0.8.6 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-core`](https://github.com/rust-lang/crates.io-index#sqlx-core@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-macros`](https://github.com/rust-lang/crates.io-index#sqlx-macros@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-macros-core`](https://github.com/rust-lang/crates.io-index#sqlx-macros-core@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-mysql`](https://github.com/rust-lang/crates.io-index#sqlx-mysql@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-postgres`](https://github.com/rust-lang/crates.io-index#sqlx-postgres@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`sqlx-sqlite`](https://github.com/rust-lang/crates.io-index#sqlx-sqlite@0.8.6) | 0.8.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stable_deref_trait`](https://github.com/rust-lang/crates.io-index#stable_deref_trait@1.2.0) | 1.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`static_assertions`](https://github.com/rust-lang/crates.io-index#static_assertions@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`string_cache`](https://github.com/rust-lang/crates.io-index#string_cache@0.8.9) | 0.8.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`string_cache_codegen`](https://github.com/rust-lang/crates.io-index#string_cache_codegen@0.5.4) | 0.5.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stringprep`](https://github.com/rust-lang/crates.io-index#stringprep@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`swift-rs`](https://github.com/rust-lang/crates.io-index#swift-rs@1.0.7) | 1.0.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`syn`](https://github.com/rust-lang/crates.io-index#syn@1.0.109) | 1.0.109 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`syn`](https://github.com/rust-lang/crates.io-index#syn@2.0.106) | 2.0.106 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-configuration`](https://github.com/rust-lang/crates.io-index#system-configuration@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-configuration-sys`](https://github.com/rust-lang/crates.io-index#system-configuration-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`system-deps`](https://github.com/rust-lang/crates.io-index#system-deps@6.2.2) | 6.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tao-macros`](https://github.com/rust-lang/crates.io-index#tao-macros@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri`](https://github.com/rust-lang/crates.io-index#tauri@2.8.4) | 2.8.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-build`](https://github.com/rust-lang/crates.io-index#tauri-build@2.4.0) | 2.4.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-codegen`](https://github.com/rust-lang/crates.io-index#tauri-codegen@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-macros`](https://github.com/rust-lang/crates.io-index#tauri-macros@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin`](https://github.com/rust-lang/crates.io-index#tauri-plugin@2.4.0) | 2.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-clipboard-manager`](https://github.com/rust-lang/crates.io-index#tauri-plugin-clipboard-manager@2.3.0) | 2.3.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-dialog`](https://github.com/rust-lang/crates.io-index#tauri-plugin-dialog@2.3.3) | 2.3.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-fs`](https://github.com/rust-lang/crates.io-index#tauri-plugin-fs@2.4.2) | 2.4.2 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-notification`](https://github.com/rust-lang/crates.io-index#tauri-plugin-notification@2.3.1) | 2.3.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-opener`](https://github.com/rust-lang/crates.io-index#tauri-plugin-opener@2.5.0) | 2.5.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-plugin-sql`](https://github.com/rust-lang/crates.io-index#tauri-plugin-sql@2.3.0) | 2.3.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-runtime`](https://github.com/rust-lang/crates.io-index#tauri-runtime@2.8.0) | 2.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-runtime-wry`](https://github.com/rust-lang/crates.io-index#tauri-runtime-wry@2.8.1) | 2.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-utils`](https://github.com/rust-lang/crates.io-index#tauri-utils@2.7.0) | 2.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tauri-winrt-notification`](https://github.com/rust-lang/crates.io-index#tauri-winrt-notification@0.7.2) | 0.7.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tempfile`](https://github.com/rust-lang/crates.io-index#tempfile@3.21.0) | 3.21.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tendril`](https://github.com/rust-lang/crates.io-index#tendril@0.4.3) | 0.4.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror`](https://github.com/rust-lang/crates.io-index#thiserror@1.0.69) | 1.0.69 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror`](https://github.com/rust-lang/crates.io-index#thiserror@2.0.16) | 2.0.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror-impl`](https://github.com/rust-lang/crates.io-index#thiserror-impl@1.0.69) | 1.0.69 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thiserror-impl`](https://github.com/rust-lang/crates.io-index#thiserror-impl@2.0.16) | 2.0.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`thread_local`](https://github.com/rust-lang/crates.io-index#thread_local@1.1.9) | 1.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time`](https://github.com/rust-lang/crates.io-index#time@0.3.41) | 0.3.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time-core`](https://github.com/rust-lang/crates.io-index#time-core@0.1.4) | 0.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`time-macros`](https://github.com/rust-lang/crates.io-index#time-macros@0.2.22) | 0.2.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml`](https://github.com/rust-lang/crates.io-index#toml@0.8.23) | 0.8.23 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml`](https://github.com/rust-lang/crates.io-index#toml@0.9.5) | 0.9.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_datetime`](https://github.com/rust-lang/crates.io-index#toml_datetime@0.6.11) | 0.6.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_datetime`](https://github.com/rust-lang/crates.io-index#toml_datetime@0.7.0) | 0.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.19.15) | 0.19.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.20.7) | 0.20.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_edit`](https://github.com/rust-lang/crates.io-index#toml_edit@0.22.27) | 0.22.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_parser`](https://github.com/rust-lang/crates.io-index#toml_parser@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`toml_writer`](https://github.com/rust-lang/crates.io-index#toml_writer@1.0.2) | 1.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tray-icon`](https://github.com/rust-lang/crates.io-index#tray-icon@0.21.1) | 0.21.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`typeid`](https://github.com/rust-lang/crates.io-index#typeid@1.0.3) | 1.0.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`typenum`](https://github.com/rust-lang/crates.io-index#typenum@1.18.0) | 1.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ucd-trie`](https://github.com/rust-lang/crates.io-index#ucd-trie@0.1.7) | 0.1.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-char-property`](https://github.com/rust-lang/crates.io-index#unic-char-property@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-char-range`](https://github.com/rust-lang/crates.io-index#unic-char-range@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-common`](https://github.com/rust-lang/crates.io-index#unic-common@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-ucd-ident`](https://github.com/rust-lang/crates.io-index#unic-ucd-ident@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unic-ucd-version`](https://github.com/rust-lang/crates.io-index#unic-ucd-version@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-bidi`](https://github.com/rust-lang/crates.io-index#unicode-bidi@0.3.18) | 0.3.18 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-normalization`](https://github.com/rust-lang/crates.io-index#unicode-normalization@0.1.24) | 0.1.24 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-properties`](https://github.com/rust-lang/crates.io-index#unicode-properties@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`unicode-segmentation`](https://github.com/rust-lang/crates.io-index#unicode-segmentation@1.12.0) | 1.12.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`url`](https://github.com/rust-lang/crates.io-index#url@2.5.7) | 2.5.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf-8`](https://github.com/rust-lang/crates.io-index#utf-8@0.7.6) | 0.7.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf8_iter`](https://github.com/rust-lang/crates.io-index#utf8_iter@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`utf8parse`](https://github.com/rust-lang/crates.io-index#utf8parse@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`uuid`](https://github.com/rust-lang/crates.io-index#uuid@1.18.0) | 1.18.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vcpkg`](https://github.com/rust-lang/crates.io-index#vcpkg@0.2.15) | 0.2.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`version_check`](https://github.com/rust-lang/crates.io-index#version_check@0.9.5) | 0.9.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wait-timeout`](https://github.com/rust-lang/crates.io-index#wait-timeout@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen`](https://github.com/rust-lang/crates.io-index#wasm-bindgen@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-backend`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-backend@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-futures`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-futures@0.4.50) | 0.4.50 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-macro`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-macro-support`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-macro-support@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-bindgen-shared`](https://github.com/rust-lang/crates.io-index#wasm-bindgen-shared@0.2.100) | 0.2.100 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wasm-streams`](https://github.com/rust-lang/crates.io-index#wasm-streams@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`web-sys`](https://github.com/rust-lang/crates.io-index#web-sys@0.3.77) | 0.3.77 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`weezl`](https://github.com/rust-lang/crates.io-index#weezl@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi`](https://github.com/rust-lang/crates.io-index#winapi@0.3.9) | 0.3.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-i686-pc-windows-gnu`](https://github.com/rust-lang/crates.io-index#winapi-i686-pc-windows-gnu@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-x86_64-pc-windows-gnu`](https://github.com/rust-lang/crates.io-index#winapi-x86_64-pc-windows-gnu@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`window-vibrancy`](https://github.com/rust-lang/crates.io-index#window-vibrancy@0.6.0) | 0.6.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows`](https://github.com/rust-lang/crates.io-index#windows@0.61.3) | 0.61.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_aarch64_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_aarch64_msvc`](https://github.com/rust-lang/crates.io-index#windows_aarch64_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnu`](https://github.com/rust-lang/crates.io-index#windows_i686_gnu@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_i686_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_i686_msvc`](https://github.com/rust-lang/crates.io-index#windows_i686_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnu`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnu@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_gnullvm`](https://github.com/rust-lang/crates.io-index#windows_x86_64_gnullvm@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows_x86_64_msvc`](https://github.com/rust-lang/crates.io-index#windows_x86_64_msvc@0.53.0) | 0.53.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-collections`](https://github.com/rust-lang/crates.io-index#windows-collections@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-core`](https://github.com/rust-lang/crates.io-index#windows-core@0.61.2) | 0.61.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-future`](https://github.com/rust-lang/crates.io-index#windows-future@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-implement`](https://github.com/rust-lang/crates.io-index#windows-implement@0.60.0) | 0.60.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-interface`](https://github.com/rust-lang/crates.io-index#windows-interface@0.59.1) | 0.59.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-link`](https://github.com/rust-lang/crates.io-index#windows-link@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-numerics`](https://github.com/rust-lang/crates.io-index#windows-numerics@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-result`](https://github.com/rust-lang/crates.io-index#windows-result@0.3.4) | 0.3.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-strings`](https://github.com/rust-lang/crates.io-index#windows-strings@0.4.2) | 0.4.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.45.0) | 0.45.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.48.0) | 0.48.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.52.0) | 0.52.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.59.0) | 0.59.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-sys`](https://github.com/rust-lang/crates.io-index#windows-sys@0.60.2) | 0.60.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.42.2) | 0.42.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.48.5) | 0.48.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.52.6) | 0.52.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-targets`](https://github.com/rust-lang/crates.io-index#windows-targets@0.53.3) | 0.53.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-threading`](https://github.com/rust-lang/crates.io-index#windows-threading@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`windows-version`](https://github.com/rust-lang/crates.io-index#windows-version@0.1.4) | 0.1.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wl-clipboard-rs`](https://github.com/rust-lang/crates.io-index#wl-clipboard-rs@0.9.2) | 0.9.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wry`](https://github.com/rust-lang/crates.io-index#wry@0.53.3) | 0.53.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11rb`](https://github.com/rust-lang/crates.io-index#x11rb@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11rb-protocol`](https://github.com/rust-lang/crates.io-index#x11rb-protocol@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zeroize`](https://github.com/rust-lang/crates.io-index#zeroize@1.8.1) | 1.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT OR Unicode-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`unicode-ident`](https://github.com/rust-lang/crates.io-index#unicode-ident@1.0.18) | 1.0.18 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 OR MIT OR Zlib
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`bytemuck`](https://github.com/rust-lang/crates.io-index#bytemuck@1.23.2) | 1.23.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dispatch2`](https://github.com/rust-lang/crates.io-index#dispatch2@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`miniz_oxide`](https://github.com/rust-lang/crates.io-index#miniz_oxide@0.8.9) | 0.8.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-app-kit`](https://github.com/rust-lang/crates.io-index#objc2-app-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-cloud-kit`](https://github.com/rust-lang/crates.io-index#objc2-cloud-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-data`](https://github.com/rust-lang/crates.io-index#objc2-core-data@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-foundation`](https://github.com/rust-lang/crates.io-index#objc2-core-foundation@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-graphics`](https://github.com/rust-lang/crates.io-index#objc2-core-graphics@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-core-image`](https://github.com/rust-lang/crates.io-index#objc2-core-image@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-exception-helper`](https://github.com/rust-lang/crates.io-index#objc2-exception-helper@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-io-surface`](https://github.com/rust-lang/crates.io-index#objc2-io-surface@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-javascript-core`](https://github.com/rust-lang/crates.io-index#objc2-javascript-core@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-quartz-core`](https://github.com/rust-lang/crates.io-index#objc2-quartz-core@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-security`](https://github.com/rust-lang/crates.io-index#objc2-security@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-ui-kit`](https://github.com/rust-lang/crates.io-index#objc2-ui-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-web-kit`](https://github.com/rust-lang/crates.io-index#objc2-web-kit@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`raw-window-handle`](https://github.com/rust-lang/crates.io-index#raw-window-handle@0.6.2) | 0.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinyvec`](https://github.com/rust-lang/crates.io-index#tinyvec@1.10.0) | 1.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinyvec_macros`](https://github.com/rust-lang/crates.io-index#tinyvec_macros@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zune-core`](https://github.com/rust-lang/crates.io-index#zune-core@0.4.12) | 0.4.12 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zune-jpeg`](https://github.com/rust-lang/crates.io-index#zune-jpeg@0.4.21) | 0.4.21 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Apache-2.0 WITH LLVM-exception
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`target-lexicon`](https://github.com/rust-lang/crates.io-index#target-lexicon@0.12.16) | 0.12.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### BSD-2-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`damerau-levenshtein`](https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz |  |
+| [`entities`](https://registry.npmjs.org/entities/-/entities-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/entities/-/entities-6.0.1.tgz |  |
+| [`eslint-scope`](https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz) | 7.2.2 | Indirect | npm: https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz |  |
+| [`espree`](https://registry.npmjs.org/espree/-/espree-9.6.1.tgz) | 9.6.1 | Indirect | npm: https://registry.npmjs.org/espree/-/espree-9.6.1.tgz |  |
+| [`esrecurse`](https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz) | 4.3.0 | Indirect | npm: https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz |  |
+| [`estraverse`](https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz) | 5.3.0 | Indirect | npm: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz |  |
+| [`esutils`](https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz |  |
+| [`uri-js`](https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz) | 4.4.1 | Indirect | npm: https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz |  |
+| [`webidl-conversions`](https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz) | 7.0.0 | Indirect | npm: https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz |  |
+
+### BSD-3-Clause
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@humanwhocodes/object-schema`](https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz | Use @eslint/object-schema instead |
+| [`alloc-no-stdlib`](https://github.com/rust-lang/crates.io-index#alloc-no-stdlib@2.0.4) | 2.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`alloc-stdlib`](https://github.com/rust-lang/crates.io-index#alloc-stdlib@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`diff`](https://registry.npmjs.org/diff/-/diff-4.0.2.tgz) | 4.0.2 | Indirect | npm: https://registry.npmjs.org/diff/-/diff-4.0.2.tgz |  |
+| [`esquery`](https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz) | 1.6.0 | Indirect | npm: https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz |  |
+| [`fast-uri`](https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz |  |
+| [`ieee754`](https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz |  |
+| [`istanbul-lib-coverage`](https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz) | 3.2.2 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz |  |
+| [`istanbul-lib-report`](https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz |  |
+| [`istanbul-lib-source-maps`](https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz) | 5.0.6 | Indirect | npm: https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz |  |
+| [`istanbul-reports`](https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz |  |
+| [`source-map-js`](https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz |  |
+| [`subtle`](https://github.com/rust-lang/crates.io-index#subtle@2.6.1) | 2.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tough-cookie`](https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz) | 5.1.2 | Indirect | npm: https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz |  |
+
+### BSD-3-Clause OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`brotli`](https://github.com/rust-lang/crates.io-index#brotli@8.0.2) | 8.0.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`brotli-decompressor`](https://github.com/rust-lang/crates.io-index#brotli-decompressor@5.0.0) | 5.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### BSL-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`clipboard-win`](https://github.com/rust-lang/crates.io-index#clipboard-win@5.4.1) | 5.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`error-code`](https://github.com/rust-lang/crates.io-index#error-code@3.3.2) | 3.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### CC-BY-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`spdx-exceptions`](https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz) | 2.5.0 | Indirect | npm: https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz |  |
+
+### CC-BY-4.0 OR MIT OR OFL-1.1
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@fortawesome/fontawesome-free`](https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz) | 6.7.2 | Direct | npm: https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz |  |
+
+### CC0-1.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`language-subtag-registry`](https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz) | 0.3.23 | Indirect | npm: https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz |  |
+| [`spdx-license-ids`](https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz) | 3.0.22 | Indirect | npm: https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz |  |
+
+### CC0-1.0 OR MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`type-fest`](https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz) | 0.20.2 | Indirect | npm: https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz |  |
+
+### ISC
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@iarna/toml`](https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz) | 2.2.5 | Direct | npm: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz |  |
+| [`@ungap/structured-clone`](https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz |  |
+| [`chownr`](https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz |  |
+| [`fastq`](https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz) | 1.19.1 | Indirect | npm: https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz |  |
+| [`flatted`](https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz) | 3.3.3 | Indirect | npm: https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz |  |
+| [`fs.realpath`](https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz |  |
+| [`glob`](https://registry.npmjs.org/glob/-/glob-7.2.3.tgz) | 7.2.3 | Indirect | npm: https://registry.npmjs.org/glob/-/glob-7.2.3.tgz | Glob versions prior to v9 are no longer supported |
+| [`glob-parent`](https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz) | 5.1.2 | Indirect | npm: https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz |  |
+| [`glob-parent`](https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz) | 6.0.2 | Indirect | npm: https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz |  |
+| [`inflight`](https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz) | 1.0.6 | Indirect | npm: https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz | This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful. |
+| [`inherits`](https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz |  |
+| [`ini`](https://registry.npmjs.org/ini/-/ini-1.3.8.tgz) | 1.3.8 | Indirect | npm: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz |  |
+| [`isexe`](https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz |  |
+| [`json5`](https://github.com/rust-lang/crates.io-index#json5@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libloading`](https://github.com/rust-lang/crates.io-index#libloading@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`lru-cache`](https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz) | 10.4.3 | Indirect | npm: https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz |  |
+| [`make-error`](https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz) | 1.3.6 | Indirect | npm: https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz |  |
+| [`minimatch`](https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz) | 3.1.2 | Indirect | npm: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz |  |
+| [`minimatch`](https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz) | 9.0.5 | Indirect | npm: https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz |  |
+| [`once`](https://registry.npmjs.org/once/-/once-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/once/-/once-1.4.0.tgz |  |
+| [`picocolors`](https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz |  |
+| [`rimraf`](https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz) | 3.0.2 | Indirect | npm: https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz | Rimraf versions prior to v4 are no longer supported |
+| [`saxes`](https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz |  |
+| [`semver`](https://registry.npmjs.org/semver/-/semver-6.3.1.tgz) | 6.3.1 | Indirect | npm: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz |  |
+| [`semver`](https://registry.npmjs.org/semver/-/semver-7.7.2.tgz) | 7.7.2 | Indirect | npm: https://registry.npmjs.org/semver/-/semver-7.7.2.tgz |  |
+| [`siginfo`](https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz |  |
+| [`signal-exit`](https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz |  |
+| [`test-exclude`](https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz |  |
+| [`which`](https://registry.npmjs.org/which/-/which-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/which/-/which-2.0.2.tgz |  |
+| [`wrappy`](https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz |  |
+| [`yaml`](https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz) | 2.8.1 | Direct | npm: https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz |  |
+
+### MIT
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@asamuzakjp/css-color`](https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz |  |
+| [`@babel/helper-string-parser`](https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz) | 7.27.1 | Indirect | npm: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz |  |
+| [`@babel/helper-validator-identifier`](https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz) | 7.27.1 | Indirect | npm: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz |  |
+| [`@babel/parser`](https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz) | 7.28.4 | Indirect | npm: https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz |  |
+| [`@babel/types`](https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz) | 7.28.4 | Indirect | npm: https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz |  |
+| [`@bcoe/v8-coverage`](https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz) | 0.2.3 | Indirect | npm: https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz |  |
+| [`@cspotcode/source-map-support`](https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz) | 0.8.1 | Indirect | npm: https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz |  |
+| [`@csstools/css-calc`](https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz) | 2.1.4 | Indirect | npm: https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz |  |
+| [`@csstools/css-color-parser`](https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz |  |
+| [`@csstools/css-parser-algorithms`](https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz) | 3.0.5 | Indirect | npm: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz |  |
+| [`@csstools/css-tokenizer`](https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz) | 3.0.4 | Indirect | npm: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz |  |
+| [`@esbuild/aix-ppc64`](https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz |  |
+| [`@esbuild/aix-ppc64`](https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz |  |
+| [`@esbuild/android-arm`](https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz |  |
+| [`@esbuild/android-arm`](https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz |  |
+| [`@esbuild/android-arm64`](https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz |  |
+| [`@esbuild/android-arm64`](https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz |  |
+| [`@esbuild/android-x64`](https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz |  |
+| [`@esbuild/android-x64`](https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz |  |
+| [`@esbuild/darwin-arm64`](https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz |  |
+| [`@esbuild/darwin-arm64`](https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz |  |
+| [`@esbuild/darwin-x64`](https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz |  |
+| [`@esbuild/darwin-x64`](https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz |  |
+| [`@esbuild/freebsd-arm64`](https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz |  |
+| [`@esbuild/freebsd-arm64`](https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/freebsd-x64`](https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz |  |
+| [`@esbuild/freebsd-x64`](https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz |  |
+| [`@esbuild/linux-arm`](https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz |  |
+| [`@esbuild/linux-arm`](https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz |  |
+| [`@esbuild/linux-arm64`](https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz |  |
+| [`@esbuild/linux-arm64`](https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz |  |
+| [`@esbuild/linux-ia32`](https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz |  |
+| [`@esbuild/linux-ia32`](https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz |  |
+| [`@esbuild/linux-loong64`](https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz |  |
+| [`@esbuild/linux-loong64`](https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz |  |
+| [`@esbuild/linux-mips64el`](https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz |  |
+| [`@esbuild/linux-mips64el`](https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz |  |
+| [`@esbuild/linux-ppc64`](https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz |  |
+| [`@esbuild/linux-ppc64`](https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz |  |
+| [`@esbuild/linux-riscv64`](https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz |  |
+| [`@esbuild/linux-riscv64`](https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz |  |
+| [`@esbuild/linux-s390x`](https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz |  |
+| [`@esbuild/linux-s390x`](https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz |  |
+| [`@esbuild/linux-x64`](https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz |  |
+| [`@esbuild/linux-x64`](https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz |  |
+| [`@esbuild/netbsd-arm64`](https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/netbsd-x64`](https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz |  |
+| [`@esbuild/netbsd-x64`](https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz |  |
+| [`@esbuild/openbsd-arm64`](https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz |  |
+| [`@esbuild/openbsd-x64`](https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz |  |
+| [`@esbuild/openbsd-x64`](https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz |  |
+| [`@esbuild/openharmony-arm64`](https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz |  |
+| [`@esbuild/sunos-x64`](https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz |  |
+| [`@esbuild/sunos-x64`](https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz |  |
+| [`@esbuild/win32-arm64`](https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz |  |
+| [`@esbuild/win32-arm64`](https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz |  |
+| [`@esbuild/win32-ia32`](https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz |  |
+| [`@esbuild/win32-ia32`](https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz |  |
+| [`@esbuild/win32-x64`](https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz |  |
+| [`@esbuild/win32-x64`](https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz |  |
+| [`@eslint-community/eslint-utils`](https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz) | 4.9.0 | Indirect | npm: https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz |  |
+| [`@eslint-community/regexpp`](https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz) | 4.12.1 | Indirect | npm: https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz |  |
+| [`@eslint/eslintrc`](https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz) | 2.1.4 | Indirect | npm: https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz |  |
+| [`@eslint/js`](https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz) | 8.57.1 | Indirect | npm: https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz |  |
+| [`@istanbuljs/schema`](https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz) | 0.1.3 | Indirect | npm: https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz |  |
+| [`@jest/schemas`](https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz) | 29.6.3 | Indirect | npm: https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz |  |
+| [`@jridgewell/gen-mapping`](https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz) | 0.3.13 | Indirect | npm: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz |  |
+| [`@jridgewell/resolve-uri`](https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz) | 3.1.2 | Indirect | npm: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz |  |
+| [`@jridgewell/sourcemap-codec`](https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz) | 1.5.5 | Indirect | npm: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz |  |
+| [`@jridgewell/trace-mapping`](https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz) | 0.3.30 | Indirect | npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz |  |
+| [`@jridgewell/trace-mapping`](https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz) | 0.3.9 | Indirect | npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz |  |
+| [`@nodelib/fs.scandir`](https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz) | 2.1.5 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz |  |
+| [`@nodelib/fs.stat`](https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz) | 2.0.5 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz |  |
+| [`@nodelib/fs.walk`](https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz |  |
+| [`@parcel/watcher`](https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz |  |
+| [`@parcel/watcher-android-arm64`](https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-darwin-arm64`](https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-darwin-x64`](https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz |  |
+| [`@parcel/watcher-freebsd-x64`](https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm-musl`](https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm64-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-arm64-musl`](https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-x64-glibc`](https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz |  |
+| [`@parcel/watcher-linux-x64-musl`](https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-arm64`](https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-ia32`](https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz |  |
+| [`@parcel/watcher-win32-x64`](https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz) | 2.5.1 | Indirect | npm: https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz |  |
+| [`@rollup/rollup-android-arm-eabi`](https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz |  |
+| [`@rollup/rollup-android-arm64`](https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-darwin-arm64`](https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-darwin-x64`](https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz |  |
+| [`@rollup/rollup-freebsd-arm64`](https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-freebsd-x64`](https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm-gnueabihf`](https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm-musleabihf`](https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-arm64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-loongarch64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-ppc64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-riscv64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-riscv64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-s390x-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-x64-gnu`](https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz |  |
+| [`@rollup/rollup-linux-x64-musl`](https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz |  |
+| [`@rollup/rollup-openharmony-arm64`](https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-arm64-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-ia32-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz |  |
+| [`@rollup/rollup-win32-x64-msvc`](https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz |  |
+| [`@rtsao/scc`](https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz |  |
+| [`@sinclair/typebox`](https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz) | 0.27.8 | Indirect | npm: https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz |  |
+| [`@tsconfig/node10`](https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz) | 1.0.11 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz |  |
+| [`@tsconfig/node12`](https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz) | 1.0.11 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz |  |
+| [`@tsconfig/node14`](https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz |  |
+| [`@tsconfig/node16`](https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz |  |
+| [`@types/better-sqlite3`](https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz) | 7.6.13 | Direct | npm: https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz |  |
+| [`@types/estree`](https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz |  |
+| [`@types/jsdom`](https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz) | 21.1.7 | Direct | npm: https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz |  |
+| [`@types/json5`](https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz) | 0.0.29 | Indirect | npm: https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz |  |
+| [`@types/node`](https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz) | 24.3.0 | Indirect | npm: https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz |  |
+| [`@types/tough-cookie`](https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz) | 4.0.5 | Indirect | npm: https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz |  |
+| [`@typescript-eslint/eslint-plugin`](https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz) | 8.44.0 | Direct | npm: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz |  |
+| [`@typescript-eslint/parser`](https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz) | 8.44.0 | Direct | npm: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz |  |
+| [`@typescript-eslint/project-service`](https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz |  |
+| [`@typescript-eslint/scope-manager`](https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz |  |
+| [`@typescript-eslint/tsconfig-utils`](https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz |  |
+| [`@typescript-eslint/type-utils`](https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz |  |
+| [`@typescript-eslint/types`](https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz |  |
+| [`@typescript-eslint/typescript-estree`](https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz |  |
+| [`@typescript-eslint/utils`](https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz |  |
+| [`@typescript-eslint/visitor-keys`](https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz) | 8.44.0 | Indirect | npm: https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz |  |
+| [`@vitest/coverage-v8`](https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz) | 1.6.1 | Direct | npm: https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz |  |
+| [`@vitest/expect`](https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz |  |
+| [`@vitest/runner`](https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz |  |
+| [`@vitest/snapshot`](https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz |  |
+| [`@vitest/spy`](https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz |  |
+| [`@vitest/utils`](https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz |  |
+| [`acorn`](https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz) | 8.15.0 | Indirect | npm: https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz |  |
+| [`acorn-jsx`](https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz |  |
+| [`acorn-walk`](https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz) | 8.3.4 | Indirect | npm: https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz |  |
+| [`agent-base`](https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz) | 7.1.4 | Indirect | npm: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz |  |
+| [`ajv`](https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz) | 6.12.6 | Direct | npm: https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz |  |
+| [`ajv`](https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz) | 8.17.1 | Direct | npm: https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz |  |
+| [`ajv-formats`](https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz) | 3.0.1 | Direct | npm: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz |  |
+| [`ansi-regex`](https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz) | 5.0.1 | Indirect | npm: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz |  |
+| [`ansi-styles`](https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz) | 4.3.0 | Indirect | npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz |  |
+| [`ansi-styles`](https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz) | 5.2.0 | Indirect | npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz |  |
+| [`arg`](https://registry.npmjs.org/arg/-/arg-4.1.3.tgz) | 4.1.3 | Indirect | npm: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz |  |
+| [`array-buffer-byte-length`](https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz |  |
+| [`array-includes`](https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz) | 3.1.9 | Indirect | npm: https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz |  |
+| [`array.prototype.findlastindex`](https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz) | 1.2.6 | Indirect | npm: https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz |  |
+| [`array.prototype.flat`](https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz) | 1.3.3 | Indirect | npm: https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz |  |
+| [`array.prototype.flatmap`](https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz) | 1.3.3 | Indirect | npm: https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz |  |
+| [`arraybuffer.prototype.slice`](https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz |  |
+| [`ashpd`](https://github.com/rust-lang/crates.io-index#ashpd@0.11.0) | 0.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`assertion-error`](https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz |  |
+| [`ast-types-flow`](https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz) | 0.0.8 | Indirect | npm: https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz |  |
+| [`async-function`](https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz |  |
+| [`atk`](https://github.com/rust-lang/crates.io-index#atk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atk-sys`](https://github.com/rust-lang/crates.io-index#atk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`atoi`](https://github.com/rust-lang/crates.io-index#atoi@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`available-typed-arrays`](https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz |  |
+| [`balanced-match`](https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz |  |
+| [`base64-js`](https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz) | 1.5.1 | Indirect | npm: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz |  |
+| [`better-sqlite3`](https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz) | 12.2.0 | Direct | npm: https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz |  |
+| [`bindings`](https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz) | 1.5.0 | Indirect | npm: https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz |  |
+| [`bl`](https://registry.npmjs.org/bl/-/bl-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/bl/-/bl-4.1.0.tgz |  |
+| [`block2`](https://github.com/rust-lang/crates.io-index#block2@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`block2`](https://github.com/rust-lang/crates.io-index#block2@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`brace-expansion`](https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz) | 1.1.12 | Indirect | npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz |  |
+| [`brace-expansion`](https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz |  |
+| [`braces`](https://registry.npmjs.org/braces/-/braces-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz |  |
+| [`buffer`](https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz) | 5.7.1 | Indirect | npm: https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz |  |
+| [`buffer-builder`](https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz) | 0.2.0 | Indirect | npm: https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz | Upstream package declares "MIT/X11"; normalized to MIT for reporting. |
+| [`bytes`](https://github.com/rust-lang/crates.io-index#bytes@1.10.1) | 1.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cac`](https://registry.npmjs.org/cac/-/cac-6.7.14.tgz) | 6.7.14 | Indirect | npm: https://registry.npmjs.org/cac/-/cac-6.7.14.tgz |  |
+| [`cairo-rs`](https://github.com/rust-lang/crates.io-index#cairo-rs@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cairo-sys-rs`](https://github.com/rust-lang/crates.io-index#cairo-sys-rs@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`call-bind`](https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz |  |
+| [`call-bind-apply-helpers`](https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz |  |
+| [`call-bound`](https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz |  |
+| [`callsites`](https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz |  |
+| [`cargo_metadata`](https://github.com/rust-lang/crates.io-index#cargo_metadata@0.19.2) | 0.19.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfb`](https://github.com/rust-lang/crates.io-index#cfb@0.7.3) | 0.7.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cfg_aliases`](https://github.com/rust-lang/crates.io-index#cfg_aliases@0.2.1) | 0.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`chai`](https://registry.npmjs.org/chai/-/chai-4.5.0.tgz) | 4.5.0 | Indirect | npm: https://registry.npmjs.org/chai/-/chai-4.5.0.tgz |  |
+| [`chalk`](https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz) | 4.1.2 | Indirect | npm: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz |  |
+| [`check-error`](https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz |  |
+| [`chokidar`](https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz |  |
+| [`color-convert`](https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz |  |
+| [`color-name`](https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz |  |
+| [`colorjs.io`](https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz) | 0.5.2 | Indirect | npm: https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz |  |
+| [`combine`](https://github.com/rust-lang/crates.io-index#combine@4.6.7) | 4.6.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`concat-map`](https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz) | 0.0.1 | Indirect | npm: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz |  |
+| [`confbox`](https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz) | 0.1.8 | Indirect | npm: https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz |  |
+| [`convert_case`](https://github.com/rust-lang/crates.io-index#convert_case@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`create-require`](https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz |  |
+| [`cross-spawn`](https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz) | 7.0.6 | Indirect | npm: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz |  |
+| [`crunchy`](https://github.com/rust-lang/crates.io-index#crunchy@0.2.4) | 0.2.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cssstyle`](https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz) | 4.6.0 | Indirect | npm: https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz |  |
+| [`darling`](https://github.com/rust-lang/crates.io-index#darling@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`darling_core`](https://github.com/rust-lang/crates.io-index#darling_core@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`darling_macro`](https://github.com/rust-lang/crates.io-index#darling_macro@0.20.11) | 0.20.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`data-urls`](https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz |  |
+| [`data-view-buffer`](https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz |  |
+| [`data-view-byte-length`](https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz |  |
+| [`data-view-byte-offset`](https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz |  |
+| [`debug`](https://registry.npmjs.org/debug/-/debug-3.2.7.tgz) | 3.2.7 | Indirect | npm: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz |  |
+| [`debug`](https://registry.npmjs.org/debug/-/debug-4.4.1.tgz) | 4.4.1 | Indirect | npm: https://registry.npmjs.org/debug/-/debug-4.4.1.tgz |  |
+| [`decimal.js`](https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz) | 10.6.0 | Indirect | npm: https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz |  |
+| [`decompress-response`](https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz |  |
+| [`deep-eql`](https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz) | 4.1.4 | Indirect | npm: https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz |  |
+| [`deep-extend`](https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz) | 0.6.0 | Indirect | npm: https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz |  |
+| [`deep-is`](https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz) | 0.1.4 | Indirect | npm: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz |  |
+| [`define-data-property`](https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz) | 1.1.4 | Indirect | npm: https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz |  |
+| [`define-properties`](https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz |  |
+| [`derive_more`](https://github.com/rust-lang/crates.io-index#derive_more@0.99.20) | 0.99.20 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`diff-sequences`](https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz) | 29.6.3 | Indirect | npm: https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz |  |
+| [`difflib`](https://github.com/rust-lang/crates.io-index#difflib@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dispatch`](https://github.com/rust-lang/crates.io-index#dispatch@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dlib`](https://github.com/rust-lang/crates.io-index#dlib@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dlopen2`](https://github.com/rust-lang/crates.io-index#dlopen2@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index | License file bundled with crate (MIT License). |
+| [`dlopen2_derive`](https://github.com/rust-lang/crates.io-index#dlopen2_derive@0.4.1) | 0.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index | License file bundled with crate (MIT License). |
+| [`doc-comment`](https://github.com/rust-lang/crates.io-index#doc-comment@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dotenvy`](https://github.com/rust-lang/crates.io-index#dotenvy@0.15.7) | 0.15.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dunder-proto`](https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz |  |
+| [`embed-resource`](https://github.com/rust-lang/crates.io-index#embed-resource@3.0.5) | 3.0.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`emoji-regex`](https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz) | 9.2.2 | Indirect | npm: https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz |  |
+| [`end-of-stream`](https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz) | 1.4.5 | Indirect | npm: https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz |  |
+| [`endi`](https://github.com/rust-lang/crates.io-index#endi@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`es-abstract`](https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz) | 1.24.0 | Indirect | npm: https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz |  |
+| [`es-define-property`](https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz |  |
+| [`es-errors`](https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz |  |
+| [`es-object-atoms`](https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz |  |
+| [`es-set-tostringtag`](https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz |  |
+| [`es-shim-unscopables`](https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz |  |
+| [`es-to-primitive`](https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz |  |
+| [`esbuild`](https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz) | 0.21.5 | Indirect | npm: https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz |  |
+| [`esbuild`](https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz) | 0.25.9 | Indirect | npm: https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz |  |
+| [`escape-string-regexp`](https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz |  |
+| [`eslint`](https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz) | 8.57.1 | Direct | npm: https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz | This version is no longer supported. Please see https://eslint.org/version-support for other options. |
+| [`eslint-import-resolver-node`](https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz) | 0.3.9 | Indirect | npm: https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz |  |
+| [`eslint-module-utils`](https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz) | 2.12.1 | Indirect | npm: https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz |  |
+| [`eslint-plugin-import`](https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz) | 2.32.0 | Direct | npm: https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz |  |
+| [`eslint-plugin-jsx-a11y`](https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz) | 6.10.2 | Direct | npm: https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz |  |
+| [`eslint-plugin-unused-imports`](https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz) | 4.2.0 | Direct | npm: https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz |  |
+| [`estree-walker`](https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz |  |
+| [`execa`](https://registry.npmjs.org/execa/-/execa-8.0.1.tgz) | 8.0.1 | Indirect | npm: https://registry.npmjs.org/execa/-/execa-8.0.1.tgz |  |
+| [`fancy-regex`](https://github.com/rust-lang/crates.io-index#fancy-regex@0.11.0) | 0.11.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fast-deep-equal`](https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz) | 3.1.3 | Indirect | npm: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz |  |
+| [`fast-glob`](https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz) | 3.3.3 | Indirect | npm: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz |  |
+| [`fast-json-stable-stringify`](https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz |  |
+| [`fast-levenshtein`](https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz) | 2.0.6 | Indirect | npm: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz |  |
+| [`fax`](https://github.com/rust-lang/crates.io-index#fax@0.2.6) | 0.2.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fax_derive`](https://github.com/rust-lang/crates.io-index#fax_derive@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`fdir`](https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz) | 6.5.0 | Indirect | npm: https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz |  |
+| [`file-entry-cache`](https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz |  |
+| [`file-rotate`](https://github.com/rust-lang/crates.io-index#file-rotate@0.7.6) | 0.7.6 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`file-uri-to-path`](https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz |  |
+| [`fill-range`](https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz) | 7.1.1 | Indirect | npm: https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz |  |
+| [`find-up`](https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz |  |
+| [`flat-cache`](https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz) | 3.2.0 | Indirect | npm: https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz |  |
+| [`for-each`](https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz) | 0.3.5 | Indirect | npm: https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz |  |
+| [`fs-constants`](https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz |  |
+| [`fsevents`](https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz) | 2.3.2 | Indirect | npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz |  |
+| [`fsevents`](https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz) | 2.3.3 | Indirect | npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz |  |
+| [`function-bind`](https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz) | 1.1.2 | Indirect | npm: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz |  |
+| [`function.prototype.name`](https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz) | 1.1.8 | Indirect | npm: https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz |  |
+| [`functions-have-names`](https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz) | 1.2.3 | Indirect | npm: https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz |  |
+| [`gdk`](https://github.com/rust-lang/crates.io-index#gdk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-pixbuf`](https://github.com/rust-lang/crates.io-index#gdk-pixbuf@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-pixbuf-sys`](https://github.com/rust-lang/crates.io-index#gdk-pixbuf-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdk-sys`](https://github.com/rust-lang/crates.io-index#gdk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkwayland-sys`](https://github.com/rust-lang/crates.io-index#gdkwayland-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkx11`](https://github.com/rust-lang/crates.io-index#gdkx11@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gdkx11-sys`](https://github.com/rust-lang/crates.io-index#gdkx11-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`generic-array`](https://github.com/rust-lang/crates.io-index#generic-array@0.14.7) | 0.14.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`get-func-name`](https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz |  |
+| [`get-intrinsic`](https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz |  |
+| [`get-proto`](https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz |  |
+| [`get-stream`](https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz) | 8.0.1 | Indirect | npm: https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz |  |
+| [`get-symbol-description`](https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz |  |
+| [`get-tsconfig`](https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz) | 4.10.1 | Indirect | npm: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz |  |
+| [`gio`](https://github.com/rust-lang/crates.io-index#gio@0.18.4) | 0.18.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gio-sys`](https://github.com/rust-lang/crates.io-index#gio-sys@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`github-from-package`](https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz) | 0.0.0 | Indirect | npm: https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz |  |
+| [`glib`](https://github.com/rust-lang/crates.io-index#glib@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glib-macros`](https://github.com/rust-lang/crates.io-index#glib-macros@0.18.5) | 0.18.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`glib-sys`](https://github.com/rust-lang/crates.io-index#glib-sys@0.18.1) | 0.18.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`globals`](https://registry.npmjs.org/globals/-/globals-13.24.0.tgz) | 13.24.0 | Indirect | npm: https://registry.npmjs.org/globals/-/globals-13.24.0.tgz |  |
+| [`globalthis`](https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz |  |
+| [`gobject-sys`](https://github.com/rust-lang/crates.io-index#gobject-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gopd`](https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz |  |
+| [`graphemer`](https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz |  |
+| [`gtk`](https://github.com/rust-lang/crates.io-index#gtk@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gtk-sys`](https://github.com/rust-lang/crates.io-index#gtk-sys@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`gtk3-macros`](https://github.com/rust-lang/crates.io-index#gtk3-macros@0.18.2) | 0.18.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`h2`](https://github.com/rust-lang/crates.io-index#h2@0.3.27) | 0.3.27 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`has-bigints`](https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz |  |
+| [`has-flag`](https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz |  |
+| [`has-property-descriptors`](https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz |  |
+| [`has-proto`](https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz |  |
+| [`has-symbols`](https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz |  |
+| [`has-tostringtag`](https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz |  |
+| [`hasown`](https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz |  |
+| [`html-encoding-sniffer`](https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz |  |
+| [`html-escaper`](https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz |  |
+| [`http-body`](https://github.com/rust-lang/crates.io-index#http-body@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-body`](https://github.com/rust-lang/crates.io-index#http-body@1.0.1) | 1.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-body-util`](https://github.com/rust-lang/crates.io-index#http-body-util@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`http-proxy-agent`](https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz) | 7.0.2 | Indirect | npm: https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz |  |
+| [`https-proxy-agent`](https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz) | 7.0.6 | Indirect | npm: https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz |  |
+| [`hyper`](https://github.com/rust-lang/crates.io-index#hyper@0.14.32) | 0.14.32 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hyper`](https://github.com/rust-lang/crates.io-index#hyper@1.7.0) | 1.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`hyper-util`](https://github.com/rust-lang/crates.io-index#hyper-util@0.1.16) | 0.1.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ico`](https://github.com/rust-lang/crates.io-index#ico@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`iconv-lite`](https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz) | 0.6.3 | Indirect | npm: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz |  |
+| [`ignore`](https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz) | 5.3.2 | Indirect | npm: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz |  |
+| [`ignore`](https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz) | 7.0.5 | Indirect | npm: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz |  |
+| [`immutable`](https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz) | 5.1.3 | Indirect | npm: https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz |  |
+| [`import-fresh`](https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz) | 3.3.1 | Indirect | npm: https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz |  |
+| [`imurmurhash`](https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz) | 0.1.4 | Indirect | npm: https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz |  |
+| [`include_dir`](https://github.com/rust-lang/crates.io-index#include_dir@0.7.4) | 0.7.4 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`include_dir_macros`](https://github.com/rust-lang/crates.io-index#include_dir_macros@0.7.4) | 0.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`infer`](https://github.com/rust-lang/crates.io-index#infer@0.19.0) | 0.19.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`internal-slot`](https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz |  |
+| [`is-array-buffer`](https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz) | 3.0.5 | Indirect | npm: https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz |  |
+| [`is-async-function`](https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz |  |
+| [`is-bigint`](https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz |  |
+| [`is-boolean-object`](https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz) | 1.2.2 | Indirect | npm: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz |  |
+| [`is-callable`](https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz) | 1.2.7 | Indirect | npm: https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz |  |
+| [`is-core-module`](https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz) | 2.16.1 | Indirect | npm: https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz |  |
+| [`is-data-view`](https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz |  |
+| [`is-date-object`](https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz |  |
+| [`is-docker`](https://github.com/rust-lang/crates.io-index#is-docker@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`is-extglob`](https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz |  |
+| [`is-finalizationregistry`](https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz |  |
+| [`is-generator-function`](https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz |  |
+| [`is-glob`](https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz |  |
+| [`is-map`](https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz |  |
+| [`is-negative-zero`](https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz |  |
+| [`is-number`](https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz) | 7.0.0 | Indirect | npm: https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz |  |
+| [`is-number-object`](https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz |  |
+| [`is-path-inside`](https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz |  |
+| [`is-potential-custom-element-name`](https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz |  |
+| [`is-regex`](https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz |  |
+| [`is-set`](https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz |  |
+| [`is-shared-array-buffer`](https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz |  |
+| [`is-stream`](https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz |  |
+| [`is-string`](https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz |  |
+| [`is-symbol`](https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz |  |
+| [`is-typed-array`](https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz) | 1.1.15 | Indirect | npm: https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz |  |
+| [`is-weakmap`](https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz |  |
+| [`is-weakref`](https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz |  |
+| [`is-weakset`](https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz) | 2.0.4 | Indirect | npm: https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz |  |
+| [`is-wsl`](https://github.com/rust-lang/crates.io-index#is-wsl@0.4.0) | 0.4.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`isarray`](https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz) | 2.0.5 | Indirect | npm: https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz |  |
+| [`iso8601`](https://github.com/rust-lang/crates.io-index#iso8601@0.6.3) | 0.6.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`javascriptcore-rs`](https://github.com/rust-lang/crates.io-index#javascriptcore-rs@1.1.2) | 1.1.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`javascriptcore-rs-sys`](https://github.com/rust-lang/crates.io-index#javascriptcore-rs-sys@1.1.1) | 1.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`js-tokens`](https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz) | 9.0.1 | Indirect | npm: https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz |  |
+| [`js-yaml`](https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz |  |
+| [`jsdom`](https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz) | 26.1.0 | Direct | npm: https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz |  |
+| [`json-buffer`](https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz |  |
+| [`json-schema-traverse`](https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz) | 0.4.1 | Indirect | npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz |  |
+| [`json-schema-traverse`](https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz |  |
+| [`json-stable-stringify-without-jsonify`](https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz |  |
+| [`json5`](https://registry.npmjs.org/json5/-/json5-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/json5/-/json5-1.0.2.tgz |  |
+| [`json5`](https://registry.npmjs.org/json5/-/json5-2.2.3.tgz) | 2.2.3 | Indirect | npm: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz |  |
+| [`jsonschema`](https://github.com/rust-lang/crates.io-index#jsonschema@0.17.1) | 0.17.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`jsx-ast-utils`](https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz) | 3.3.5 | Indirect | npm: https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz |  |
+| [`keyv`](https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz) | 4.5.4 | Indirect | npm: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz |  |
+| [`kuchikiki`](https://github.com/rust-lang/crates.io-index#kuchikiki@0.8.8-speedreader) | 0.8.8-speedreader | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`language-tags`](https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz) | 1.0.9 | Indirect | npm: https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz |  |
+| [`levn`](https://registry.npmjs.org/levn/-/levn-0.4.1.tgz) | 0.4.1 | Indirect | npm: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz |  |
+| [`libm`](https://github.com/rust-lang/crates.io-index#libm@0.2.15) | 0.2.15 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libredox`](https://github.com/rust-lang/crates.io-index#libredox@0.1.9) | 0.1.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`libsqlite3-sys`](https://github.com/rust-lang/crates.io-index#libsqlite3-sys@0.30.1) | 0.30.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`local-pkg`](https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz) | 0.5.1 | Indirect | npm: https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz |  |
+| [`locate-path`](https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz |  |
+| [`lodash.merge`](https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz) | 4.6.2 | Indirect | npm: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz |  |
+| [`loupe`](https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz) | 2.3.7 | Indirect | npm: https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz |  |
+| [`mac-notification-sys`](https://github.com/rust-lang/crates.io-index#mac-notification-sys@0.6.6) | 0.6.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`magic-string`](https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz) | 0.30.19 | Indirect | npm: https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz |  |
+| [`magicast`](https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz) | 0.3.5 | Indirect | npm: https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz |  |
+| [`make-dir`](https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz |  |
+| [`matchers`](https://github.com/rust-lang/crates.io-index#matchers@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`matches`](https://github.com/rust-lang/crates.io-index#matches@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`math-intrinsics`](https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz |  |
+| [`memoffset`](https://github.com/rust-lang/crates.io-index#memoffset@0.9.1) | 0.9.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`merge-stream`](https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz |  |
+| [`merge2`](https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz) | 1.4.1 | Indirect | npm: https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz |  |
+| [`micromatch`](https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz) | 4.0.8 | Indirect | npm: https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz |  |
+| [`mimic-fn`](https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz |  |
+| [`mimic-response`](https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz |  |
+| [`minimist`](https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz) | 1.2.8 | Indirect | npm: https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz |  |
+| [`mio`](https://github.com/rust-lang/crates.io-index#mio@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`mkdirp-classic`](https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz) | 0.5.3 | Indirect | npm: https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz |  |
+| [`mlly`](https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz) | 1.8.0 | Indirect | npm: https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz |  |
+| [`ms`](https://registry.npmjs.org/ms/-/ms-2.1.3.tgz) | 2.1.3 | Indirect | npm: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz |  |
+| [`nanoid`](https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz) | 3.3.11 | Indirect | npm: https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz |  |
+| [`napi-build-utils`](https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz |  |
+| [`natural-compare`](https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz) | 1.4.0 | Indirect | npm: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz |  |
+| [`new_debug_unreachable`](https://github.com/rust-lang/crates.io-index#new_debug_unreachable@1.0.6) | 1.0.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nix`](https://github.com/rust-lang/crates.io-index#nix@0.30.1) | 0.30.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`node-abi`](https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz) | 3.75.0 | Indirect | npm: https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz |  |
+| [`node-addon-api`](https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz) | 7.1.1 | Indirect | npm: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz |  |
+| [`nom`](https://github.com/rust-lang/crates.io-index#nom@7.1.3) | 7.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nom`](https://github.com/rust-lang/crates.io-index#nom@8.0.0) | 8.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`npm-run-path`](https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz) | 5.3.0 | Indirect | npm: https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz |  |
+| [`nu-ansi-term`](https://github.com/rust-lang/crates.io-index#nu-ansi-term@0.50.1) | 0.50.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`nwsapi`](https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz) | 2.2.22 | Indirect | npm: https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz |  |
+| [`objc-sys`](https://github.com/rust-lang/crates.io-index#objc-sys@0.3.5) | 0.3.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2`](https://github.com/rust-lang/crates.io-index#objc2@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2`](https://github.com/rust-lang/crates.io-index#objc2@0.6.2) | 0.6.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-encode`](https://github.com/rust-lang/crates.io-index#objc2-encode@4.1.0) | 4.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-foundation`](https://github.com/rust-lang/crates.io-index#objc2-foundation@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-foundation`](https://github.com/rust-lang/crates.io-index#objc2-foundation@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-metal`](https://github.com/rust-lang/crates.io-index#objc2-metal@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`objc2-quartz-core`](https://github.com/rust-lang/crates.io-index#objc2-quartz-core@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`object-inspect`](https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz) | 1.13.4 | Indirect | npm: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz |  |
+| [`object-keys`](https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz |  |
+| [`object.assign`](https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz) | 4.1.7 | Indirect | npm: https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz |  |
+| [`object.fromentries`](https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz) | 2.0.8 | Indirect | npm: https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz |  |
+| [`object.groupby`](https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz |  |
+| [`object.values`](https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz |  |
+| [`onetime`](https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz |  |
+| [`open`](https://github.com/rust-lang/crates.io-index#open@5.3.2) | 5.3.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`optionator`](https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz) | 0.9.4 | Indirect | npm: https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz |  |
+| [`os_pipe`](https://github.com/rust-lang/crates.io-index#os_pipe@1.2.2) | 1.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`own-keys`](https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz |  |
+| [`p-limit`](https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz) | 3.1.0 | Indirect | npm: https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz |  |
+| [`p-limit`](https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz |  |
+| [`p-locate`](https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz |  |
+| [`pango`](https://github.com/rust-lang/crates.io-index#pango@0.18.3) | 0.18.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`pango-sys`](https://github.com/rust-lang/crates.io-index#pango-sys@0.18.0) | 0.18.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`parent-module`](https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz |  |
+| [`parse5`](https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz) | 7.3.0 | Indirect | npm: https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz |  |
+| [`path-exists`](https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz |  |
+| [`path-is-absolute`](https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz |  |
+| [`path-key`](https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz |  |
+| [`path-key`](https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz |  |
+| [`path-parse`](https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz |  |
+| [`pathe`](https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz) | 1.1.2 | Indirect | npm: https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz |  |
+| [`pathe`](https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz |  |
+| [`pathval`](https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.10.1) | 0.10.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf`](https://github.com/rust-lang/crates.io-index#phf@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_codegen`](https://github.com/rust-lang/crates.io-index#phf_codegen@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_codegen`](https://github.com/rust-lang/crates.io-index#phf_codegen@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_generator`](https://github.com/rust-lang/crates.io-index#phf_generator@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_macros`](https://github.com/rust-lang/crates.io-index#phf_macros@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_macros`](https://github.com/rust-lang/crates.io-index#phf_macros@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.10.0) | 0.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.11.3) | 0.11.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.12.1) | 0.12.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`phf_shared`](https://github.com/rust-lang/crates.io-index#phf_shared@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`picomatch`](https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz) | 2.3.1 | Indirect | npm: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz |  |
+| [`picomatch`](https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz) | 4.0.3 | Indirect | npm: https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz |  |
+| [`pkg-types`](https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz) | 1.3.1 | Indirect | npm: https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz |  |
+| [`plist`](https://github.com/rust-lang/crates.io-index#plist@1.7.4) | 1.7.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`possible-typed-array-names`](https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz |  |
+| [`postcss`](https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz) | 8.5.6 | Indirect | npm: https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz |  |
+| [`prebuild-install`](https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz) | 7.1.3 | Indirect | npm: https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz |  |
+| [`precomputed-hash`](https://github.com/rust-lang/crates.io-index#precomputed-hash@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`prelude-ls`](https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz |  |
+| [`pretty-format`](https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz) | 29.7.0 | Indirect | npm: https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz |  |
+| [`pump`](https://registry.npmjs.org/pump/-/pump-3.0.3.tgz) | 3.0.3 | Indirect | npm: https://registry.npmjs.org/pump/-/pump-3.0.3.tgz |  |
+| [`punycode`](https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz) | 2.3.1 | Indirect | npm: https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz |  |
+| [`queue-microtask`](https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz) | 1.2.3 | Indirect | npm: https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz |  |
+| [`quick-xml`](https://github.com/rust-lang/crates.io-index#quick-xml@0.37.5) | 0.37.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`quick-xml`](https://github.com/rust-lang/crates.io-index#quick-xml@0.38.3) | 0.38.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`react-is`](https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz) | 18.3.1 | Indirect | npm: https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz |  |
+| [`readable-stream`](https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz) | 3.6.2 | Indirect | npm: https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz |  |
+| [`readdirp`](https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz) | 4.1.2 | Indirect | npm: https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz |  |
+| [`redox_syscall`](https://github.com/rust-lang/crates.io-index#redox_syscall@0.5.17) | 0.5.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`redox_users`](https://github.com/rust-lang/crates.io-index#redox_users@0.4.6) | 0.4.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`redox_users`](https://github.com/rust-lang/crates.io-index#redox_users@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`reflect.getprototypeof`](https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz) | 1.0.10 | Indirect | npm: https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz |  |
+| [`regexp-tree`](https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz) | 0.1.27 | Indirect | npm: https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz |  |
+| [`regexp.prototype.flags`](https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz) | 1.5.4 | Indirect | npm: https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz |  |
+| [`require-from-string`](https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz |  |
+| [`resolve`](https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz) | 1.22.10 | Indirect | npm: https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz |  |
+| [`resolve-from`](https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz |  |
+| [`resolve-pkg-maps`](https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz |  |
+| [`reusify`](https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz |  |
+| [`rfd`](https://github.com/rust-lang/crates.io-index#rfd@0.15.4) | 0.15.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`rollup`](https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz) | 4.50.0 | Indirect | npm: https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz |  |
+| [`rrweb-cssom`](https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz) | 0.8.0 | Indirect | npm: https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz |  |
+| [`run-parallel`](https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz) | 1.2.0 | Indirect | npm: https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz |  |
+| [`rusqlite`](https://github.com/rust-lang/crates.io-index#rusqlite@0.32.1) | 0.32.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`safe-array-concat`](https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz) | 1.1.3 | Indirect | npm: https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz |  |
+| [`safe-buffer`](https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz) | 5.2.1 | Indirect | npm: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz |  |
+| [`safe-push-apply`](https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz |  |
+| [`safe-regex`](https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz |  |
+| [`safe-regex-test`](https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz |  |
+| [`safer-buffer`](https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz) | 2.1.2 | Indirect | npm: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz |  |
+| [`sass`](https://registry.npmjs.org/sass/-/sass-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass/-/sass-1.91.0.tgz |  |
+| [`sass-embedded`](https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz) | 1.91.0 | Direct | npm: https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz |  |
+| [`sass-embedded-all-unknown`](https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz |  |
+| [`sass-embedded-android-arm`](https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz |  |
+| [`sass-embedded-android-arm64`](https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz |  |
+| [`sass-embedded-android-riscv64`](https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-android-x64`](https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz |  |
+| [`sass-embedded-darwin-arm64`](https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz |  |
+| [`sass-embedded-darwin-x64`](https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz |  |
+| [`sass-embedded-linux-arm`](https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz |  |
+| [`sass-embedded-linux-arm64`](https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-arm`](https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-arm64`](https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-riscv64`](https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-linux-musl-x64`](https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz |  |
+| [`sass-embedded-linux-riscv64`](https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz |  |
+| [`sass-embedded-linux-x64`](https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz |  |
+| [`sass-embedded-unknown-all`](https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz |  |
+| [`sass-embedded-win32-arm64`](https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz |  |
+| [`sass-embedded-win32-x64`](https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz) | 1.91.0 | Indirect | npm: https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@0.8.22) | 0.8.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@0.9.0) | 0.9.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars`](https://github.com/rust-lang/crates.io-index#schemars@1.0.4) | 1.0.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`schemars_derive`](https://github.com/rust-lang/crates.io-index#schemars_derive@0.8.22) | 0.8.22 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`set-function-length`](https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz) | 1.2.2 | Indirect | npm: https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz |  |
+| [`set-function-name`](https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz) | 2.0.2 | Indirect | npm: https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz |  |
+| [`set-proto`](https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz |  |
+| [`sharded-slab`](https://github.com/rust-lang/crates.io-index#sharded-slab@0.1.7) | 0.1.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`shebang-command`](https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz) | 2.0.0 | Indirect | npm: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz |  |
+| [`shebang-regex`](https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz |  |
+| [`side-channel`](https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz |  |
+| [`side-channel-list`](https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz |  |
+| [`side-channel-map`](https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz |  |
+| [`side-channel-weakmap`](https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz |  |
+| [`simd-adler32`](https://github.com/rust-lang/crates.io-index#simd-adler32@0.3.7) | 0.3.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`simple-concat`](https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz) | 1.0.1 | Indirect | npm: https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz |  |
+| [`simple-get`](https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz) | 4.0.1 | Indirect | npm: https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz |  |
+| [`slab`](https://github.com/rust-lang/crates.io-index#slab@0.4.11) | 0.4.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`soup3`](https://github.com/rust-lang/crates.io-index#soup3@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`soup3-sys`](https://github.com/rust-lang/crates.io-index#soup3-sys@0.5.0) | 0.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`spdx-expression-parse`](https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz) | 4.0.0 | Direct | npm: https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz |  |
+| [`spin`](https://github.com/rust-lang/crates.io-index#spin@0.9.8) | 0.9.8 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`stackback`](https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz) | 0.0.2 | Indirect | npm: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz |  |
+| [`std-env`](https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz) | 3.9.0 | Indirect | npm: https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz |  |
+| [`stop-iteration-iterator`](https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz |  |
+| [`string_decoder`](https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz) | 1.3.0 | Indirect | npm: https://registry.npmjs.org/string\_decoder/-/string\_decoder-1.3.0.tgz |  |
+| [`string.prototype.includes`](https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz |  |
+| [`string.prototype.trim`](https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz) | 1.2.10 | Indirect | npm: https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz |  |
+| [`string.prototype.trimend`](https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz) | 1.0.9 | Indirect | npm: https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz |  |
+| [`string.prototype.trimstart`](https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz) | 1.0.8 | Indirect | npm: https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz |  |
+| [`strip-ansi`](https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz) | 6.0.1 | Indirect | npm: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz |  |
+| [`strip-bom`](https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz |  |
+| [`strip-final-newline`](https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz) | 3.0.0 | Indirect | npm: https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz |  |
+| [`strip-json-comments`](https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz |  |
+| [`strip-json-comments`](https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz |  |
+| [`strip-literal`](https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz) | 2.1.1 | Indirect | npm: https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz |  |
+| [`strsim`](https://github.com/rust-lang/crates.io-index#strsim@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`supports-color`](https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz) | 7.2.0 | Indirect | npm: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz |  |
+| [`supports-color`](https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz) | 8.1.1 | Indirect | npm: https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz |  |
+| [`supports-preserve-symlinks-flag`](https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz) | 1.0.0 | Indirect | npm: https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz |  |
+| [`symbol-tree`](https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz) | 3.2.4 | Indirect | npm: https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz |  |
+| [`sync-child-process`](https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz |  |
+| [`sync-message-port`](https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz) | 1.1.3 | Indirect | npm: https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz |  |
+| [`synstructure`](https://github.com/rust-lang/crates.io-index#synstructure@0.13.2) | 0.13.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tar-fs`](https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz) | 2.1.3 | Indirect | npm: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz |  |
+| [`tar-stream`](https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz) | 2.2.0 | Indirect | npm: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz |  |
+| [`tauri-winres`](https://github.com/rust-lang/crates.io-index#tauri-winres@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`termtree`](https://github.com/rust-lang/crates.io-index#termtree@0.5.1) | 0.5.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`text-table`](https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz) | 0.2.0 | Indirect | npm: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz |  |
+| [`tiff`](https://github.com/rust-lang/crates.io-index#tiff@0.10.3) | 0.10.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinybench`](https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz) | 2.9.0 | Indirect | npm: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz |  |
+| [`tinyglobby`](https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz) | 0.2.14 | Indirect | npm: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz |  |
+| [`tinypool`](https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz) | 0.8.4 | Indirect | npm: https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz |  |
+| [`tinyspy`](https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz) | 2.2.1 | Indirect | npm: https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz |  |
+| [`tldts`](https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz) | 6.1.86 | Indirect | npm: https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz |  |
+| [`tldts-core`](https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz) | 6.1.86 | Indirect | npm: https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz |  |
+| [`to-regex-range`](https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz) | 5.0.1 | Indirect | npm: https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz |  |
+| [`tokio`](https://github.com/rust-lang/crates.io-index#tokio@1.47.1) | 1.47.1 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-macros`](https://github.com/rust-lang/crates.io-index#tokio-macros@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-stream`](https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.17) | 0.1.17 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tokio-util`](https://github.com/rust-lang/crates.io-index#tokio-util@0.7.16) | 0.7.16 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower`](https://github.com/rust-lang/crates.io-index#tower@0.5.2) | 0.5.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-http`](https://github.com/rust-lang/crates.io-index#tower-http@0.6.6) | 0.6.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-layer`](https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tower-service`](https://github.com/rust-lang/crates.io-index#tower-service@0.3.3) | 0.3.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tr46`](https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz) | 5.1.1 | Indirect | npm: https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz |  |
+| [`tracing`](https://github.com/rust-lang/crates.io-index#tracing@0.1.41) | 0.1.41 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-appender`](https://github.com/rust-lang/crates.io-index#tracing-appender@0.2.3) | 0.2.3 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-attributes`](https://github.com/rust-lang/crates.io-index#tracing-attributes@0.1.30) | 0.1.30 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-core`](https://github.com/rust-lang/crates.io-index#tracing-core@0.1.34) | 0.1.34 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-log`](https://github.com/rust-lang/crates.io-index#tracing-log@0.2.0) | 0.2.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-serde`](https://github.com/rust-lang/crates.io-index#tracing-serde@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tracing-subscriber`](https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.20) | 0.3.20 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tree_magic_mini`](https://github.com/rust-lang/crates.io-index#tree_magic_mini@3.2.0) | 3.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`try-lock`](https://github.com/rust-lang/crates.io-index#try-lock@0.2.5) | 0.2.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ts-api-utils`](https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz) | 2.1.0 | Indirect | npm: https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz |  |
+| [`ts-node`](https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz) | 10.9.2 | Direct | npm: https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz |  |
+| [`ts-rs`](https://github.com/rust-lang/crates.io-index#ts-rs@10.1.0) | 10.1.0 | Direct | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ts-rs-macros`](https://github.com/rust-lang/crates.io-index#ts-rs-macros@10.1.0) | 10.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tsconfig-paths`](https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz) | 3.15.0 | Direct | npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz |  |
+| [`tsconfig-paths`](https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz) | 4.2.0 | Direct | npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz |  |
+| [`tsx`](https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz) | 4.20.5 | Direct | npm: https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz |  |
+| [`type-check`](https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz) | 0.4.0 | Indirect | npm: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz |  |
+| [`type-detect`](https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz) | 4.1.0 | Indirect | npm: https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz |  |
+| [`typed-array-buffer`](https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz |  |
+| [`typed-array-byte-length`](https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz) | 1.0.3 | Indirect | npm: https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz |  |
+| [`typed-array-byte-offset`](https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz) | 1.0.4 | Indirect | npm: https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz |  |
+| [`typed-array-length`](https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz) | 1.0.7 | Indirect | npm: https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz |  |
+| [`uds_windows`](https://github.com/rust-lang/crates.io-index#uds_windows@1.1.0) | 1.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`ufo`](https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz |  |
+| [`unbox-primitive`](https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz) | 1.1.0 | Indirect | npm: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz |  |
+| [`undici-types`](https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz) | 7.10.0 | Indirect | npm: https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz |  |
+| [`urlpattern`](https://github.com/rust-lang/crates.io-index#urlpattern@0.3.0) | 0.3.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`util-deprecate`](https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz |  |
+| [`v8-compile-cache-lib`](https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz) | 3.0.1 | Indirect | npm: https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz |  |
+| [`valuable`](https://github.com/rust-lang/crates.io-index#valuable@0.1.1) | 0.1.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`varint`](https://registry.npmjs.org/varint/-/varint-6.0.0.tgz) | 6.0.0 | Indirect | npm: https://registry.npmjs.org/varint/-/varint-6.0.0.tgz |  |
+| [`version-compare`](https://github.com/rust-lang/crates.io-index#version-compare@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vite`](https://registry.npmjs.org/vite/-/vite-5.4.20.tgz) | 5.4.20 | Direct | npm: https://registry.npmjs.org/vite/-/vite-5.4.20.tgz |  |
+| [`vite`](https://registry.npmjs.org/vite/-/vite-6.3.5.tgz) | 6.3.5 | Direct | npm: https://registry.npmjs.org/vite/-/vite-6.3.5.tgz |  |
+| [`vite-node`](https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz) | 1.6.1 | Indirect | npm: https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz |  |
+| [`vitest`](https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz) | 1.6.1 | Direct | npm: https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz |  |
+| [`vswhom`](https://github.com/rust-lang/crates.io-index#vswhom@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`vswhom-sys`](https://github.com/rust-lang/crates.io-index#vswhom-sys@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`w3c-xmlserializer`](https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz) | 5.0.0 | Indirect | npm: https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz |  |
+| [`want`](https://github.com/rust-lang/crates.io-index#want@0.3.1) | 0.3.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-backend`](https://github.com/rust-lang/crates.io-index#wayland-backend@0.3.11) | 0.3.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-client`](https://github.com/rust-lang/crates.io-index#wayland-client@0.31.11) | 0.31.11 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-protocols`](https://github.com/rust-lang/crates.io-index#wayland-protocols@0.32.9) | 0.32.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-protocols-wlr`](https://github.com/rust-lang/crates.io-index#wayland-protocols-wlr@0.3.9) | 0.3.9 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-scanner`](https://github.com/rust-lang/crates.io-index#wayland-scanner@0.31.7) | 0.31.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`wayland-sys`](https://github.com/rust-lang/crates.io-index#wayland-sys@0.31.7) | 0.31.7 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webkit2gtk`](https://github.com/rust-lang/crates.io-index#webkit2gtk@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webkit2gtk-sys`](https://github.com/rust-lang/crates.io-index#webkit2gtk-sys@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com`](https://github.com/rust-lang/crates.io-index#webview2-com@0.38.0) | 0.38.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com-macros`](https://github.com/rust-lang/crates.io-index#webview2-com-macros@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`webview2-com-sys`](https://github.com/rust-lang/crates.io-index#webview2-com-sys@0.38.0) | 0.38.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`whatwg-encoding`](https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz |  |
+| [`whatwg-mimetype`](https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz) | 4.0.0 | Indirect | npm: https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz |  |
+| [`whatwg-url`](https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz) | 14.2.0 | Indirect | npm: https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz |  |
+| [`which-boxed-primitive`](https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz) | 1.1.1 | Indirect | npm: https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz |  |
+| [`which-builtin-type`](https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz |  |
+| [`which-collection`](https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz) | 1.0.2 | Indirect | npm: https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz |  |
+| [`which-typed-array`](https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz) | 1.1.19 | Indirect | npm: https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz |  |
+| [`why-is-node-running`](https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz) | 2.3.0 | Indirect | npm: https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz |  |
+| [`winnow`](https://github.com/rust-lang/crates.io-index#winnow@0.5.40) | 0.5.40 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winnow`](https://github.com/rust-lang/crates.io-index#winnow@0.7.13) | 0.7.13 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winreg`](https://github.com/rust-lang/crates.io-index#winreg@0.50.0) | 0.50.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winreg`](https://github.com/rust-lang/crates.io-index#winreg@0.55.0) | 0.55.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`word-wrap`](https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz) | 1.2.5 | Indirect | npm: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz |  |
+| [`ws`](https://registry.npmjs.org/ws/-/ws-8.18.3.tgz) | 8.18.3 | Indirect | npm: https://registry.npmjs.org/ws/-/ws-8.18.3.tgz |  |
+| [`x11`](https://github.com/rust-lang/crates.io-index#x11@2.21.0) | 2.21.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`x11-dl`](https://github.com/rust-lang/crates.io-index#x11-dl@2.21.0) | 2.21.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`xmlchars`](https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz) | 2.2.0 | Indirect | npm: https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz |  |
+| [`yn`](https://registry.npmjs.org/yn/-/yn-3.1.1.tgz) | 3.1.1 | Indirect | npm: https://registry.npmjs.org/yn/-/yn-3.1.1.tgz |  |
+| [`yocto-queue`](https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz) | 0.1.0 | Indirect | npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz |  |
+| [`yocto-queue`](https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz) | 1.2.1 | Indirect | npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz |  |
+| [`zbus`](https://github.com/rust-lang/crates.io-index#zbus@5.10.0) | 5.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zbus_macros`](https://github.com/rust-lang/crates.io-index#zbus_macros@5.10.0) | 5.10.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zbus_names`](https://github.com/rust-lang/crates.io-index#zbus_names@4.2.0) | 4.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant`](https://github.com/rust-lang/crates.io-index#zvariant@5.7.0) | 5.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant_derive`](https://github.com/rust-lang/crates.io-index#zvariant_derive@5.7.0) | 5.7.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zvariant_utils`](https://github.com/rust-lang/crates.io-index#zvariant_utils@3.2.1) | 3.2.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### MIT OR Unlicense
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`aho-corasick`](https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.3) | 1.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`byteorder`](https://github.com/rust-lang/crates.io-index#byteorder@1.5.0) | 1.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`byteorder-lite`](https://github.com/rust-lang/crates.io-index#byteorder-lite@0.1.0) | 0.1.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`memchr`](https://github.com/rust-lang/crates.io-index#memchr@2.7.5) | 2.7.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`same-file`](https://github.com/rust-lang/crates.io-index#same-file@1.0.6) | 1.0.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`termcolor`](https://github.com/rust-lang/crates.io-index#termcolor@1.4.1) | 1.4.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`walkdir`](https://github.com/rust-lang/crates.io-index#walkdir@2.5.0) | 2.5.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`winapi-util`](https://github.com/rust-lang/crates.io-index#winapi-util@0.1.10) | 0.1.10 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### MIT OR WTFPL
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`expand-template`](https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz) | 2.0.3 | Indirect | npm: https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz |  |
+
+### MIT-0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@csstools/color-helpers`](https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz) | 5.1.0 | Indirect | npm: https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz |  |
+
+### MPL-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`@axe-core/playwright`](https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz) | 4.10.2 | Direct | npm: https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz |  |
+| [`axe-core`](https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz) | 4.10.3 | Indirect | npm: https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz |  |
+| [`cssparser`](https://github.com/rust-lang/crates.io-index#cssparser@0.29.6) | 0.29.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`cssparser-macros`](https://github.com/rust-lang/crates.io-index#cssparser-macros@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`dtoa-short`](https://github.com/rust-lang/crates.io-index#dtoa-short@0.3.5) | 0.3.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`option-ext`](https://github.com/rust-lang/crates.io-index#option-ext@0.2.0) | 0.2.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`selectors`](https://github.com/rust-lang/crates.io-index#selectors@0.24.0) | 0.24.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Python-2.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`argparse`](https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz) | 2.0.1 | Indirect | npm: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz |  |
+
+### Unicode-3.0
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`icu_collections`](https://github.com/rust-lang/crates.io-index#icu_collections@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_locale_core`](https://github.com/rust-lang/crates.io-index#icu_locale_core@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_normalizer`](https://github.com/rust-lang/crates.io-index#icu_normalizer@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_normalizer_data`](https://github.com/rust-lang/crates.io-index#icu_normalizer_data@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_properties`](https://github.com/rust-lang/crates.io-index#icu_properties@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_properties_data`](https://github.com/rust-lang/crates.io-index#icu_properties_data@2.0.1) | 2.0.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`icu_provider`](https://github.com/rust-lang/crates.io-index#icu_provider@2.0.0) | 2.0.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`litemap`](https://github.com/rust-lang/crates.io-index#litemap@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`potential_utf`](https://github.com/rust-lang/crates.io-index#potential_utf@0.1.3) | 0.1.3 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`tinystr`](https://github.com/rust-lang/crates.io-index#tinystr@0.8.1) | 0.8.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`writeable`](https://github.com/rust-lang/crates.io-index#writeable@0.6.1) | 0.6.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`yoke`](https://github.com/rust-lang/crates.io-index#yoke@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`yoke-derive`](https://github.com/rust-lang/crates.io-index#yoke-derive@0.8.0) | 0.8.0 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerofrom`](https://github.com/rust-lang/crates.io-index#zerofrom@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerofrom-derive`](https://github.com/rust-lang/crates.io-index#zerofrom-derive@0.1.6) | 0.1.6 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerotrie`](https://github.com/rust-lang/crates.io-index#zerotrie@0.2.2) | 0.2.2 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerovec`](https://github.com/rust-lang/crates.io-index#zerovec@0.11.4) | 0.11.4 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+| [`zerovec-derive`](https://github.com/rust-lang/crates.io-index#zerovec-derive@0.11.1) | 0.11.1 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Zlib
+
+| Package | Version | Type | Source | Notes |
+| --- | --- | --- | --- | --- |
+| [`foldhash`](https://github.com/rust-lang/crates.io-index#foldhash@0.1.5) | 0.1.5 | Indirect | registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index |  |
+
+### Fonts and Icons
+
+Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+"Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+
+### Questions & Contact
+
+For questions about licensing or attribution, please contact the Arklowdun team at [compliance@arklowdun.local](mailto:compliance@arklowdun.local).
+
+---
+
+This file is generated automatically; run `npm run generate:notice` after updating dependencies to refresh it.

--- a/artifacts/.gitignore
+++ b/artifacts/.gitignore
@@ -1,3 +1,6 @@
 # Generated licensing and compliance artifacts
 *
 !.gitignore
+!licensing/
+licensing/*
+!licensing/notice-checksums.json

--- a/artifacts/licensing/notice-checksums.json
+++ b/artifacts/licensing/notice-checksums.json
@@ -1,0 +1,26 @@
+{
+  "inventoryHash": "9ac1b0cf439bb4f30580d6ed19a62d48f0383a4a42b60a202c3c0e0dfaf683ee",
+  "sourceInventory": "artifacts/licensing/full-inventory.json",
+  "files": [
+    {
+      "path": "CREDITS.md",
+      "sha256": "17e754bf964e11699676656649ec3d474882d5c5df4681cbc4737a2432c0563a",
+      "bytes": 270542
+    },
+    {
+      "path": "NOTICE.md",
+      "sha256": "19a2aeb382371bdbca9ff6b84669061338fdda9f41cb60cbe9247ac8d8dbb130",
+      "bytes": 270560
+    },
+    {
+      "path": "src-tauri/resources/licenses/CREDITS.txt",
+      "sha256": "bb4f5aac0e5162e2dfbb7bd6b9ccae2b47b1a3c0e2129d9663c0f006f7bff0df",
+      "bytes": 171111
+    },
+    {
+      "path": "src-tauri/resources/licenses/NOTICE.txt",
+      "sha256": "d1a1666e123394fd2ecb88d73c2a3794c4a0e5b8964ed03c9a087147a8419193",
+      "bytes": 171045
+    }
+  ]
+}

--- a/docs/licensing/README.md
+++ b/docs/licensing/README.md
@@ -1,0 +1,61 @@
+# Licensing NOTICE & CREDITS Automation
+
+This document explains how the automated NOTICE and CREDITS artifacts are generated, verified, and shipped with Arklowdun builds.
+
+## Overview
+
+The licensing pipeline produces a consolidated dependency inventory that feeds the NOTICE/CREDITS generator. Templates under `scripts/licensing/templates` define the published format, and committed outputs live at:
+
+- `NOTICE.md` (repository Markdown copy)
+- `CREDITS.md` (repository Markdown copy)
+- `src-tauri/resources/licenses/NOTICE.txt` (plaintext bundle resource)
+- `src-tauri/resources/licenses/CREDITS.txt` (plaintext bundle resource)
+
+Checksums for the committed artifacts are captured in `artifacts/licensing/notice-checksums.json` to evidence provenance. The Tauri bundler ships the plaintext copies alongside other resources.
+
+## Commands
+
+```bash
+# Refresh the licensing inventory and regenerate all NOTICE/CREDITS outputs
+npm run generate:notice
+
+# Re-run the generator in verification mode (fails when committed copies drift)
+npm run generate:notice -- --check
+```
+
+Both commands expect Node.js 20+. The generator reads the most recent `artifacts/licensing/full-inventory.json`; if it is missing, the command will rebuild it automatically.
+
+## Manual Sections & Overrides
+
+Manual appendices (fonts, icons, bespoke attributions) live in `scripts/licensing/notices.yaml` under the `manualSections` key. Each entry specifies the target (`notice`, `credits`, or both), a heading, and content variants for Markdown/plaintext/HTML. Update this file when new bundled assets require explicit notice text.
+
+Package-level metadata corrections continue to live in `scripts/licensing/overrides.yaml`, which feeds the consolidated inventory pipeline.
+
+## Expected Outputs
+
+Successful generation refreshes the four committed NOTICE/CREDITS files and the checksum manifest. CI enforces that these files remain in sync with the dependency inventory; pull requests will fail if any artifact is stale.
+
+The checksum manifest structure:
+
+```json
+{
+  "inventoryHash": "…",
+  "sourceInventory": "artifacts/licensing/full-inventory.json",
+  "files": [
+    {
+      "path": "NOTICE.md",
+      "sha256": "…",
+      "bytes": 1234
+    }
+  ]
+}
+```
+
+The `inventoryHash` is derived from a normalized view of the dependency inventory so that the manifest only changes when the underlying dependency set does.
+
+## Troubleshooting
+
+- **Missing inventory** – Run `npm run licensing:inventory` to recreate `artifacts/licensing/full-inventory.json` and retry.
+- **Template rendering errors** – Inspect the template files for unmatched `{{PLACEHOLDER}}` tokens. The generator replaces `{{DEPENDENCY_SECTIONS}}` and `{{MANUAL_SECTIONS}}`.
+- **New assets not represented in lockfiles** – Add a manual section in `scripts/licensing/notices.yaml` with explicit attribution text. For recurring issues, consider extending the licensing overrides.
+- **CI failure on NOTICE drift** – Run `npm run generate:notice`, review the diff, and commit the updated artifacts alongside dependency changes.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "perf:query:local": "node scripts/ci/query-perf-local.mjs",
     "gate:scan": "npm run gate:ipc-in-components && npm run gate:no-deep-relatives && npm run gate:cross-feature-report",
     "licensing:inventory": "tsx scripts/licensing/pipeline.ts",
+    "generate:notice": "node scripts/licensing/run-generate-notice.mjs",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:structure": "node scripts/guards/structure-lint.mjs",
     "check": "npm run typecheck && echo TS OK && npm run lint && npm run guard:invoke && npm run guard:ui-colors && npm run guard:db-writes && npm run guard:recovery-strings && npm run lint:structure",

--- a/scripts/licensing/cargo-inventory.ts
+++ b/scripts/licensing/cargo-inventory.ts
@@ -258,7 +258,7 @@ export async function generateCargoInventory({
             "--manifest-path",
             manifestPath ?? lockfilePath.replace(/Cargo\\.lock$/, "Cargo.toml")
           ],
-          { encoding: "utf8" }
+          { encoding: "utf8", maxBuffer: 20 * 1024 * 1024 }
         )
       ).stdout;
   const metadata: Metadata = JSON.parse(metadataRaw);

--- a/scripts/licensing/generate-notices.ts
+++ b/scripts/licensing/generate-notices.ts
@@ -1,0 +1,497 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+import { createHash } from "node:crypto";
+import { parse as parseYaml } from "yaml";
+import {
+  Inventory,
+  InventoryDependency,
+  sortDependencies
+} from "./lib/utils.ts";
+
+type OutputTarget = "notice" | "credits";
+type OutputFormat = "markdown" | "text" | "html";
+
+type OutputConfig = {
+  id: string;
+  target: OutputTarget;
+  format: OutputFormat;
+  template: string;
+  output: string;
+};
+
+type ManualSection = {
+  id: string;
+  title?: string;
+  includeIn: OutputTarget[];
+  content: Partial<Record<OutputFormat, string>> & {
+    markdown?: string;
+    text?: string;
+    html?: string;
+  };
+};
+
+type NoticeConfig = {
+  outputs: OutputConfig[];
+  manualSections?: ManualSection[];
+  checksumsOutput?: string;
+};
+
+type GeneratedOutput = {
+  config: OutputConfig;
+  content: string;
+  checksum: string;
+  bytes: number;
+};
+
+type DependencyGroup = {
+  licenseKey: string;
+  dependencies: InventoryDependency[];
+};
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      config: { type: "string" },
+      inventory: { type: "string" },
+      templates: { type: "string" },
+      check: { type: "boolean" }
+    }
+  });
+
+  const projectRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const configPath = values.config
+    ? resolve(values.config)
+    : join(projectRoot, "scripts", "licensing", "notices.yaml");
+  const inventoryPath = values.inventory
+    ? resolve(values.inventory)
+    : join(projectRoot, "artifacts", "licensing", "full-inventory.json");
+  const templatesDir = values.templates
+    ? resolve(values.templates)
+    : join(projectRoot, "scripts", "licensing", "templates");
+  const checkOnly = Boolean(values.check);
+
+  const [config, inventory] = await Promise.all([
+    loadConfig(configPath),
+    loadInventory(inventoryPath)
+  ]);
+
+  const dependencyGroups = groupDependencies(inventory.dependencies);
+
+  const outputs: GeneratedOutput[] = [];
+
+  for (const outputConfig of config.outputs) {
+    const templatePath = resolveTemplatePath(
+      templatesDir,
+      outputConfig.template
+    );
+    const templateRaw = await readFile(templatePath, "utf8");
+    const dependencySection = renderDependencySections(
+      dependencyGroups,
+      outputConfig.format
+    );
+    const manualSection = renderManualSections(
+      config.manualSections ?? [],
+      outputConfig.target,
+      outputConfig.format
+    );
+
+    const rendered = templateRaw
+      .replaceAll("{{DEPENDENCY_SECTIONS}}", dependencySection.trimEnd())
+      .replaceAll("{{MANUAL_SECTIONS}}", manualSection.trimEnd());
+
+    const content = ensureTrailingNewline(rendered.trimEnd());
+    const checksum = sha256(content);
+    outputs.push({
+      config: outputConfig,
+      content,
+      checksum,
+      bytes: Buffer.byteLength(content, "utf8")
+    });
+  }
+
+  const checksumOutputPath = config.checksumsOutput
+    ? resolve(config.checksumsOutput)
+    : undefined;
+
+  if (checkOnly) {
+    const failures: string[] = [];
+    for (const output of outputs) {
+      const diskPath = resolve(projectRoot, output.config.output);
+      const existing = await readMaybe(diskPath);
+      if (existing === undefined) {
+        failures.push(
+          `${relative(projectRoot, diskPath)} is missing. Run npm run generate:notice.`
+        );
+        continue;
+      }
+      if (!contentsMatch(existing, output.content)) {
+        failures.push(
+          `${relative(projectRoot, diskPath)} is out of date. Regenerate with npm run generate:notice.`
+        );
+      }
+    }
+
+    if (checksumOutputPath) {
+      const existingChecksums = await readMaybe(checksumOutputPath);
+      const expectedChecksums = serializeChecksums(
+        outputs,
+        projectRoot,
+        inventory,
+        inventoryPath
+      );
+      if (existingChecksums === undefined) {
+        failures.push(
+          `${relative(projectRoot, checksumOutputPath)} is missing. Regenerate with npm run generate:notice.`
+        );
+      } else if (!contentsMatch(existingChecksums, expectedChecksums)) {
+        failures.push(
+          `${relative(projectRoot, checksumOutputPath)} is out of date. Regenerate with npm run generate:notice.`
+        );
+      }
+    }
+
+    if (failures.length > 0) {
+      for (const failure of failures) {
+        console.error(failure);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log("NOTICE/CREDITS artifacts are up to date.");
+    return;
+  }
+
+  for (const output of outputs) {
+    const diskPath = resolve(projectRoot, output.config.output);
+    await mkdir(dirname(diskPath), { recursive: true });
+    await writeFile(diskPath, output.content, "utf8");
+    console.log(
+      `Wrote ${relative(projectRoot, diskPath)} (${output.bytes} bytes, sha256 ${output.checksum}).`
+    );
+  }
+
+  if (checksumOutputPath) {
+    const serialized = serializeChecksums(
+      outputs,
+      projectRoot,
+      inventory,
+      inventoryPath
+    );
+    await mkdir(dirname(checksumOutputPath), { recursive: true });
+    await writeFile(checksumOutputPath, serialized, "utf8");
+    console.log(
+      `Wrote ${relative(projectRoot, checksumOutputPath)} (${Buffer.byteLength(serialized, "utf8")} bytes).`
+    );
+  }
+}
+
+async function loadConfig(path: string): Promise<NoticeConfig> {
+  const raw = await readFile(path, "utf8");
+  const parsed = parseYaml(raw);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Invalid notice configuration at ${path}`);
+  }
+  return parsed as NoticeConfig;
+}
+
+async function loadInventory(path: string): Promise<Inventory> {
+  const raw = await readFile(path, "utf8");
+  const parsed = JSON.parse(raw) as Inventory;
+  return parsed;
+}
+
+function groupDependencies(dependencies: InventoryDependency[]): DependencyGroup[] {
+  const groups = new Map<string, InventoryDependency[]>();
+  for (const dependency of dependencies) {
+    const normalizedLicenses = [...dependency.licenses].sort((a, b) =>
+      a.localeCompare(b)
+    );
+    const key = normalizedLicenses.join(" OR ");
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(dependency);
+    } else {
+      groups.set(key, [dependency]);
+    }
+  }
+
+  const sortedKeys = [...groups.keys()].sort((a, b) => a.localeCompare(b));
+  return sortedKeys.map((licenseKey) => ({
+    licenseKey,
+    dependencies: sortDependencies(groups.get(licenseKey) ?? [])
+  }));
+}
+
+function renderDependencySections(
+  groups: DependencyGroup[],
+  format: OutputFormat
+): string {
+  if (groups.length === 0) {
+    return format === "markdown"
+      ? "_No third-party dependencies recorded._"
+      : "No third-party dependencies recorded.";
+  }
+
+  const sections: string[] = [];
+  for (const group of groups) {
+    if (format === "markdown") {
+      sections.push(renderMarkdownGroup(group));
+    } else if (format === "text") {
+      sections.push(renderTextGroup(group));
+    } else {
+      sections.push(renderHtmlGroup(group));
+    }
+  }
+  const separator = format === "markdown" ? "\n\n" : "\n\n";
+  return sections.join(separator) + "\n";
+}
+
+function renderMarkdownGroup(group: DependencyGroup): string {
+  const lines: string[] = [];
+  lines.push(`### ${group.licenseKey}`);
+  lines.push("");
+  lines.push("| Package | Version | Type | Source | Notes |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const dependency of group.dependencies) {
+    const packageCell = formatMarkdownPackage(dependency);
+    const sourceCell = formatSource(dependency, true);
+    const notesCell = formatNotes(dependency.notes, true);
+    lines.push(
+      `| ${packageCell} | ${escapeMarkdown(dependency.version)} | ${capitalize(
+        dependency.dependencyType
+      )} | ${sourceCell} | ${notesCell} |`
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderTextGroup(group: DependencyGroup): string {
+  const lines: string[] = [];
+  lines.push(group.licenseKey);
+  lines.push("-".repeat(group.licenseKey.length));
+  for (const dependency of group.dependencies) {
+    const sourceCell = formatSource(dependency, false);
+    const note = dependency.notes ? `\n    Notes: ${dependency.notes.trim()}` : "";
+    lines.push(
+      `- ${dependency.name} ${dependency.version} [${capitalize(
+        dependency.dependencyType
+      )}] — ${sourceCell}${note}`
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderHtmlGroup(group: DependencyGroup): string {
+  const rows = group.dependencies
+    .map((dependency) => {
+      const packageCell = escapeHtml(dependency.name);
+      const versionCell = escapeHtml(dependency.version);
+      const typeCell = escapeHtml(capitalize(dependency.dependencyType));
+      const sourceCell = escapeHtml(formatSource(dependency, false));
+      const notesCell = escapeHtml(dependency.notes ?? "");
+      return `<tr><td>${packageCell}</td><td>${versionCell}</td><td>${typeCell}</td><td>${sourceCell}</td><td>${notesCell}</td></tr>`;
+    })
+    .join("");
+  return `<section><h3>${escapeHtml(group.licenseKey)}</h3><table><thead><tr><th>Package</th><th>Version</th><th>Type</th><th>Source</th><th>Notes</th></tr></thead><tbody>${rows}</tbody></table></section>`;
+}
+
+function formatMarkdownPackage(dependency: InventoryDependency): string {
+  const label = `\`${dependency.name}\``;
+  if (looksLikeUrl(dependency.resolved)) {
+    return `[${label}](${dependency.resolved})`;
+  }
+  return label;
+}
+
+function formatSource(dependency: InventoryDependency, markdown: boolean): string {
+  const { type, location, registry } = dependency.source;
+  const prefix = registry ? `${type} (${registry})` : type;
+  const raw = `${prefix}: ${location}`;
+  if (markdown) {
+    return escapeMarkdown(raw);
+  }
+  return raw;
+}
+
+function formatNotes(notes: string | undefined, markdown: boolean): string {
+  if (!notes) return markdown ? "" : "";
+  const normalized = notes.replace(/\s+/g, " ").trim();
+  if (markdown) {
+    return escapeMarkdown(normalized);
+  }
+  return normalized;
+}
+
+function renderManualSections(
+  sections: ManualSection[],
+  target: OutputTarget,
+  format: OutputFormat
+): string {
+  const filtered = sections.filter((section) =>
+    section.includeIn.includes(target)
+  );
+  if (filtered.length === 0) {
+    return format === "markdown" ? "" : "";
+  }
+  const rendered = filtered.map((section) =>
+    renderManualSection(section, format)
+  );
+  return rendered.join(format === "markdown" ? "\n\n" : "\n\n") + "\n";
+}
+
+function renderManualSection(
+  section: ManualSection,
+  format: OutputFormat
+): string {
+  const body =
+    section.content[format] ??
+    section.content.markdown ??
+    section.content.text ??
+    "";
+  const trimmedBody = body.trim();
+  if (format === "markdown") {
+    if (section.title) {
+      return `### ${section.title}\n\n${trimmedBody}`;
+    }
+    return trimmedBody;
+  }
+  if (format === "text") {
+    if (section.title) {
+      const underline = "-".repeat(section.title.length);
+      return `${section.title}\n${underline}\n\n${trimmedBody}`;
+    }
+    return trimmedBody;
+  }
+  if (section.title) {
+    return `<section><h3>${escapeHtml(section.title)}</h3><p>${escapeHtml(
+      trimmedBody
+    )}</p></section>`;
+  }
+  return `<p>${escapeHtml(trimmedBody)}</p>`;
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+async function readMaybe(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function contentsMatch(expected: string, actual: string): boolean {
+  return expected === actual;
+}
+
+function serializeChecksums(
+  outputs: GeneratedOutput[],
+  projectRoot: string,
+  inventory: Inventory,
+  inventoryPath: string
+): string {
+  const files = outputs
+    .map((output) => ({
+      path: normalizePath(relative(projectRoot, resolve(projectRoot, output.config.output))),
+      sha256: output.checksum,
+      bytes: output.bytes
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  const payload = {
+    inventoryHash: computeInventoryHash(inventory),
+    sourceInventory: normalizePath(
+      relative(projectRoot, resolve(inventoryPath))
+    ),
+    files
+  };
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+function computeInventoryHash(inventory: Inventory): string {
+  const dependencies = sortDependencies([...inventory.dependencies]).map(
+    (dependency) => ({
+      name: dependency.name,
+      version: dependency.version,
+      dependencyType: dependency.dependencyType,
+      licenses: [...dependency.licenses].sort(),
+      resolved: dependency.resolved,
+      checksum: dependency.checksum,
+      source: dependency.source,
+      features: dependency.features ? [...dependency.features].sort() : undefined,
+      notes: dependency.notes ?? undefined,
+      provenance: dependency.provenance
+        .map((entry) => ({
+          ecosystem: entry.ecosystem,
+          dependencyType: entry.dependencyType,
+          resolved: entry.resolved,
+          checksum: entry.checksum,
+          source: entry.source,
+          features: entry.features ? [...entry.features].sort() : undefined,
+          notes: entry.notes ?? undefined
+        }))
+        .sort((a, b) =>
+          a.ecosystem.localeCompare(b.ecosystem) ||
+          a.resolved.localeCompare(b.resolved) ||
+          a.checksum.localeCompare(b.checksum)
+        )
+    })
+  );
+  return sha256(JSON.stringify({ dependencies }));
+}
+
+function normalizePath(path: string): string {
+  return path.split("\\").join("/");
+}
+
+function resolveTemplatePath(baseDir: string, template: string): string {
+  if (isAbsolute(template)) return template;
+  return join(baseDir, template);
+}
+
+function looksLikeUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function escapeMarkdown(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/licensing/lib/spdx.ts
+++ b/scripts/licensing/lib/spdx.ts
@@ -37,6 +37,14 @@ export function normaliseLicenses(
       const parsed = spdxParse(value);
       collectSpdx(parsed, licenses);
     } catch (error) {
+      const normalised = value.replace(/\s+/g, " ").trim();
+      if (normalised.includes("/")) {
+        const parts = normalised.split("/").map((part) => part.trim()).filter(Boolean);
+        if (parts.every((part) => /^[A-Za-z0-9.+-]+$/.test(part))) {
+          licenses.push(...parts);
+          continue;
+        }
+      }
       if (/^[A-Za-z0-9.+-]+$/.test(value)) {
         licenses.push(value);
       } else {

--- a/scripts/licensing/notices.yaml
+++ b/scripts/licensing/notices.yaml
@@ -1,0 +1,43 @@
+outputs:
+  - id: notice_markdown
+    target: notice
+    format: markdown
+    template: notice.md.tmpl
+    output: NOTICE.md
+  - id: notice_text
+    target: notice
+    format: text
+    template: notice.txt.tmpl
+    output: src-tauri/resources/licenses/NOTICE.txt
+  - id: credits_markdown
+    target: credits
+    format: markdown
+    template: credits.md.tmpl
+    output: CREDITS.md
+  - id: credits_text
+    target: credits
+    format: text
+    template: credits.txt.tmpl
+    output: src-tauri/resources/licenses/CREDITS.txt
+checksumsOutput: artifacts/licensing/notice-checksums.json
+manualSections:
+  - id: fonts-and-icons
+    title: Fonts and Icons
+    includeIn: [notice, credits]
+    content:
+      markdown: |
+        Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+        "Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+      text: |
+        Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+        "Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+  - id: contact
+    title: Questions & Contact
+    includeIn: [notice, credits]
+    content:
+      markdown: |
+        For questions about licensing or attribution, please contact the Arklowdun team at [compliance@arklowdun.local](mailto:compliance@arklowdun.local).
+      text: |
+        For questions about licensing or attribution, contact the Arklowdun team at compliance@arklowdun.local.

--- a/scripts/licensing/overrides.yaml
+++ b/scripts/licensing/overrides.yaml
@@ -2,3 +2,11 @@ buffer-builder@0.2.0:
   licenses:
     - MIT
   notes: "Upstream package declares \"MIT/X11\"; normalized to MIT for reporting."
+dlopen2@0.8.0:
+  licenses:
+    - MIT
+  notes: "License file bundled with crate (MIT License)."
+dlopen2_derive@0.4.1:
+  licenses:
+    - MIT
+  notes: "License file bundled with crate (MIT License)."

--- a/scripts/licensing/run-generate-notice.mjs
+++ b/scripts/licensing/run-generate-notice.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptArgs = process.argv.slice(2);
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const tsxExecutable = join(
+  projectRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx"
+);
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      cwd: projectRoot,
+      env: process.env,
+      shell: false
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Process terminated with signal ${signal}`));
+      } else {
+        resolve(code ?? 0);
+      }
+    });
+  });
+}
+
+async function main() {
+  const pipelineExit = await run(tsxExecutable, [
+    "scripts/licensing/pipeline.ts"
+  ]);
+  if (pipelineExit !== 0) {
+    console.error(
+      `Licensing inventory generation completed with exit code ${pipelineExit}. Continuing to render NOTICE artifacts.`
+    );
+  }
+
+  const generatorExit = await run(tsxExecutable, [
+    "scripts/licensing/generate-notices.ts",
+    ...scriptArgs
+  ]);
+
+  if (pipelineExit !== 0) {
+    process.exit(pipelineExit);
+  }
+  process.exit(generatorExit);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/licensing/templates/credits.md.tmpl
+++ b/scripts/licensing/templates/credits.md.tmpl
@@ -1,0 +1,13 @@
+# CREDITS
+
+This CREDITS file enumerates third-party components bundled with Arklowdun and acknowledges the open source community whose work makes the project possible. It was generated from the consolidated licensing inventory.
+
+## Open Source Components
+
+{{DEPENDENCY_SECTIONS}}
+
+{{MANUAL_SECTIONS}}
+
+---
+
+Generated automatically; refresh with `npm run generate:notice` whenever dependencies change.

--- a/scripts/licensing/templates/credits.txt.tmpl
+++ b/scripts/licensing/templates/credits.txt.tmpl
@@ -1,0 +1,14 @@
+CREDITS
+=======
+
+This file acknowledges the open source community whose work ships with Arklowdun. It was generated from the consolidated licensing inventory.
+
+Open Source Components
+----------------------
+
+{{DEPENDENCY_SECTIONS}}
+
+{{MANUAL_SECTIONS}}
+
+--
+Generated automatically; refresh with "npm run generate:notice" whenever dependencies change.

--- a/scripts/licensing/templates/notice.md.tmpl
+++ b/scripts/licensing/templates/notice.md.tmpl
@@ -1,0 +1,13 @@
+# NOTICE
+
+This NOTICE file was generated from Arklowdun's consolidated licensing inventory. It lists the third-party components distributed with the application together with their license identifiers and provenance information.
+
+## Third-Party Components
+
+{{DEPENDENCY_SECTIONS}}
+
+{{MANUAL_SECTIONS}}
+
+---
+
+This file is generated automatically; run `npm run generate:notice` after updating dependencies to refresh it.

--- a/scripts/licensing/templates/notice.txt.tmpl
+++ b/scripts/licensing/templates/notice.txt.tmpl
@@ -1,0 +1,14 @@
+NOTICE
+======
+
+Generated from Arklowdun's consolidated licensing inventory.
+
+Third-Party Components
+----------------------
+
+{{DEPENDENCY_SECTIONS}}
+
+{{MANUAL_SECTIONS}}
+
+--
+This file is generated automatically; run "npm run generate:notice" after updating dependencies to refresh it.

--- a/src-tauri/resources/licenses/CREDITS.txt
+++ b/src-tauri/resources/licenses/CREDITS.txt
@@ -1,0 +1,1405 @@
+CREDITS
+=======
+
+This file acknowledges the open source community whose work ships with Arklowdun. It was generated from the consolidated licensing inventory.
+
+Open Source Components
+----------------------
+
+0BSD
+----
+- tslib 2.8.1 [Indirect] — npm: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz
+
+0BSD OR Apache-2.0 OR MIT
+-------------------------
+- adler2 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0
+----------
+- @ampproject/remapping 2.3.0 [Indirect] — npm: https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz
+- @humanwhocodes/config-array 0.13.0 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz
+    Notes: Use @eslint/config-array instead
+- @humanwhocodes/module-importer 1.0.1 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+- @playwright/test 1.55.0 [Direct] — npm: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz
+- aria-query 5.3.2 [Indirect] — npm: https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz
+- axobject-query 4.1.0 [Indirect] — npm: https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz
+- detect-libc 1.0.3 [Indirect] — npm: https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz
+- detect-libc 2.0.4 [Indirect] — npm: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz
+- doctrine 2.1.0 [Indirect] — npm: https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz
+- doctrine 3.0.0 [Indirect] — npm: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz
+- eslint-plugin-security 2.1.1 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz
+- eslint-visitor-keys 3.4.3 [Indirect] — npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+- eslint-visitor-keys 4.2.1 [Indirect] — npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+- gethostname 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- human-signals 5.0.0 [Indirect] — npm: https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz
+- playwright 1.55.0 [Indirect] — npm: https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz
+- playwright-core 1.55.0 [Indirect] — npm: https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz
+- rxjs 7.8.2 [Indirect] — npm: https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz
+- similar 2.7.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sync_wrapper 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sync_wrapper 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tao 0.34.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tunnel-agent 0.6.0 [Indirect] — npm: https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz
+- typescript 5.9.2 [Direct] — npm: https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz
+- xml-name-validator 5.0.0 [Indirect] — npm: https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz
+
+Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+---------------------------------------------------
+- linux-raw-sys 0.4.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- linux-raw-sys 0.9.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustix 0.38.44 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustix 1.0.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.11.1+wasi-snapshot-preview1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.14.3+wasi-0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.9.0+wasi-snapshot-preview1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wit-bindgen 0.45.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-2-Clause OR MIT
+---------------------------------
+- rc 1.2.8 [Indirect] — npm: https://registry.npmjs.org/rc/-/rc-1.2.8.tgz
+- zerocopy 0.8.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerocopy-derive 0.8.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-3-Clause
+--------------------------
+- @bufbuild/protobuf 2.7.0 [Indirect] — npm: https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz
+- moxcms 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pxfm 0.1.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-3-Clause OR MIT
+---------------------------------
+- encoding_rs 0.8.35 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num_enum 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num_enum_derive 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSL-1.0
+---------------------
+- ryu 1.0.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSL-1.0 OR MIT
+----------------------------
+- wasite 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- whoami 1.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR CC0-1.0 OR MIT-0
+------------------------------
+- dunce 1.0.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR LGPL-2.1-or-later OR MIT
+--------------------------------------
+- r-efi 5.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT
+-----------------
+- @tauri-apps/api 2.8.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz
+- @tauri-apps/cli 2.8.3 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz
+- @tauri-apps/cli-darwin-arm64 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz
+- @tauri-apps/cli-darwin-x64 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz
+- @tauri-apps/cli-linux-arm-gnueabihf 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz
+- @tauri-apps/cli-linux-arm64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-arm64-musl 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz
+- @tauri-apps/cli-linux-riscv64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-x64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-x64-musl 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz
+- @tauri-apps/cli-win32-arm64-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz
+- @tauri-apps/cli-win32-ia32-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz
+- @tauri-apps/cli-win32-x64-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz
+- @tauri-apps/plugin-clipboard-manager 2.3.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz
+- @tauri-apps/plugin-dialog 2.3.3 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz
+- @tauri-apps/plugin-fs 2.4.2 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz
+- @tauri-apps/plugin-notification 2.3.1 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz
+- @tauri-apps/plugin-opener 2.5.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz
+- @tauri-apps/plugin-sql 2.3.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz
+- addr2line 0.24.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ahash 0.8.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- allocator-api2 0.2.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- android_system_properties 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- android-tzdata 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstream 0.6.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle 1.0.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-parse 0.2.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-query 1.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-wincon 3.0.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anyhow 1.0.99 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- arboard 3.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- assert_cmd 2.0.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-broadcast 0.7.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-channel 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-executor 1.13.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-io 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-lock 3.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-process 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-recursion 1.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-signal 0.2.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-task 4.7.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-trait 0.1.89 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atomic-waker 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- autocfg 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- backtrace 0.3.75 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64 0.21.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64 0.22.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64ct 1.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bit-set 0.5.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bit-vec 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bitflags 1.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bitflags 2.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- block-buffer 0.10.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- blocking 1.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bstr 1.12.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bumpalo 3.19.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bytecount 0.6.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- camino 1.1.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cargo_toml 0.22.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cargo-platform 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cc 1.2.34 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cesu8 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg-expr 0.15.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg-if 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chrono 0.4.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chrono-tz 0.10.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap 4.5.47 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_builder 4.5.47 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_derive 4.5.47 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_lex 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- colorchoice 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- concurrent-queue 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- const-oid 0.9.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cookie 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation 0.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation 0.9.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation-sys 0.8.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-graphics 0.24.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-graphics-types 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cpufeatures 0.2.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc 3.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc-catalog 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc32fast 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-channel 0.5.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-queue 0.3.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-utils 0.8.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crypto-common 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ctor 0.2.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- der 0.7.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- deranged 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- digest 0.10.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs 5.0.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs 6.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs-sys 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- displaydoc 0.2.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- downcast-rs 1.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dpi 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dtoa 1.0.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dyn-clone 1.0.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- either 1.15.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- embed_plist 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- enumflags2 0.7.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- enumflags2_derive 0.7.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- equivalent 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- erased-serde 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- errno 0.3.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- etcetera 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- event-listener 5.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- event-listener-strategy 0.5.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fallible-iterator 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fallible-streaming-iterator 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fastrand 2.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fdeflate 0.3.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- field-offset 0.3.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fixedbitset 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- flate2 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- flume 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fnv 1.0.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types-macros 0.2.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types-shared 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- form_urlencoded 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fraction 0.13.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fs2 0.4.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futf 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures 0.3.31 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-channel 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-core 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-executor 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-intrusive 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-io 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-lite 2.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-macro 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-sink 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-task 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-util 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fxhash 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.1.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.2.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gimli 0.31.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glob 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- half 2.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.12.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.14.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.15.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashlink 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashlink 0.9.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- heck 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- heck 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hermit-abi 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hex 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hkdf 0.12.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hmac 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- home 0.5.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- html5ever 0.29.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http 0.2.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http 1.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- httparse 1.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- httpdate 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iana-time-zone 0.1.63 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iana-time-zone-haiku 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ident_case 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- idna 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- idna_adapter 1.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- image 0.25.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- indexmap 1.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- indexmap 2.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- io-uring 0.7.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ipnet 2.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iri-string 0.7.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- is_terminal_polyfill 1.70.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- itoa 1.0.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jni 0.21.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jni-sys 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- js-sys 0.3.77 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- json-patch 3.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jsonptr 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- keyboard-types 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lazy_static 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libappindicator 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libappindicator-sys 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libc 0.2.175 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lock_api 0.4.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- log 0.4.27 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mac 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- markup5ever 0.14.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- match_token 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- md-5 0.10.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mime 0.3.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- minimal-lexical 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- muda 0.17.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk-context 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk-sys 0.6.0+11769913 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nodrop 0.1.14 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- notify-rust 4.11.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-bigint 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-bigint-dig 0.8.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-cmp 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-complex 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-conv 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-integer 0.1.46 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-iter 0.1.45 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-rational 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-traits 0.2.19 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- object 0.36.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- once_cell 1.21.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- once_cell_polyfill 1.70.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ordered-stream 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking 2.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking_lot 0.12.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking_lot_core 0.9.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- paste 1.0.15 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pathdiff 0.2.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pem-rfc7468 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- percent-encoding 2.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_derive 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_generator 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_meta 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- petgraph 0.6.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pin-project-lite 0.2.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pin-utils 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- piper 0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkcs1 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkcs8 0.10.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkg-config 0.3.32 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- png 0.17.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- png 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- polling 3.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- powerfmt 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ppv-lite86 0.2.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates 3.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates-core 1.0.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates-tree 1.0.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 1.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 3.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-error 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-error-attr 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-hack 0.5.20+deprecated [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro2 1.0.101 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quick-error 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quote 1.0.40 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.8.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.9.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.6.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_hc 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_pcg 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ref-cast 1.0.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ref-cast-impl 1.0.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex 1.11.2 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex-automata 0.4.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex-syntax 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reqwest 0.11.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reqwest 0.12.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rrule 0.14.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rsa 0.9.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustc_version 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustc-demangle 0.1.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustversion 1.0.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- scoped-tls 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- scopeguard 1.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- semver 1.0.26 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde 1.0.219 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_derive 1.0.219 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_derive_internals 0.29.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_json 1.0.143 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_repr 0.1.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_spanned 0.6.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_spanned 1.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_urlencoded 0.7.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_with 3.14.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_with_macros 3.14.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde-untagged 0.1.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serialize-to-javascript 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serialize-to-javascript-impl 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- servo_arc 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sha1 0.10.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sha2 0.10.9 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- shlex 1.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- signal-hook-registry 1.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- signature 2.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- siphasher 0.3.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- siphasher 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- smallvec 1.15.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- socket2 0.5.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- socket2 0.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- softbuffer 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- spki 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx 0.8.6 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-core 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-macros 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-macros-core 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-mysql 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-postgres 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-sqlite 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stable_deref_trait 1.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- static_assertions 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- string_cache 0.8.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- string_cache_codegen 0.5.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stringprep 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- swift-rs 1.0.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- syn 1.0.109 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- syn 2.0.106 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-configuration 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-configuration-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-deps 6.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tao-macros 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri 2.8.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-build 2.4.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-codegen 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-macros 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-clipboard-manager 2.3.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-dialog 2.3.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-fs 2.4.2 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-notification 2.3.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-opener 2.5.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-sql 2.3.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-runtime 2.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-runtime-wry 2.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-utils 2.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-winrt-notification 0.7.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tempfile 3.21.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tendril 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror 1.0.69 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror 2.0.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror-impl 1.0.69 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror-impl 2.0.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thread_local 1.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time 0.3.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time-core 0.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time-macros 0.2.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml 0.8.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml 0.9.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_datetime 0.6.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_datetime 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.19.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.20.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.22.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_parser 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_writer 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tray-icon 0.21.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- typeid 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- typenum 1.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ucd-trie 0.1.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-char-property 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-char-range 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-common 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-ucd-ident 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-ucd-version 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-bidi 0.3.18 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-normalization 0.1.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-properties 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-segmentation 1.12.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- url 2.5.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf-8 0.7.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf8_iter 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf8parse 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- uuid 1.18.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vcpkg 0.2.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- version_check 0.9.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wait-timeout 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-backend 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-futures 0.4.50 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-macro 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-macro-support 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-shared 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-streams 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- web-sys 0.3.77 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- weezl 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi 0.3.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-i686-pc-windows-gnu 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-x86_64-pc-windows-gnu 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- window-vibrancy 0.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows 0.61.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-collections 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-core 0.61.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-future 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-implement 0.60.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-interface 0.59.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-link 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-numerics 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-result 0.3.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-strings 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.45.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.48.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.52.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.59.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.60.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.53.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-threading 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-version 0.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wl-clipboard-rs 0.9.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wry 0.53.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11rb 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11rb-protocol 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zeroize 1.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT OR Unicode-3.0
+--------------------------------
+- unicode-ident 1.0.18 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT OR Zlib
+-------------------------
+- bytemuck 1.23.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dispatch2 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- miniz_oxide 0.8.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-app-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-cloud-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-data 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-foundation 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-graphics 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-image 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-exception-helper 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-io-surface 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-javascript-core 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-quartz-core 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-security 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-ui-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-web-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- raw-window-handle 0.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinyvec 1.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinyvec_macros 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zune-core 0.4.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zune-jpeg 0.4.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 WITH LLVM-exception
+------------------------------
+- target-lexicon 0.12.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+BSD-2-Clause
+------------
+- damerau-levenshtein 1.0.8 [Indirect] — npm: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz
+- entities 6.0.1 [Indirect] — npm: https://registry.npmjs.org/entities/-/entities-6.0.1.tgz
+- eslint-scope 7.2.2 [Indirect] — npm: https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz
+- espree 9.6.1 [Indirect] — npm: https://registry.npmjs.org/espree/-/espree-9.6.1.tgz
+- esrecurse 4.3.0 [Indirect] — npm: https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+- estraverse 5.3.0 [Indirect] — npm: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+- esutils 2.0.3 [Indirect] — npm: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+- uri-js 4.4.1 [Indirect] — npm: https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+- webidl-conversions 7.0.0 [Indirect] — npm: https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz
+
+BSD-3-Clause
+------------
+- @humanwhocodes/object-schema 2.0.3 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz
+    Notes: Use @eslint/object-schema instead
+- alloc-no-stdlib 2.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- alloc-stdlib 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- diff 4.0.2 [Indirect] — npm: https://registry.npmjs.org/diff/-/diff-4.0.2.tgz
+- esquery 1.6.0 [Indirect] — npm: https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz
+- fast-uri 3.1.0 [Indirect] — npm: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz
+- ieee754 1.2.1 [Indirect] — npm: https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz
+- istanbul-lib-coverage 3.2.2 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz
+- istanbul-lib-report 3.0.1 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz
+- istanbul-lib-source-maps 5.0.6 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz
+- istanbul-reports 3.2.0 [Indirect] — npm: https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz
+- source-map-js 1.2.1 [Indirect] — npm: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz
+- subtle 2.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tough-cookie 5.1.2 [Indirect] — npm: https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz
+
+BSD-3-Clause OR MIT
+-------------------
+- brotli 8.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- brotli-decompressor 5.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+BSL-1.0
+-------
+- clipboard-win 5.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- error-code 3.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+CC-BY-3.0
+---------
+- spdx-exceptions 2.5.0 [Indirect] — npm: https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz
+
+CC-BY-4.0 OR MIT OR OFL-1.1
+---------------------------
+- @fortawesome/fontawesome-free 6.7.2 [Direct] — npm: https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz
+
+CC0-1.0
+-------
+- language-subtag-registry 0.3.23 [Indirect] — npm: https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz
+- spdx-license-ids 3.0.22 [Indirect] — npm: https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz
+
+CC0-1.0 OR MIT
+--------------
+- type-fest 0.20.2 [Indirect] — npm: https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz
+
+ISC
+---
+- @iarna/toml 2.2.5 [Direct] — npm: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz
+- @ungap/structured-clone 1.3.0 [Indirect] — npm: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz
+- chownr 1.1.4 [Indirect] — npm: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz
+- fastq 1.19.1 [Indirect] — npm: https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz
+- flatted 3.3.3 [Indirect] — npm: https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz
+- fs.realpath 1.0.0 [Indirect] — npm: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz
+- glob 7.2.3 [Indirect] — npm: https://registry.npmjs.org/glob/-/glob-7.2.3.tgz
+    Notes: Glob versions prior to v9 are no longer supported
+- glob-parent 5.1.2 [Indirect] — npm: https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+- glob-parent 6.0.2 [Indirect] — npm: https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+- inflight 1.0.6 [Indirect] — npm: https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz
+    Notes: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+- inherits 2.0.4 [Indirect] — npm: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz
+- ini 1.3.8 [Indirect] — npm: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz
+- isexe 2.0.0 [Indirect] — npm: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+- json5 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libloading 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lru-cache 10.4.3 [Indirect] — npm: https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz
+- make-error 1.3.6 [Indirect] — npm: https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz
+- minimatch 3.1.2 [Indirect] — npm: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz
+- minimatch 9.0.5 [Indirect] — npm: https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz
+- once 1.4.0 [Indirect] — npm: https://registry.npmjs.org/once/-/once-1.4.0.tgz
+- picocolors 1.1.1 [Indirect] — npm: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+- rimraf 3.0.2 [Indirect] — npm: https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz
+    Notes: Rimraf versions prior to v4 are no longer supported
+- saxes 6.0.0 [Indirect] — npm: https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz
+- semver 6.3.1 [Indirect] — npm: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz
+- semver 7.7.2 [Indirect] — npm: https://registry.npmjs.org/semver/-/semver-7.7.2.tgz
+- siginfo 2.0.0 [Indirect] — npm: https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz
+- signal-exit 4.1.0 [Indirect] — npm: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+- test-exclude 6.0.0 [Indirect] — npm: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz
+- which 2.0.2 [Indirect] — npm: https://registry.npmjs.org/which/-/which-2.0.2.tgz
+- wrappy 1.0.2 [Indirect] — npm: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz
+- yaml 2.8.1 [Direct] — npm: https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz
+
+MIT
+---
+- @asamuzakjp/css-color 3.2.0 [Indirect] — npm: https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz
+- @babel/helper-string-parser 7.27.1 [Indirect] — npm: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz
+- @babel/helper-validator-identifier 7.27.1 [Indirect] — npm: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz
+- @babel/parser 7.28.4 [Indirect] — npm: https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz
+- @babel/types 7.28.4 [Indirect] — npm: https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz
+- @bcoe/v8-coverage 0.2.3 [Indirect] — npm: https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz
+- @cspotcode/source-map-support 0.8.1 [Indirect] — npm: https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz
+- @csstools/css-calc 2.1.4 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz
+- @csstools/css-color-parser 3.1.0 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz
+- @csstools/css-parser-algorithms 3.0.5 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz
+- @csstools/css-tokenizer 3.0.4 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz
+- @esbuild/aix-ppc64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz
+- @esbuild/aix-ppc64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz
+- @esbuild/android-arm 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz
+- @esbuild/android-arm 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz
+- @esbuild/android-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz
+- @esbuild/android-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz
+- @esbuild/android-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz
+- @esbuild/android-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz
+- @esbuild/darwin-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz
+- @esbuild/darwin-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz
+- @esbuild/darwin-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz
+- @esbuild/darwin-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz
+- @esbuild/freebsd-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz
+- @esbuild/freebsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz
+- @esbuild/freebsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz
+- @esbuild/freebsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz
+- @esbuild/linux-arm 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz
+- @esbuild/linux-arm 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz
+- @esbuild/linux-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz
+- @esbuild/linux-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz
+- @esbuild/linux-ia32 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz
+- @esbuild/linux-ia32 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz
+- @esbuild/linux-loong64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz
+- @esbuild/linux-loong64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz
+- @esbuild/linux-mips64el 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz
+- @esbuild/linux-mips64el 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz
+- @esbuild/linux-ppc64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz
+- @esbuild/linux-ppc64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz
+- @esbuild/linux-riscv64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz
+- @esbuild/linux-riscv64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz
+- @esbuild/linux-s390x 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz
+- @esbuild/linux-s390x 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz
+- @esbuild/linux-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz
+- @esbuild/linux-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz
+- @esbuild/netbsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz
+- @esbuild/netbsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz
+- @esbuild/netbsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz
+- @esbuild/openbsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz
+- @esbuild/openbsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz
+- @esbuild/openbsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz
+- @esbuild/openharmony-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz
+- @esbuild/sunos-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz
+- @esbuild/sunos-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz
+- @esbuild/win32-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz
+- @esbuild/win32-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz
+- @esbuild/win32-ia32 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz
+- @esbuild/win32-ia32 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz
+- @esbuild/win32-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz
+- @esbuild/win32-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz
+- @eslint-community/eslint-utils 4.9.0 [Indirect] — npm: https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz
+- @eslint-community/regexpp 4.12.1 [Indirect] — npm: https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz
+- @eslint/eslintrc 2.1.4 [Indirect] — npm: https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz
+- @eslint/js 8.57.1 [Indirect] — npm: https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz
+- @istanbuljs/schema 0.1.3 [Indirect] — npm: https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz
+- @jest/schemas 29.6.3 [Indirect] — npm: https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz
+- @jridgewell/gen-mapping 0.3.13 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz
+- @jridgewell/resolve-uri 3.1.2 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz
+- @jridgewell/sourcemap-codec 1.5.5 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz
+- @jridgewell/trace-mapping 0.3.30 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz
+- @jridgewell/trace-mapping 0.3.9 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz
+- @nodelib/fs.scandir 2.1.5 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+- @nodelib/fs.stat 2.0.5 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+- @nodelib/fs.walk 1.2.8 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+- @parcel/watcher 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz
+- @parcel/watcher-android-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz
+- @parcel/watcher-darwin-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz
+- @parcel/watcher-darwin-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz
+- @parcel/watcher-freebsd-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz
+- @parcel/watcher-linux-arm-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz
+- @parcel/watcher-linux-arm-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz
+- @parcel/watcher-linux-arm64-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz
+- @parcel/watcher-linux-arm64-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz
+- @parcel/watcher-linux-x64-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz
+- @parcel/watcher-linux-x64-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz
+- @parcel/watcher-win32-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz
+- @parcel/watcher-win32-ia32 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz
+- @parcel/watcher-win32-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz
+- @rollup/rollup-android-arm-eabi 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz
+- @rollup/rollup-android-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz
+- @rollup/rollup-darwin-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz
+- @rollup/rollup-darwin-x64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz
+- @rollup/rollup-freebsd-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz
+- @rollup/rollup-freebsd-x64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz
+- @rollup/rollup-linux-arm-gnueabihf 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz
+- @rollup/rollup-linux-arm-musleabihf 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz
+- @rollup/rollup-linux-arm64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-arm64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz
+- @rollup/rollup-linux-loongarch64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-ppc64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-riscv64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-riscv64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz
+- @rollup/rollup-linux-s390x-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz
+- @rollup/rollup-linux-x64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-x64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz
+- @rollup/rollup-openharmony-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz
+- @rollup/rollup-win32-arm64-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz
+- @rollup/rollup-win32-ia32-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz
+- @rollup/rollup-win32-x64-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz
+- @rtsao/scc 1.1.0 [Indirect] — npm: https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz
+- @sinclair/typebox 0.27.8 [Indirect] — npm: https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz
+- @tsconfig/node10 1.0.11 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz
+- @tsconfig/node12 1.0.11 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz
+- @tsconfig/node14 1.0.3 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz
+- @tsconfig/node16 1.0.4 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz
+- @types/better-sqlite3 7.6.13 [Direct] — npm: https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz
+- @types/estree 1.0.8 [Indirect] — npm: https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+- @types/jsdom 21.1.7 [Direct] — npm: https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz
+- @types/json5 0.0.29 [Indirect] — npm: https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz
+- @types/node 24.3.0 [Indirect] — npm: https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz
+- @types/tough-cookie 4.0.5 [Indirect] — npm: https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz
+- @typescript-eslint/eslint-plugin 8.44.0 [Direct] — npm: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz
+- @typescript-eslint/parser 8.44.0 [Direct] — npm: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz
+- @typescript-eslint/project-service 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz
+- @typescript-eslint/scope-manager 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz
+- @typescript-eslint/tsconfig-utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz
+- @typescript-eslint/type-utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz
+- @typescript-eslint/types 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz
+- @typescript-eslint/typescript-estree 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz
+- @typescript-eslint/utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz
+- @typescript-eslint/visitor-keys 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz
+- @vitest/coverage-v8 1.6.1 [Direct] — npm: https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz
+- @vitest/expect 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz
+- @vitest/runner 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz
+- @vitest/snapshot 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz
+- @vitest/spy 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz
+- @vitest/utils 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz
+- acorn 8.15.0 [Indirect] — npm: https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz
+- acorn-jsx 5.3.2 [Indirect] — npm: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+- acorn-walk 8.3.4 [Indirect] — npm: https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz
+- agent-base 7.1.4 [Indirect] — npm: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz
+- ajv 6.12.6 [Direct] — npm: https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+- ajv 8.17.1 [Direct] — npm: https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz
+- ajv-formats 3.0.1 [Direct] — npm: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz
+- ansi-regex 5.0.1 [Indirect] — npm: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+- ansi-styles 4.3.0 [Indirect] — npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+- ansi-styles 5.2.0 [Indirect] — npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz
+- arg 4.1.3 [Indirect] — npm: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz
+- array-buffer-byte-length 1.0.2 [Indirect] — npm: https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz
+- array-includes 3.1.9 [Indirect] — npm: https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz
+- array.prototype.findlastindex 1.2.6 [Indirect] — npm: https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz
+- array.prototype.flat 1.3.3 [Indirect] — npm: https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz
+- array.prototype.flatmap 1.3.3 [Indirect] — npm: https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz
+- arraybuffer.prototype.slice 1.0.4 [Indirect] — npm: https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz
+- ashpd 0.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- assertion-error 1.1.0 [Indirect] — npm: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
+- ast-types-flow 0.0.8 [Indirect] — npm: https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz
+- async-function 1.0.0 [Indirect] — npm: https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz
+- atk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atoi 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- available-typed-arrays 1.0.7 [Indirect] — npm: https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz
+- balanced-match 1.0.2 [Indirect] — npm: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+- base64-js 1.5.1 [Indirect] — npm: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz
+- better-sqlite3 12.2.0 [Direct] — npm: https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz
+- bindings 1.5.0 [Indirect] — npm: https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz
+- bl 4.1.0 [Indirect] — npm: https://registry.npmjs.org/bl/-/bl-4.1.0.tgz
+- block2 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- block2 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- brace-expansion 1.1.12 [Indirect] — npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz
+- brace-expansion 2.0.2 [Indirect] — npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz
+- braces 3.0.3 [Indirect] — npm: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+- buffer 5.7.1 [Indirect] — npm: https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz
+- buffer-builder 0.2.0 [Indirect] — npm: https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz
+    Notes: Upstream package declares "MIT/X11"; normalized to MIT for reporting.
+- bytes 1.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cac 6.7.14 [Indirect] — npm: https://registry.npmjs.org/cac/-/cac-6.7.14.tgz
+- cairo-rs 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cairo-sys-rs 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- call-bind 1.0.8 [Indirect] — npm: https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz
+- call-bind-apply-helpers 1.0.2 [Indirect] — npm: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz
+- call-bound 1.0.4 [Indirect] — npm: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz
+- callsites 3.1.0 [Indirect] — npm: https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+- cargo_metadata 0.19.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfb 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg_aliases 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chai 4.5.0 [Indirect] — npm: https://registry.npmjs.org/chai/-/chai-4.5.0.tgz
+- chalk 4.1.2 [Indirect] — npm: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+- check-error 1.0.3 [Indirect] — npm: https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz
+- chokidar 4.0.3 [Indirect] — npm: https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz
+- color-convert 2.0.1 [Indirect] — npm: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+- color-name 1.1.4 [Indirect] — npm: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+- colorjs.io 0.5.2 [Indirect] — npm: https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz
+- combine 4.6.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- concat-map 0.0.1 [Indirect] — npm: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+- confbox 0.1.8 [Indirect] — npm: https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz
+- convert_case 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- create-require 1.1.1 [Indirect] — npm: https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz
+- cross-spawn 7.0.6 [Indirect] — npm: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+- crunchy 0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cssstyle 4.6.0 [Indirect] — npm: https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz
+- darling 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- darling_core 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- darling_macro 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- data-urls 5.0.0 [Indirect] — npm: https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz
+- data-view-buffer 1.0.2 [Indirect] — npm: https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz
+- data-view-byte-length 1.0.2 [Indirect] — npm: https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz
+- data-view-byte-offset 1.0.1 [Indirect] — npm: https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz
+- debug 3.2.7 [Indirect] — npm: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz
+- debug 4.4.1 [Indirect] — npm: https://registry.npmjs.org/debug/-/debug-4.4.1.tgz
+- decimal.js 10.6.0 [Indirect] — npm: https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz
+- decompress-response 6.0.0 [Indirect] — npm: https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz
+- deep-eql 4.1.4 [Indirect] — npm: https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz
+- deep-extend 0.6.0 [Indirect] — npm: https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz
+- deep-is 0.1.4 [Indirect] — npm: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+- define-data-property 1.1.4 [Indirect] — npm: https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz
+- define-properties 1.2.1 [Indirect] — npm: https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz
+- derive_more 0.99.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- diff-sequences 29.6.3 [Indirect] — npm: https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz
+- difflib 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dispatch 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dlib 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dlopen2 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+    Notes: License file bundled with crate (MIT License).
+- dlopen2_derive 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+    Notes: License file bundled with crate (MIT License).
+- doc-comment 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dotenvy 0.15.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dunder-proto 1.0.1 [Indirect] — npm: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz
+- embed-resource 3.0.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- emoji-regex 9.2.2 [Indirect] — npm: https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz
+- end-of-stream 1.4.5 [Indirect] — npm: https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz
+- endi 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- es-abstract 1.24.0 [Indirect] — npm: https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz
+- es-define-property 1.0.1 [Indirect] — npm: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz
+- es-errors 1.3.0 [Indirect] — npm: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz
+- es-object-atoms 1.1.1 [Indirect] — npm: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz
+- es-set-tostringtag 2.1.0 [Indirect] — npm: https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz
+- es-shim-unscopables 1.1.0 [Indirect] — npm: https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz
+- es-to-primitive 1.3.0 [Indirect] — npm: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz
+- esbuild 0.21.5 [Indirect] — npm: https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz
+- esbuild 0.25.9 [Indirect] — npm: https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz
+- escape-string-regexp 4.0.0 [Indirect] — npm: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+- eslint 8.57.1 [Direct] — npm: https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz
+    Notes: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+- eslint-import-resolver-node 0.3.9 [Indirect] — npm: https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz
+- eslint-module-utils 2.12.1 [Indirect] — npm: https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz
+- eslint-plugin-import 2.32.0 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz
+- eslint-plugin-jsx-a11y 6.10.2 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz
+- eslint-plugin-unused-imports 4.2.0 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz
+- estree-walker 3.0.3 [Indirect] — npm: https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz
+- execa 8.0.1 [Indirect] — npm: https://registry.npmjs.org/execa/-/execa-8.0.1.tgz
+- fancy-regex 0.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fast-deep-equal 3.1.3 [Indirect] — npm: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+- fast-glob 3.3.3 [Indirect] — npm: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+- fast-json-stable-stringify 2.1.0 [Indirect] — npm: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+- fast-levenshtein 2.0.6 [Indirect] — npm: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+- fax 0.2.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fax_derive 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fdir 6.5.0 [Indirect] — npm: https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz
+- file-entry-cache 6.0.1 [Indirect] — npm: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz
+- file-rotate 0.7.6 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- file-uri-to-path 1.0.0 [Indirect] — npm: https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz
+- fill-range 7.1.1 [Indirect] — npm: https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+- find-up 5.0.0 [Indirect] — npm: https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+- flat-cache 3.2.0 [Indirect] — npm: https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz
+- for-each 0.3.5 [Indirect] — npm: https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz
+- fs-constants 1.0.0 [Indirect] — npm: https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz
+- fsevents 2.3.2 [Indirect] — npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz
+- fsevents 2.3.3 [Indirect] — npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz
+- function-bind 1.1.2 [Indirect] — npm: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz
+- function.prototype.name 1.1.8 [Indirect] — npm: https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz
+- functions-have-names 1.2.3 [Indirect] — npm: https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz
+- gdk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-pixbuf 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-pixbuf-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkwayland-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkx11 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkx11-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- generic-array 0.14.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- get-func-name 2.0.2 [Indirect] — npm: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz
+- get-intrinsic 1.3.0 [Indirect] — npm: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz
+- get-proto 1.0.1 [Indirect] — npm: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz
+- get-stream 8.0.1 [Indirect] — npm: https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz
+- get-symbol-description 1.1.0 [Indirect] — npm: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz
+- get-tsconfig 4.10.1 [Indirect] — npm: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz
+- gio 0.18.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gio-sys 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- github-from-package 0.0.0 [Indirect] — npm: https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz
+- glib 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glib-macros 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glib-sys 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- globals 13.24.0 [Indirect] — npm: https://registry.npmjs.org/globals/-/globals-13.24.0.tgz
+- globalthis 1.0.4 [Indirect] — npm: https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz
+- gobject-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gopd 1.2.0 [Indirect] — npm: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz
+- graphemer 1.4.0 [Indirect] — npm: https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz
+- gtk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gtk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gtk3-macros 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- h2 0.3.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- has-bigints 1.1.0 [Indirect] — npm: https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz
+- has-flag 4.0.0 [Indirect] — npm: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+- has-property-descriptors 1.0.2 [Indirect] — npm: https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz
+- has-proto 1.2.0 [Indirect] — npm: https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz
+- has-symbols 1.1.0 [Indirect] — npm: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz
+- has-tostringtag 1.0.2 [Indirect] — npm: https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz
+- hasown 2.0.2 [Indirect] — npm: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz
+- html-encoding-sniffer 4.0.0 [Indirect] — npm: https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz
+- html-escaper 2.0.2 [Indirect] — npm: https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz
+- http-body 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-body 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-body-util 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-proxy-agent 7.0.2 [Indirect] — npm: https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz
+- https-proxy-agent 7.0.6 [Indirect] — npm: https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz
+- hyper 0.14.32 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hyper 1.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hyper-util 0.1.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ico 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iconv-lite 0.6.3 [Indirect] — npm: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz
+- ignore 5.3.2 [Indirect] — npm: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+- ignore 7.0.5 [Indirect] — npm: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz
+- immutable 5.1.3 [Indirect] — npm: https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz
+- import-fresh 3.3.1 [Indirect] — npm: https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+- imurmurhash 0.1.4 [Indirect] — npm: https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+- include_dir 0.7.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- include_dir_macros 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- infer 0.19.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- internal-slot 1.1.0 [Indirect] — npm: https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz
+- is-array-buffer 3.0.5 [Indirect] — npm: https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz
+- is-async-function 2.1.1 [Indirect] — npm: https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz
+- is-bigint 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz
+- is-boolean-object 1.2.2 [Indirect] — npm: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz
+- is-callable 1.2.7 [Indirect] — npm: https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz
+- is-core-module 2.16.1 [Indirect] — npm: https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz
+- is-data-view 1.0.2 [Indirect] — npm: https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz
+- is-date-object 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz
+- is-docker 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- is-extglob 2.1.1 [Indirect] — npm: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+- is-finalizationregistry 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz
+- is-generator-function 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz
+- is-glob 4.0.3 [Indirect] — npm: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+- is-map 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz
+- is-negative-zero 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz
+- is-number 7.0.0 [Indirect] — npm: https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+- is-number-object 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz
+- is-path-inside 3.0.3 [Indirect] — npm: https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz
+- is-potential-custom-element-name 1.0.1 [Indirect] — npm: https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz
+- is-regex 1.2.1 [Indirect] — npm: https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz
+- is-set 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz
+- is-shared-array-buffer 1.0.4 [Indirect] — npm: https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz
+- is-stream 3.0.0 [Indirect] — npm: https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz
+- is-string 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz
+- is-symbol 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz
+- is-typed-array 1.1.15 [Indirect] — npm: https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz
+- is-weakmap 2.0.2 [Indirect] — npm: https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz
+- is-weakref 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz
+- is-weakset 2.0.4 [Indirect] — npm: https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz
+- is-wsl 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- isarray 2.0.5 [Indirect] — npm: https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz
+- iso8601 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- javascriptcore-rs 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- javascriptcore-rs-sys 1.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- js-tokens 9.0.1 [Indirect] — npm: https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz
+- js-yaml 4.1.0 [Indirect] — npm: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz
+- jsdom 26.1.0 [Direct] — npm: https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz
+- json-buffer 3.0.1 [Indirect] — npm: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+- json-schema-traverse 0.4.1 [Indirect] — npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+- json-schema-traverse 1.0.0 [Indirect] — npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz
+- json-stable-stringify-without-jsonify 1.0.1 [Indirect] — npm: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+- json5 1.0.2 [Indirect] — npm: https://registry.npmjs.org/json5/-/json5-1.0.2.tgz
+- json5 2.2.3 [Indirect] — npm: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz
+- jsonschema 0.17.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jsx-ast-utils 3.3.5 [Indirect] — npm: https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz
+- keyv 4.5.4 [Indirect] — npm: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+- kuchikiki 0.8.8-speedreader [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- language-tags 1.0.9 [Indirect] — npm: https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz
+- levn 0.4.1 [Indirect] — npm: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+- libm 0.2.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libredox 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libsqlite3-sys 0.30.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- local-pkg 0.5.1 [Indirect] — npm: https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz
+- locate-path 6.0.0 [Indirect] — npm: https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+- lodash.merge 4.6.2 [Indirect] — npm: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+- loupe 2.3.7 [Indirect] — npm: https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz
+- mac-notification-sys 0.6.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- magic-string 0.30.19 [Indirect] — npm: https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz
+- magicast 0.3.5 [Indirect] — npm: https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz
+- make-dir 4.0.0 [Indirect] — npm: https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz
+- matchers 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- matches 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- math-intrinsics 1.1.0 [Indirect] — npm: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz
+- memoffset 0.9.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- merge-stream 2.0.0 [Indirect] — npm: https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz
+- merge2 1.4.1 [Indirect] — npm: https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+- micromatch 4.0.8 [Indirect] — npm: https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+- mimic-fn 4.0.0 [Indirect] — npm: https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz
+- mimic-response 3.1.0 [Indirect] — npm: https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz
+- minimist 1.2.8 [Indirect] — npm: https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz
+- mio 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mkdirp-classic 0.5.3 [Indirect] — npm: https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz
+- mlly 1.8.0 [Indirect] — npm: https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz
+- ms 2.1.3 [Indirect] — npm: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+- nanoid 3.3.11 [Indirect] — npm: https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz
+- napi-build-utils 2.0.0 [Indirect] — npm: https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz
+- natural-compare 1.4.0 [Indirect] — npm: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+- new_debug_unreachable 1.0.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nix 0.30.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- node-abi 3.75.0 [Indirect] — npm: https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz
+- node-addon-api 7.1.1 [Indirect] — npm: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz
+- nom 7.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nom 8.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- npm-run-path 5.3.0 [Indirect] — npm: https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz
+- nu-ansi-term 0.50.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nwsapi 2.2.22 [Indirect] — npm: https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz
+- objc-sys 0.3.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2 0.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-encode 4.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-foundation 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-foundation 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-metal 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-quartz-core 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- object-inspect 1.13.4 [Indirect] — npm: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz
+- object-keys 1.1.1 [Indirect] — npm: https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz
+- object.assign 4.1.7 [Indirect] — npm: https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz
+- object.fromentries 2.0.8 [Indirect] — npm: https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz
+- object.groupby 1.0.3 [Indirect] — npm: https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz
+- object.values 1.2.1 [Indirect] — npm: https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz
+- onetime 6.0.0 [Indirect] — npm: https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz
+- open 5.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- optionator 0.9.4 [Indirect] — npm: https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+- os_pipe 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- own-keys 1.0.1 [Indirect] — npm: https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz
+- p-limit 3.1.0 [Indirect] — npm: https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+- p-limit 5.0.0 [Indirect] — npm: https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz
+- p-locate 5.0.0 [Indirect] — npm: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+- pango 0.18.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pango-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parent-module 1.0.1 [Indirect] — npm: https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+- parse5 7.3.0 [Indirect] — npm: https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz
+- path-exists 4.0.0 [Indirect] — npm: https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+- path-is-absolute 1.0.1 [Indirect] — npm: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz
+- path-key 3.1.1 [Indirect] — npm: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+- path-key 4.0.0 [Indirect] — npm: https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz
+- path-parse 1.0.7 [Indirect] — npm: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz
+- pathe 1.1.2 [Indirect] — npm: https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz
+- pathe 2.0.3 [Indirect] — npm: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz
+- pathval 1.1.1 [Indirect] — npm: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
+- phf 0.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_codegen 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_codegen 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_macros 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_macros 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- picomatch 2.3.1 [Indirect] — npm: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz
+- picomatch 4.0.3 [Indirect] — npm: https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz
+- pkg-types 1.3.1 [Indirect] — npm: https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz
+- plist 1.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- possible-typed-array-names 1.1.0 [Indirect] — npm: https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz
+- postcss 8.5.6 [Indirect] — npm: https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz
+- prebuild-install 7.1.3 [Indirect] — npm: https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz
+- precomputed-hash 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- prelude-ls 1.2.1 [Indirect] — npm: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+- pretty-format 29.7.0 [Indirect] — npm: https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz
+- pump 3.0.3 [Indirect] — npm: https://registry.npmjs.org/pump/-/pump-3.0.3.tgz
+- punycode 2.3.1 [Indirect] — npm: https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+- queue-microtask 1.2.3 [Indirect] — npm: https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+- quick-xml 0.37.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quick-xml 0.38.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- react-is 18.3.1 [Indirect] — npm: https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz
+- readable-stream 3.6.2 [Indirect] — npm: https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz
+- readdirp 4.1.2 [Indirect] — npm: https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz
+- redox_syscall 0.5.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- redox_users 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- redox_users 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reflect.getprototypeof 1.0.10 [Indirect] — npm: https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz
+- regexp-tree 0.1.27 [Indirect] — npm: https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz
+- regexp.prototype.flags 1.5.4 [Indirect] — npm: https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz
+- require-from-string 2.0.2 [Indirect] — npm: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz
+- resolve 1.22.10 [Indirect] — npm: https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz
+- resolve-from 4.0.0 [Indirect] — npm: https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+- resolve-pkg-maps 1.0.0 [Indirect] — npm: https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz
+- reusify 1.1.0 [Indirect] — npm: https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+- rfd 0.15.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rollup 4.50.0 [Indirect] — npm: https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz
+- rrweb-cssom 0.8.0 [Indirect] — npm: https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz
+- run-parallel 1.2.0 [Indirect] — npm: https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+- rusqlite 0.32.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- safe-array-concat 1.1.3 [Indirect] — npm: https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz
+- safe-buffer 5.2.1 [Indirect] — npm: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz
+- safe-push-apply 1.0.0 [Indirect] — npm: https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz
+- safe-regex 2.1.1 [Indirect] — npm: https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz
+- safe-regex-test 1.1.0 [Indirect] — npm: https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz
+- safer-buffer 2.1.2 [Indirect] — npm: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+- sass 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass/-/sass-1.91.0.tgz
+- sass-embedded 1.91.0 [Direct] — npm: https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz
+- sass-embedded-all-unknown 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz
+- sass-embedded-android-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz
+- sass-embedded-android-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz
+- sass-embedded-android-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz
+- sass-embedded-android-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz
+- sass-embedded-darwin-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz
+- sass-embedded-darwin-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz
+- sass-embedded-linux-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz
+- sass-embedded-linux-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz
+- sass-embedded-linux-musl-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz
+- sass-embedded-linux-musl-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz
+- sass-embedded-linux-musl-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz
+- sass-embedded-linux-musl-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz
+- sass-embedded-linux-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz
+- sass-embedded-linux-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz
+- sass-embedded-unknown-all 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz
+- sass-embedded-win32-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz
+- sass-embedded-win32-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz
+- schemars 0.8.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars_derive 0.8.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- set-function-length 1.2.2 [Indirect] — npm: https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz
+- set-function-name 2.0.2 [Indirect] — npm: https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz
+- set-proto 1.0.0 [Indirect] — npm: https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz
+- sharded-slab 0.1.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- shebang-command 2.0.0 [Indirect] — npm: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+- shebang-regex 3.0.0 [Indirect] — npm: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+- side-channel 1.1.0 [Indirect] — npm: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz
+- side-channel-list 1.0.0 [Indirect] — npm: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz
+- side-channel-map 1.0.1 [Indirect] — npm: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz
+- side-channel-weakmap 1.0.2 [Indirect] — npm: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz
+- simd-adler32 0.3.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- simple-concat 1.0.1 [Indirect] — npm: https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz
+- simple-get 4.0.1 [Indirect] — npm: https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz
+- slab 0.4.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- soup3 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- soup3-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- spdx-expression-parse 4.0.0 [Direct] — npm: https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz
+- spin 0.9.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stackback 0.0.2 [Indirect] — npm: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz
+- std-env 3.9.0 [Indirect] — npm: https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz
+- stop-iteration-iterator 1.1.0 [Indirect] — npm: https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz
+- string_decoder 1.3.0 [Indirect] — npm: https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz
+- string.prototype.includes 2.0.1 [Indirect] — npm: https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz
+- string.prototype.trim 1.2.10 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz
+- string.prototype.trimend 1.0.9 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz
+- string.prototype.trimstart 1.0.8 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz
+- strip-ansi 6.0.1 [Indirect] — npm: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+- strip-bom 3.0.0 [Indirect] — npm: https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+- strip-final-newline 3.0.0 [Indirect] — npm: https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz
+- strip-json-comments 2.0.1 [Indirect] — npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz
+- strip-json-comments 3.1.1 [Indirect] — npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+- strip-literal 2.1.1 [Indirect] — npm: https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz
+- strsim 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- supports-color 7.2.0 [Indirect] — npm: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+- supports-color 8.1.1 [Indirect] — npm: https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz
+- supports-preserve-symlinks-flag 1.0.0 [Indirect] — npm: https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz
+- symbol-tree 3.2.4 [Indirect] — npm: https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz
+- sync-child-process 1.0.2 [Indirect] — npm: https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz
+- sync-message-port 1.1.3 [Indirect] — npm: https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz
+- synstructure 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tar-fs 2.1.3 [Indirect] — npm: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz
+- tar-stream 2.2.0 [Indirect] — npm: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz
+- tauri-winres 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- termtree 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- text-table 0.2.0 [Indirect] — npm: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz
+- tiff 0.10.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinybench 2.9.0 [Indirect] — npm: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz
+- tinyglobby 0.2.14 [Indirect] — npm: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz
+- tinypool 0.8.4 [Indirect] — npm: https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz
+- tinyspy 2.2.1 [Indirect] — npm: https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz
+- tldts 6.1.86 [Indirect] — npm: https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz
+- tldts-core 6.1.86 [Indirect] — npm: https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz
+- to-regex-range 5.0.1 [Indirect] — npm: https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+- tokio 1.47.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-macros 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-stream 0.1.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-util 0.7.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-http 0.6.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-layer 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-service 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tr46 5.1.1 [Indirect] — npm: https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz
+- tracing 0.1.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-appender 0.2.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-attributes 0.1.30 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-core 0.1.34 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-log 0.2.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-serde 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-subscriber 0.3.20 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tree_magic_mini 3.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- try-lock 0.2.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ts-api-utils 2.1.0 [Indirect] — npm: https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz
+- ts-node 10.9.2 [Direct] — npm: https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz
+- ts-rs 10.1.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ts-rs-macros 10.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tsconfig-paths 3.15.0 [Direct] — npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz
+- tsconfig-paths 4.2.0 [Direct] — npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz
+- tsx 4.20.5 [Direct] — npm: https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz
+- type-check 0.4.0 [Indirect] — npm: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+- type-detect 4.1.0 [Indirect] — npm: https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz
+- typed-array-buffer 1.0.3 [Indirect] — npm: https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz
+- typed-array-byte-length 1.0.3 [Indirect] — npm: https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz
+- typed-array-byte-offset 1.0.4 [Indirect] — npm: https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz
+- typed-array-length 1.0.7 [Indirect] — npm: https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz
+- uds_windows 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ufo 1.6.1 [Indirect] — npm: https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz
+- unbox-primitive 1.1.0 [Indirect] — npm: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz
+- undici-types 7.10.0 [Indirect] — npm: https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz
+- urlpattern 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- util-deprecate 1.0.2 [Indirect] — npm: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz
+- v8-compile-cache-lib 3.0.1 [Indirect] — npm: https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz
+- valuable 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- varint 6.0.0 [Indirect] — npm: https://registry.npmjs.org/varint/-/varint-6.0.0.tgz
+- version-compare 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vite 5.4.20 [Direct] — npm: https://registry.npmjs.org/vite/-/vite-5.4.20.tgz
+- vite 6.3.5 [Direct] — npm: https://registry.npmjs.org/vite/-/vite-6.3.5.tgz
+- vite-node 1.6.1 [Indirect] — npm: https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz
+- vitest 1.6.1 [Direct] — npm: https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz
+- vswhom 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vswhom-sys 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- w3c-xmlserializer 5.0.0 [Indirect] — npm: https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz
+- want 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-backend 0.3.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-client 0.31.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-protocols 0.32.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-protocols-wlr 0.3.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-scanner 0.31.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-sys 0.31.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webkit2gtk 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webkit2gtk-sys 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com 0.38.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com-macros 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com-sys 0.38.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- whatwg-encoding 3.1.1 [Indirect] — npm: https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz
+- whatwg-mimetype 4.0.0 [Indirect] — npm: https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz
+- whatwg-url 14.2.0 [Indirect] — npm: https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz
+- which-boxed-primitive 1.1.1 [Indirect] — npm: https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz
+- which-builtin-type 1.2.1 [Indirect] — npm: https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz
+- which-collection 1.0.2 [Indirect] — npm: https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz
+- which-typed-array 1.1.19 [Indirect] — npm: https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz
+- why-is-node-running 2.3.0 [Indirect] — npm: https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz
+- winnow 0.5.40 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winnow 0.7.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winreg 0.50.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winreg 0.55.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- word-wrap 1.2.5 [Indirect] — npm: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+- ws 8.18.3 [Indirect] — npm: https://registry.npmjs.org/ws/-/ws-8.18.3.tgz
+- x11 2.21.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11-dl 2.21.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- xmlchars 2.2.0 [Indirect] — npm: https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz
+- yn 3.1.1 [Indirect] — npm: https://registry.npmjs.org/yn/-/yn-3.1.1.tgz
+- yocto-queue 0.1.0 [Indirect] — npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+- yocto-queue 1.2.1 [Indirect] — npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz
+- zbus 5.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zbus_macros 5.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zbus_names 4.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant 5.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant_derive 5.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant_utils 3.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+MIT OR Unlicense
+----------------
+- aho-corasick 1.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- byteorder 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- byteorder-lite 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- memchr 2.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- same-file 1.0.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- termcolor 1.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- walkdir 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-util 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+MIT OR WTFPL
+------------
+- expand-template 2.0.3 [Indirect] — npm: https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz
+
+MIT-0
+-----
+- @csstools/color-helpers 5.1.0 [Indirect] — npm: https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz
+
+MPL-2.0
+-------
+- @axe-core/playwright 4.10.2 [Direct] — npm: https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz
+- axe-core 4.10.3 [Indirect] — npm: https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz
+- cssparser 0.29.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cssparser-macros 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dtoa-short 0.3.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- option-ext 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- selectors 0.24.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Python-2.0
+----------
+- argparse 2.0.1 [Indirect] — npm: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+
+Unicode-3.0
+-----------
+- icu_collections 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_locale_core 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_normalizer 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_normalizer_data 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_properties 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_properties_data 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_provider 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- litemap 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- potential_utf 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinystr 0.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- writeable 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- yoke 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- yoke-derive 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerofrom 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerofrom-derive 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerotrie 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerovec 0.11.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerovec-derive 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Zlib
+----
+- foldhash 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Fonts and Icons
+---------------
+
+Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+"Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+
+Questions & Contact
+-------------------
+
+For questions about licensing or attribution, contact the Arklowdun team at compliance@arklowdun.local.
+
+--
+Generated automatically; refresh with "npm run generate:notice" whenever dependencies change.

--- a/src-tauri/resources/licenses/NOTICE.txt
+++ b/src-tauri/resources/licenses/NOTICE.txt
@@ -1,0 +1,1405 @@
+NOTICE
+======
+
+Generated from Arklowdun's consolidated licensing inventory.
+
+Third-Party Components
+----------------------
+
+0BSD
+----
+- tslib 2.8.1 [Indirect] — npm: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz
+
+0BSD OR Apache-2.0 OR MIT
+-------------------------
+- adler2 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0
+----------
+- @ampproject/remapping 2.3.0 [Indirect] — npm: https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz
+- @humanwhocodes/config-array 0.13.0 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz
+    Notes: Use @eslint/config-array instead
+- @humanwhocodes/module-importer 1.0.1 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz
+- @playwright/test 1.55.0 [Direct] — npm: https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz
+- aria-query 5.3.2 [Indirect] — npm: https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz
+- axobject-query 4.1.0 [Indirect] — npm: https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz
+- detect-libc 1.0.3 [Indirect] — npm: https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz
+- detect-libc 2.0.4 [Indirect] — npm: https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz
+- doctrine 2.1.0 [Indirect] — npm: https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz
+- doctrine 3.0.0 [Indirect] — npm: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz
+- eslint-plugin-security 2.1.1 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz
+- eslint-visitor-keys 3.4.3 [Indirect] — npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz
+- eslint-visitor-keys 4.2.1 [Indirect] — npm: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz
+- gethostname 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- human-signals 5.0.0 [Indirect] — npm: https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz
+- playwright 1.55.0 [Indirect] — npm: https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz
+- playwright-core 1.55.0 [Indirect] — npm: https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz
+- rxjs 7.8.2 [Indirect] — npm: https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz
+- similar 2.7.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sync_wrapper 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sync_wrapper 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tao 0.34.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tunnel-agent 0.6.0 [Indirect] — npm: https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz
+- typescript 5.9.2 [Direct] — npm: https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz
+- xml-name-validator 5.0.0 [Indirect] — npm: https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz
+
+Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
+---------------------------------------------------
+- linux-raw-sys 0.4.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- linux-raw-sys 0.9.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustix 0.38.44 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustix 1.0.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.11.1+wasi-snapshot-preview1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.14.3+wasi-0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasi 0.9.0+wasi-snapshot-preview1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wit-bindgen 0.45.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-2-Clause OR MIT
+---------------------------------
+- rc 1.2.8 [Indirect] — npm: https://registry.npmjs.org/rc/-/rc-1.2.8.tgz
+- zerocopy 0.8.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerocopy-derive 0.8.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-3-Clause
+--------------------------
+- @bufbuild/protobuf 2.7.0 [Indirect] — npm: https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz
+- moxcms 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pxfm 0.1.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSD-3-Clause OR MIT
+---------------------------------
+- encoding_rs 0.8.35 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num_enum 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num_enum_derive 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSL-1.0
+---------------------
+- ryu 1.0.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR BSL-1.0 OR MIT
+----------------------------
+- wasite 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- whoami 1.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR CC0-1.0 OR MIT-0
+------------------------------
+- dunce 1.0.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR LGPL-2.1-or-later OR MIT
+--------------------------------------
+- r-efi 5.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT
+-----------------
+- @tauri-apps/api 2.8.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz
+- @tauri-apps/cli 2.8.3 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.3.tgz
+- @tauri-apps/cli-darwin-arm64 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.3.tgz
+- @tauri-apps/cli-darwin-x64 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.3.tgz
+- @tauri-apps/cli-linux-arm-gnueabihf 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.3.tgz
+- @tauri-apps/cli-linux-arm64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-arm64-musl 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.3.tgz
+- @tauri-apps/cli-linux-riscv64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-x64-gnu 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.3.tgz
+- @tauri-apps/cli-linux-x64-musl 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.3.tgz
+- @tauri-apps/cli-win32-arm64-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.3.tgz
+- @tauri-apps/cli-win32-ia32-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.3.tgz
+- @tauri-apps/cli-win32-x64-msvc 2.8.3 [Indirect] — npm: https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.3.tgz
+- @tauri-apps/plugin-clipboard-manager 2.3.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.0.tgz
+- @tauri-apps/plugin-dialog 2.3.3 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.3.3.tgz
+- @tauri-apps/plugin-fs 2.4.2 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz
+- @tauri-apps/plugin-notification 2.3.1 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.1.tgz
+- @tauri-apps/plugin-opener 2.5.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.0.tgz
+- @tauri-apps/plugin-sql 2.3.0 [Direct] — npm: https://registry.npmjs.org/@tauri-apps/plugin-sql/-/plugin-sql-2.3.0.tgz
+- addr2line 0.24.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ahash 0.8.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- allocator-api2 0.2.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- android_system_properties 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- android-tzdata 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstream 0.6.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle 1.0.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-parse 0.2.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-query 1.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anstyle-wincon 3.0.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- anyhow 1.0.99 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- arboard 3.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- assert_cmd 2.0.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-broadcast 0.7.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-channel 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-executor 1.13.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-io 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-lock 3.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-process 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-recursion 1.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-signal 0.2.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-task 4.7.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- async-trait 0.1.89 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atomic-waker 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- autocfg 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- backtrace 0.3.75 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64 0.21.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64 0.22.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- base64ct 1.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bit-set 0.5.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bit-vec 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bitflags 1.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bitflags 2.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- block-buffer 0.10.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- blocking 1.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bstr 1.12.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bumpalo 3.19.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- bytecount 0.6.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- camino 1.1.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cargo_toml 0.22.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cargo-platform 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cc 1.2.34 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cesu8 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg-expr 0.15.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg-if 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chrono 0.4.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chrono-tz 0.10.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap 4.5.47 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_builder 4.5.47 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_derive 4.5.47 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- clap_lex 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- colorchoice 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- concurrent-queue 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- const-oid 0.9.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cookie 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation 0.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation 0.9.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-foundation-sys 0.8.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-graphics 0.24.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- core-graphics-types 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cpufeatures 0.2.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc 3.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc-catalog 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crc32fast 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-channel 0.5.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-queue 0.3.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crossbeam-utils 0.8.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- crypto-common 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ctor 0.2.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- der 0.7.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- deranged 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- digest 0.10.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs 5.0.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs 6.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs-sys 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dirs-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- displaydoc 0.2.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- downcast-rs 1.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dpi 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dtoa 1.0.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dyn-clone 1.0.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- either 1.15.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- embed_plist 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- enumflags2 0.7.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- enumflags2_derive 0.7.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- equivalent 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- erased-serde 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- errno 0.3.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- etcetera 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- event-listener 5.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- event-listener-strategy 0.5.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fallible-iterator 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fallible-streaming-iterator 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fastrand 2.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fdeflate 0.3.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- field-offset 0.3.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fixedbitset 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- flate2 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- flume 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fnv 1.0.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types-macros 0.2.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- foreign-types-shared 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- form_urlencoded 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fraction 0.13.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fs2 0.4.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futf 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures 0.3.31 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-channel 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-core 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-executor 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-intrusive 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-io 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-lite 2.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-macro 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-sink 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-task 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- futures-util 0.3.31 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fxhash 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.1.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.2.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- getrandom 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gimli 0.31.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glob 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- half 2.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.12.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.14.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashbrown 0.15.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashlink 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hashlink 0.9.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- heck 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- heck 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hermit-abi 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hex 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hkdf 0.12.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hmac 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- home 0.5.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- html5ever 0.29.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http 0.2.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http 1.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- httparse 1.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- httpdate 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iana-time-zone 0.1.63 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iana-time-zone-haiku 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ident_case 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- idna 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- idna_adapter 1.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- image 0.25.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- indexmap 1.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- indexmap 2.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- io-uring 0.7.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ipnet 2.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iri-string 0.7.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- is_terminal_polyfill 1.70.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- itoa 1.0.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jni 0.21.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jni-sys 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- js-sys 0.3.77 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- json-patch 3.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jsonptr 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- keyboard-types 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lazy_static 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libappindicator 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libappindicator-sys 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libc 0.2.175 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lock_api 0.4.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- log 0.4.27 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mac 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- markup5ever 0.14.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- match_token 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- md-5 0.10.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mime 0.3.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- minimal-lexical 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- muda 0.17.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk-context 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ndk-sys 0.6.0+11769913 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nodrop 0.1.14 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- notify-rust 4.11.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-bigint 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-bigint-dig 0.8.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-cmp 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-complex 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-conv 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-integer 0.1.46 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-iter 0.1.45 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-rational 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- num-traits 0.2.19 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- object 0.36.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- once_cell 1.21.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- once_cell_polyfill 1.70.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ordered-stream 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking 2.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking_lot 0.12.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parking_lot_core 0.9.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- paste 1.0.15 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pathdiff 0.2.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pem-rfc7468 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- percent-encoding 2.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_derive 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_generator 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pest_meta 2.8.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- petgraph 0.6.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pin-project-lite 0.2.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pin-utils 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- piper 0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkcs1 0.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkcs8 0.10.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pkg-config 0.3.32 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- png 0.17.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- png 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- polling 3.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- powerfmt 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ppv-lite86 0.2.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates 3.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates-core 1.0.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- predicates-tree 1.0.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 1.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-crate 3.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-error 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-error-attr 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro-hack 0.5.20+deprecated [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- proc-macro2 1.0.101 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quick-error 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quote 1.0.40 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.8.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand 0.9.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_chacha 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.6.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_core 0.9.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_hc 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rand_pcg 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ref-cast 1.0.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ref-cast-impl 1.0.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex 1.11.2 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex-automata 0.4.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- regex-syntax 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reqwest 0.11.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reqwest 0.12.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rrule 0.14.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rsa 0.9.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustc_version 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustc-demangle 0.1.26 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rustversion 1.0.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- scoped-tls 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- scopeguard 1.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- semver 1.0.26 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde 1.0.219 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_derive 1.0.219 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_derive_internals 0.29.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_json 1.0.143 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_repr 0.1.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_spanned 0.6.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_spanned 1.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_urlencoded 0.7.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_with 3.14.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde_with_macros 3.14.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serde-untagged 0.1.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serialize-to-javascript 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- serialize-to-javascript-impl 0.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- servo_arc 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sha1 0.10.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sha2 0.10.9 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- shlex 1.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- signal-hook-registry 1.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- signature 2.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- siphasher 0.3.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- siphasher 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- smallvec 1.15.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- socket2 0.5.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- socket2 0.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- softbuffer 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- spki 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx 0.8.6 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-core 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-macros 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-macros-core 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-mysql 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-postgres 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- sqlx-sqlite 0.8.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stable_deref_trait 1.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- static_assertions 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- string_cache 0.8.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- string_cache_codegen 0.5.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stringprep 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- swift-rs 1.0.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- syn 1.0.109 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- syn 2.0.106 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-configuration 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-configuration-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- system-deps 6.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tao-macros 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri 2.8.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-build 2.4.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-codegen 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-macros 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin 2.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-clipboard-manager 2.3.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-dialog 2.3.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-fs 2.4.2 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-notification 2.3.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-opener 2.5.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-plugin-sql 2.3.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-runtime 2.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-runtime-wry 2.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-utils 2.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tauri-winrt-notification 0.7.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tempfile 3.21.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tendril 0.4.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror 1.0.69 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror 2.0.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror-impl 1.0.69 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thiserror-impl 2.0.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- thread_local 1.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time 0.3.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time-core 0.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- time-macros 0.2.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml 0.8.23 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml 0.9.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_datetime 0.6.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_datetime 0.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.19.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.20.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_edit 0.22.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_parser 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- toml_writer 1.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tray-icon 0.21.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- typeid 1.0.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- typenum 1.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ucd-trie 0.1.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-char-property 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-char-range 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-common 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-ucd-ident 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unic-ucd-version 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-bidi 0.3.18 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-normalization 0.1.24 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-properties 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- unicode-segmentation 1.12.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- url 2.5.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf-8 0.7.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf8_iter 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- utf8parse 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- uuid 1.18.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vcpkg 0.2.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- version_check 0.9.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wait-timeout 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-backend 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-futures 0.4.50 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-macro 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-macro-support 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-bindgen-shared 0.2.100 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wasm-streams 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- web-sys 0.3.77 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- weezl 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi 0.3.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-i686-pc-windows-gnu 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-x86_64-pc-windows-gnu 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- window-vibrancy 0.6.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows 0.61.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_aarch64_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnu 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_i686_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnu 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_gnullvm 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows_x86_64_msvc 0.53.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-collections 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-core 0.61.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-future 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-implement 0.60.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-interface 0.59.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-link 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-numerics 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-result 0.3.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-strings 0.4.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.45.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.48.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.52.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.59.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-sys 0.60.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.42.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.48.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.52.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-targets 0.53.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-threading 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- windows-version 0.1.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wl-clipboard-rs 0.9.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wry 0.53.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11rb 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11rb-protocol 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zeroize 1.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT OR Unicode-3.0
+--------------------------------
+- unicode-ident 1.0.18 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 OR MIT OR Zlib
+-------------------------
+- bytemuck 1.23.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dispatch2 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- miniz_oxide 0.8.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-app-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-cloud-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-data 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-foundation 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-graphics 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-core-image 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-exception-helper 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-io-surface 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-javascript-core 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-quartz-core 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-security 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-ui-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-web-kit 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- raw-window-handle 0.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinyvec 1.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinyvec_macros 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zune-core 0.4.12 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zune-jpeg 0.4.21 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Apache-2.0 WITH LLVM-exception
+------------------------------
+- target-lexicon 0.12.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+BSD-2-Clause
+------------
+- damerau-levenshtein 1.0.8 [Indirect] — npm: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz
+- entities 6.0.1 [Indirect] — npm: https://registry.npmjs.org/entities/-/entities-6.0.1.tgz
+- eslint-scope 7.2.2 [Indirect] — npm: https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz
+- espree 9.6.1 [Indirect] — npm: https://registry.npmjs.org/espree/-/espree-9.6.1.tgz
+- esrecurse 4.3.0 [Indirect] — npm: https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz
+- estraverse 5.3.0 [Indirect] — npm: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz
+- esutils 2.0.3 [Indirect] — npm: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz
+- uri-js 4.4.1 [Indirect] — npm: https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz
+- webidl-conversions 7.0.0 [Indirect] — npm: https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz
+
+BSD-3-Clause
+------------
+- @humanwhocodes/object-schema 2.0.3 [Indirect] — npm: https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz
+    Notes: Use @eslint/object-schema instead
+- alloc-no-stdlib 2.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- alloc-stdlib 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- diff 4.0.2 [Indirect] — npm: https://registry.npmjs.org/diff/-/diff-4.0.2.tgz
+- esquery 1.6.0 [Indirect] — npm: https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz
+- fast-uri 3.1.0 [Indirect] — npm: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz
+- ieee754 1.2.1 [Indirect] — npm: https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz
+- istanbul-lib-coverage 3.2.2 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz
+- istanbul-lib-report 3.0.1 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz
+- istanbul-lib-source-maps 5.0.6 [Indirect] — npm: https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz
+- istanbul-reports 3.2.0 [Indirect] — npm: https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz
+- source-map-js 1.2.1 [Indirect] — npm: https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz
+- subtle 2.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tough-cookie 5.1.2 [Indirect] — npm: https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz
+
+BSD-3-Clause OR MIT
+-------------------
+- brotli 8.0.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- brotli-decompressor 5.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+BSL-1.0
+-------
+- clipboard-win 5.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- error-code 3.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+CC-BY-3.0
+---------
+- spdx-exceptions 2.5.0 [Indirect] — npm: https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz
+
+CC-BY-4.0 OR MIT OR OFL-1.1
+---------------------------
+- @fortawesome/fontawesome-free 6.7.2 [Direct] — npm: https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz
+
+CC0-1.0
+-------
+- language-subtag-registry 0.3.23 [Indirect] — npm: https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz
+- spdx-license-ids 3.0.22 [Indirect] — npm: https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz
+
+CC0-1.0 OR MIT
+--------------
+- type-fest 0.20.2 [Indirect] — npm: https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz
+
+ISC
+---
+- @iarna/toml 2.2.5 [Direct] — npm: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz
+- @ungap/structured-clone 1.3.0 [Indirect] — npm: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz
+- chownr 1.1.4 [Indirect] — npm: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz
+- fastq 1.19.1 [Indirect] — npm: https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz
+- flatted 3.3.3 [Indirect] — npm: https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz
+- fs.realpath 1.0.0 [Indirect] — npm: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz
+- glob 7.2.3 [Indirect] — npm: https://registry.npmjs.org/glob/-/glob-7.2.3.tgz
+    Notes: Glob versions prior to v9 are no longer supported
+- glob-parent 5.1.2 [Indirect] — npm: https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz
+- glob-parent 6.0.2 [Indirect] — npm: https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz
+- inflight 1.0.6 [Indirect] — npm: https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz
+    Notes: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+- inherits 2.0.4 [Indirect] — npm: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz
+- ini 1.3.8 [Indirect] — npm: https://registry.npmjs.org/ini/-/ini-1.3.8.tgz
+- isexe 2.0.0 [Indirect] — npm: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz
+- json5 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libloading 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- lru-cache 10.4.3 [Indirect] — npm: https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz
+- make-error 1.3.6 [Indirect] — npm: https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz
+- minimatch 3.1.2 [Indirect] — npm: https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz
+- minimatch 9.0.5 [Indirect] — npm: https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz
+- once 1.4.0 [Indirect] — npm: https://registry.npmjs.org/once/-/once-1.4.0.tgz
+- picocolors 1.1.1 [Indirect] — npm: https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz
+- rimraf 3.0.2 [Indirect] — npm: https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz
+    Notes: Rimraf versions prior to v4 are no longer supported
+- saxes 6.0.0 [Indirect] — npm: https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz
+- semver 6.3.1 [Indirect] — npm: https://registry.npmjs.org/semver/-/semver-6.3.1.tgz
+- semver 7.7.2 [Indirect] — npm: https://registry.npmjs.org/semver/-/semver-7.7.2.tgz
+- siginfo 2.0.0 [Indirect] — npm: https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz
+- signal-exit 4.1.0 [Indirect] — npm: https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz
+- test-exclude 6.0.0 [Indirect] — npm: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz
+- which 2.0.2 [Indirect] — npm: https://registry.npmjs.org/which/-/which-2.0.2.tgz
+- wrappy 1.0.2 [Indirect] — npm: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz
+- yaml 2.8.1 [Direct] — npm: https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz
+
+MIT
+---
+- @asamuzakjp/css-color 3.2.0 [Indirect] — npm: https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz
+- @babel/helper-string-parser 7.27.1 [Indirect] — npm: https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz
+- @babel/helper-validator-identifier 7.27.1 [Indirect] — npm: https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz
+- @babel/parser 7.28.4 [Indirect] — npm: https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz
+- @babel/types 7.28.4 [Indirect] — npm: https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz
+- @bcoe/v8-coverage 0.2.3 [Indirect] — npm: https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz
+- @cspotcode/source-map-support 0.8.1 [Indirect] — npm: https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz
+- @csstools/css-calc 2.1.4 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz
+- @csstools/css-color-parser 3.1.0 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz
+- @csstools/css-parser-algorithms 3.0.5 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz
+- @csstools/css-tokenizer 3.0.4 [Indirect] — npm: https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz
+- @esbuild/aix-ppc64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz
+- @esbuild/aix-ppc64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz
+- @esbuild/android-arm 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz
+- @esbuild/android-arm 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz
+- @esbuild/android-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz
+- @esbuild/android-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz
+- @esbuild/android-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz
+- @esbuild/android-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz
+- @esbuild/darwin-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz
+- @esbuild/darwin-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz
+- @esbuild/darwin-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz
+- @esbuild/darwin-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz
+- @esbuild/freebsd-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz
+- @esbuild/freebsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz
+- @esbuild/freebsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz
+- @esbuild/freebsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz
+- @esbuild/linux-arm 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz
+- @esbuild/linux-arm 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz
+- @esbuild/linux-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz
+- @esbuild/linux-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz
+- @esbuild/linux-ia32 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz
+- @esbuild/linux-ia32 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz
+- @esbuild/linux-loong64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz
+- @esbuild/linux-loong64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz
+- @esbuild/linux-mips64el 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz
+- @esbuild/linux-mips64el 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz
+- @esbuild/linux-ppc64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz
+- @esbuild/linux-ppc64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz
+- @esbuild/linux-riscv64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz
+- @esbuild/linux-riscv64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz
+- @esbuild/linux-s390x 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz
+- @esbuild/linux-s390x 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz
+- @esbuild/linux-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz
+- @esbuild/linux-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz
+- @esbuild/netbsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz
+- @esbuild/netbsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz
+- @esbuild/netbsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz
+- @esbuild/openbsd-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz
+- @esbuild/openbsd-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz
+- @esbuild/openbsd-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz
+- @esbuild/openharmony-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz
+- @esbuild/sunos-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz
+- @esbuild/sunos-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz
+- @esbuild/win32-arm64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz
+- @esbuild/win32-arm64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz
+- @esbuild/win32-ia32 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz
+- @esbuild/win32-ia32 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz
+- @esbuild/win32-x64 0.21.5 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz
+- @esbuild/win32-x64 0.25.9 [Indirect] — npm: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz
+- @eslint-community/eslint-utils 4.9.0 [Indirect] — npm: https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz
+- @eslint-community/regexpp 4.12.1 [Indirect] — npm: https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz
+- @eslint/eslintrc 2.1.4 [Indirect] — npm: https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz
+- @eslint/js 8.57.1 [Indirect] — npm: https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz
+- @istanbuljs/schema 0.1.3 [Indirect] — npm: https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz
+- @jest/schemas 29.6.3 [Indirect] — npm: https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz
+- @jridgewell/gen-mapping 0.3.13 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz
+- @jridgewell/resolve-uri 3.1.2 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz
+- @jridgewell/sourcemap-codec 1.5.5 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz
+- @jridgewell/trace-mapping 0.3.30 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz
+- @jridgewell/trace-mapping 0.3.9 [Indirect] — npm: https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz
+- @nodelib/fs.scandir 2.1.5 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz
+- @nodelib/fs.stat 2.0.5 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz
+- @nodelib/fs.walk 1.2.8 [Indirect] — npm: https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz
+- @parcel/watcher 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz
+- @parcel/watcher-android-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz
+- @parcel/watcher-darwin-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz
+- @parcel/watcher-darwin-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz
+- @parcel/watcher-freebsd-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz
+- @parcel/watcher-linux-arm-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz
+- @parcel/watcher-linux-arm-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz
+- @parcel/watcher-linux-arm64-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz
+- @parcel/watcher-linux-arm64-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz
+- @parcel/watcher-linux-x64-glibc 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz
+- @parcel/watcher-linux-x64-musl 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz
+- @parcel/watcher-win32-arm64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz
+- @parcel/watcher-win32-ia32 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz
+- @parcel/watcher-win32-x64 2.5.1 [Indirect] — npm: https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz
+- @rollup/rollup-android-arm-eabi 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz
+- @rollup/rollup-android-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz
+- @rollup/rollup-darwin-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz
+- @rollup/rollup-darwin-x64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz
+- @rollup/rollup-freebsd-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz
+- @rollup/rollup-freebsd-x64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz
+- @rollup/rollup-linux-arm-gnueabihf 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz
+- @rollup/rollup-linux-arm-musleabihf 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz
+- @rollup/rollup-linux-arm64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-arm64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz
+- @rollup/rollup-linux-loongarch64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-ppc64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-riscv64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-riscv64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz
+- @rollup/rollup-linux-s390x-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz
+- @rollup/rollup-linux-x64-gnu 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz
+- @rollup/rollup-linux-x64-musl 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz
+- @rollup/rollup-openharmony-arm64 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz
+- @rollup/rollup-win32-arm64-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz
+- @rollup/rollup-win32-ia32-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz
+- @rollup/rollup-win32-x64-msvc 4.50.0 [Indirect] — npm: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz
+- @rtsao/scc 1.1.0 [Indirect] — npm: https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz
+- @sinclair/typebox 0.27.8 [Indirect] — npm: https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz
+- @tsconfig/node10 1.0.11 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz
+- @tsconfig/node12 1.0.11 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz
+- @tsconfig/node14 1.0.3 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz
+- @tsconfig/node16 1.0.4 [Indirect] — npm: https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz
+- @types/better-sqlite3 7.6.13 [Direct] — npm: https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz
+- @types/estree 1.0.8 [Indirect] — npm: https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz
+- @types/jsdom 21.1.7 [Direct] — npm: https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz
+- @types/json5 0.0.29 [Indirect] — npm: https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz
+- @types/node 24.3.0 [Indirect] — npm: https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz
+- @types/tough-cookie 4.0.5 [Indirect] — npm: https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz
+- @typescript-eslint/eslint-plugin 8.44.0 [Direct] — npm: https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz
+- @typescript-eslint/parser 8.44.0 [Direct] — npm: https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz
+- @typescript-eslint/project-service 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz
+- @typescript-eslint/scope-manager 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz
+- @typescript-eslint/tsconfig-utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz
+- @typescript-eslint/type-utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz
+- @typescript-eslint/types 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz
+- @typescript-eslint/typescript-estree 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz
+- @typescript-eslint/utils 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz
+- @typescript-eslint/visitor-keys 8.44.0 [Indirect] — npm: https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz
+- @vitest/coverage-v8 1.6.1 [Direct] — npm: https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz
+- @vitest/expect 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz
+- @vitest/runner 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz
+- @vitest/snapshot 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz
+- @vitest/spy 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz
+- @vitest/utils 1.6.1 [Indirect] — npm: https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz
+- acorn 8.15.0 [Indirect] — npm: https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz
+- acorn-jsx 5.3.2 [Indirect] — npm: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz
+- acorn-walk 8.3.4 [Indirect] — npm: https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz
+- agent-base 7.1.4 [Indirect] — npm: https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz
+- ajv 6.12.6 [Direct] — npm: https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz
+- ajv 8.17.1 [Direct] — npm: https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz
+- ajv-formats 3.0.1 [Direct] — npm: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz
+- ansi-regex 5.0.1 [Indirect] — npm: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz
+- ansi-styles 4.3.0 [Indirect] — npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz
+- ansi-styles 5.2.0 [Indirect] — npm: https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz
+- arg 4.1.3 [Indirect] — npm: https://registry.npmjs.org/arg/-/arg-4.1.3.tgz
+- array-buffer-byte-length 1.0.2 [Indirect] — npm: https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz
+- array-includes 3.1.9 [Indirect] — npm: https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz
+- array.prototype.findlastindex 1.2.6 [Indirect] — npm: https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz
+- array.prototype.flat 1.3.3 [Indirect] — npm: https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz
+- array.prototype.flatmap 1.3.3 [Indirect] — npm: https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz
+- arraybuffer.prototype.slice 1.0.4 [Indirect] — npm: https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz
+- ashpd 0.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- assertion-error 1.1.0 [Indirect] — npm: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
+- ast-types-flow 0.0.8 [Indirect] — npm: https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz
+- async-function 1.0.0 [Indirect] — npm: https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz
+- atk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- atoi 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- available-typed-arrays 1.0.7 [Indirect] — npm: https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz
+- balanced-match 1.0.2 [Indirect] — npm: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz
+- base64-js 1.5.1 [Indirect] — npm: https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz
+- better-sqlite3 12.2.0 [Direct] — npm: https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz
+- bindings 1.5.0 [Indirect] — npm: https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz
+- bl 4.1.0 [Indirect] — npm: https://registry.npmjs.org/bl/-/bl-4.1.0.tgz
+- block2 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- block2 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- brace-expansion 1.1.12 [Indirect] — npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz
+- brace-expansion 2.0.2 [Indirect] — npm: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz
+- braces 3.0.3 [Indirect] — npm: https://registry.npmjs.org/braces/-/braces-3.0.3.tgz
+- buffer 5.7.1 [Indirect] — npm: https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz
+- buffer-builder 0.2.0 [Indirect] — npm: https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz
+    Notes: Upstream package declares "MIT/X11"; normalized to MIT for reporting.
+- bytes 1.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cac 6.7.14 [Indirect] — npm: https://registry.npmjs.org/cac/-/cac-6.7.14.tgz
+- cairo-rs 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cairo-sys-rs 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- call-bind 1.0.8 [Indirect] — npm: https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz
+- call-bind-apply-helpers 1.0.2 [Indirect] — npm: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz
+- call-bound 1.0.4 [Indirect] — npm: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz
+- callsites 3.1.0 [Indirect] — npm: https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz
+- cargo_metadata 0.19.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfb 0.7.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cfg_aliases 0.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- chai 4.5.0 [Indirect] — npm: https://registry.npmjs.org/chai/-/chai-4.5.0.tgz
+- chalk 4.1.2 [Indirect] — npm: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz
+- check-error 1.0.3 [Indirect] — npm: https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz
+- chokidar 4.0.3 [Indirect] — npm: https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz
+- color-convert 2.0.1 [Indirect] — npm: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz
+- color-name 1.1.4 [Indirect] — npm: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz
+- colorjs.io 0.5.2 [Indirect] — npm: https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz
+- combine 4.6.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- concat-map 0.0.1 [Indirect] — npm: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz
+- confbox 0.1.8 [Indirect] — npm: https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz
+- convert_case 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- create-require 1.1.1 [Indirect] — npm: https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz
+- cross-spawn 7.0.6 [Indirect] — npm: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz
+- crunchy 0.2.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cssstyle 4.6.0 [Indirect] — npm: https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz
+- darling 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- darling_core 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- darling_macro 0.20.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- data-urls 5.0.0 [Indirect] — npm: https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz
+- data-view-buffer 1.0.2 [Indirect] — npm: https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz
+- data-view-byte-length 1.0.2 [Indirect] — npm: https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz
+- data-view-byte-offset 1.0.1 [Indirect] — npm: https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz
+- debug 3.2.7 [Indirect] — npm: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz
+- debug 4.4.1 [Indirect] — npm: https://registry.npmjs.org/debug/-/debug-4.4.1.tgz
+- decimal.js 10.6.0 [Indirect] — npm: https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz
+- decompress-response 6.0.0 [Indirect] — npm: https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz
+- deep-eql 4.1.4 [Indirect] — npm: https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz
+- deep-extend 0.6.0 [Indirect] — npm: https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz
+- deep-is 0.1.4 [Indirect] — npm: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz
+- define-data-property 1.1.4 [Indirect] — npm: https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz
+- define-properties 1.2.1 [Indirect] — npm: https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz
+- derive_more 0.99.20 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- diff-sequences 29.6.3 [Indirect] — npm: https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz
+- difflib 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dispatch 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dlib 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dlopen2 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+    Notes: License file bundled with crate (MIT License).
+- dlopen2_derive 0.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+    Notes: License file bundled with crate (MIT License).
+- doc-comment 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dotenvy 0.15.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dunder-proto 1.0.1 [Indirect] — npm: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz
+- embed-resource 3.0.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- emoji-regex 9.2.2 [Indirect] — npm: https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz
+- end-of-stream 1.4.5 [Indirect] — npm: https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz
+- endi 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- es-abstract 1.24.0 [Indirect] — npm: https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz
+- es-define-property 1.0.1 [Indirect] — npm: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz
+- es-errors 1.3.0 [Indirect] — npm: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz
+- es-object-atoms 1.1.1 [Indirect] — npm: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz
+- es-set-tostringtag 2.1.0 [Indirect] — npm: https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz
+- es-shim-unscopables 1.1.0 [Indirect] — npm: https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz
+- es-to-primitive 1.3.0 [Indirect] — npm: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz
+- esbuild 0.21.5 [Indirect] — npm: https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz
+- esbuild 0.25.9 [Indirect] — npm: https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz
+- escape-string-regexp 4.0.0 [Indirect] — npm: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz
+- eslint 8.57.1 [Direct] — npm: https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz
+    Notes: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+- eslint-import-resolver-node 0.3.9 [Indirect] — npm: https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz
+- eslint-module-utils 2.12.1 [Indirect] — npm: https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz
+- eslint-plugin-import 2.32.0 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz
+- eslint-plugin-jsx-a11y 6.10.2 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz
+- eslint-plugin-unused-imports 4.2.0 [Direct] — npm: https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz
+- estree-walker 3.0.3 [Indirect] — npm: https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz
+- execa 8.0.1 [Indirect] — npm: https://registry.npmjs.org/execa/-/execa-8.0.1.tgz
+- fancy-regex 0.11.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fast-deep-equal 3.1.3 [Indirect] — npm: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz
+- fast-glob 3.3.3 [Indirect] — npm: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz
+- fast-json-stable-stringify 2.1.0 [Indirect] — npm: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
+- fast-levenshtein 2.0.6 [Indirect] — npm: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz
+- fax 0.2.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fax_derive 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- fdir 6.5.0 [Indirect] — npm: https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz
+- file-entry-cache 6.0.1 [Indirect] — npm: https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz
+- file-rotate 0.7.6 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- file-uri-to-path 1.0.0 [Indirect] — npm: https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz
+- fill-range 7.1.1 [Indirect] — npm: https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz
+- find-up 5.0.0 [Indirect] — npm: https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz
+- flat-cache 3.2.0 [Indirect] — npm: https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz
+- for-each 0.3.5 [Indirect] — npm: https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz
+- fs-constants 1.0.0 [Indirect] — npm: https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz
+- fsevents 2.3.2 [Indirect] — npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz
+- fsevents 2.3.3 [Indirect] — npm: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz
+- function-bind 1.1.2 [Indirect] — npm: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz
+- function.prototype.name 1.1.8 [Indirect] — npm: https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz
+- functions-have-names 1.2.3 [Indirect] — npm: https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz
+- gdk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-pixbuf 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-pixbuf-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkwayland-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkx11 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gdkx11-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- generic-array 0.14.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- get-func-name 2.0.2 [Indirect] — npm: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz
+- get-intrinsic 1.3.0 [Indirect] — npm: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz
+- get-proto 1.0.1 [Indirect] — npm: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz
+- get-stream 8.0.1 [Indirect] — npm: https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz
+- get-symbol-description 1.1.0 [Indirect] — npm: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz
+- get-tsconfig 4.10.1 [Indirect] — npm: https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz
+- gio 0.18.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gio-sys 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- github-from-package 0.0.0 [Indirect] — npm: https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz
+- glib 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glib-macros 0.18.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- glib-sys 0.18.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- globals 13.24.0 [Indirect] — npm: https://registry.npmjs.org/globals/-/globals-13.24.0.tgz
+- globalthis 1.0.4 [Indirect] — npm: https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz
+- gobject-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gopd 1.2.0 [Indirect] — npm: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz
+- graphemer 1.4.0 [Indirect] — npm: https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz
+- gtk 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gtk-sys 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- gtk3-macros 0.18.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- h2 0.3.27 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- has-bigints 1.1.0 [Indirect] — npm: https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz
+- has-flag 4.0.0 [Indirect] — npm: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz
+- has-property-descriptors 1.0.2 [Indirect] — npm: https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz
+- has-proto 1.2.0 [Indirect] — npm: https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz
+- has-symbols 1.1.0 [Indirect] — npm: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz
+- has-tostringtag 1.0.2 [Indirect] — npm: https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz
+- hasown 2.0.2 [Indirect] — npm: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz
+- html-encoding-sniffer 4.0.0 [Indirect] — npm: https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz
+- html-escaper 2.0.2 [Indirect] — npm: https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz
+- http-body 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-body 1.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-body-util 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- http-proxy-agent 7.0.2 [Indirect] — npm: https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz
+- https-proxy-agent 7.0.6 [Indirect] — npm: https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz
+- hyper 0.14.32 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hyper 1.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- hyper-util 0.1.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ico 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- iconv-lite 0.6.3 [Indirect] — npm: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz
+- ignore 5.3.2 [Indirect] — npm: https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz
+- ignore 7.0.5 [Indirect] — npm: https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz
+- immutable 5.1.3 [Indirect] — npm: https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz
+- import-fresh 3.3.1 [Indirect] — npm: https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz
+- imurmurhash 0.1.4 [Indirect] — npm: https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz
+- include_dir 0.7.4 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- include_dir_macros 0.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- infer 0.19.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- internal-slot 1.1.0 [Indirect] — npm: https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz
+- is-array-buffer 3.0.5 [Indirect] — npm: https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz
+- is-async-function 2.1.1 [Indirect] — npm: https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz
+- is-bigint 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz
+- is-boolean-object 1.2.2 [Indirect] — npm: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz
+- is-callable 1.2.7 [Indirect] — npm: https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz
+- is-core-module 2.16.1 [Indirect] — npm: https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz
+- is-data-view 1.0.2 [Indirect] — npm: https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz
+- is-date-object 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz
+- is-docker 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- is-extglob 2.1.1 [Indirect] — npm: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz
+- is-finalizationregistry 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz
+- is-generator-function 1.1.0 [Indirect] — npm: https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz
+- is-glob 4.0.3 [Indirect] — npm: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz
+- is-map 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz
+- is-negative-zero 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz
+- is-number 7.0.0 [Indirect] — npm: https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz
+- is-number-object 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz
+- is-path-inside 3.0.3 [Indirect] — npm: https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz
+- is-potential-custom-element-name 1.0.1 [Indirect] — npm: https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz
+- is-regex 1.2.1 [Indirect] — npm: https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz
+- is-set 2.0.3 [Indirect] — npm: https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz
+- is-shared-array-buffer 1.0.4 [Indirect] — npm: https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz
+- is-stream 3.0.0 [Indirect] — npm: https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz
+- is-string 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz
+- is-symbol 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz
+- is-typed-array 1.1.15 [Indirect] — npm: https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz
+- is-weakmap 2.0.2 [Indirect] — npm: https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz
+- is-weakref 1.1.1 [Indirect] — npm: https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz
+- is-weakset 2.0.4 [Indirect] — npm: https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz
+- is-wsl 0.4.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- isarray 2.0.5 [Indirect] — npm: https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz
+- iso8601 0.6.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- javascriptcore-rs 1.1.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- javascriptcore-rs-sys 1.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- js-tokens 9.0.1 [Indirect] — npm: https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz
+- js-yaml 4.1.0 [Indirect] — npm: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz
+- jsdom 26.1.0 [Direct] — npm: https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz
+- json-buffer 3.0.1 [Indirect] — npm: https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz
+- json-schema-traverse 0.4.1 [Indirect] — npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz
+- json-schema-traverse 1.0.0 [Indirect] — npm: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz
+- json-stable-stringify-without-jsonify 1.0.1 [Indirect] — npm: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz
+- json5 1.0.2 [Indirect] — npm: https://registry.npmjs.org/json5/-/json5-1.0.2.tgz
+- json5 2.2.3 [Indirect] — npm: https://registry.npmjs.org/json5/-/json5-2.2.3.tgz
+- jsonschema 0.17.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- jsx-ast-utils 3.3.5 [Indirect] — npm: https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz
+- keyv 4.5.4 [Indirect] — npm: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz
+- kuchikiki 0.8.8-speedreader [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- language-tags 1.0.9 [Indirect] — npm: https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz
+- levn 0.4.1 [Indirect] — npm: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz
+- libm 0.2.15 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libredox 0.1.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- libsqlite3-sys 0.30.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- local-pkg 0.5.1 [Indirect] — npm: https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz
+- locate-path 6.0.0 [Indirect] — npm: https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz
+- lodash.merge 4.6.2 [Indirect] — npm: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz
+- loupe 2.3.7 [Indirect] — npm: https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz
+- mac-notification-sys 0.6.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- magic-string 0.30.19 [Indirect] — npm: https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz
+- magicast 0.3.5 [Indirect] — npm: https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz
+- make-dir 4.0.0 [Indirect] — npm: https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz
+- matchers 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- matches 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- math-intrinsics 1.1.0 [Indirect] — npm: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz
+- memoffset 0.9.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- merge-stream 2.0.0 [Indirect] — npm: https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz
+- merge2 1.4.1 [Indirect] — npm: https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz
+- micromatch 4.0.8 [Indirect] — npm: https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz
+- mimic-fn 4.0.0 [Indirect] — npm: https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz
+- mimic-response 3.1.0 [Indirect] — npm: https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz
+- minimist 1.2.8 [Indirect] — npm: https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz
+- mio 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- mkdirp-classic 0.5.3 [Indirect] — npm: https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz
+- mlly 1.8.0 [Indirect] — npm: https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz
+- ms 2.1.3 [Indirect] — npm: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz
+- nanoid 3.3.11 [Indirect] — npm: https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz
+- napi-build-utils 2.0.0 [Indirect] — npm: https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz
+- natural-compare 1.4.0 [Indirect] — npm: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz
+- new_debug_unreachable 1.0.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nix 0.30.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- node-abi 3.75.0 [Indirect] — npm: https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz
+- node-addon-api 7.1.1 [Indirect] — npm: https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz
+- nom 7.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nom 8.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- npm-run-path 5.3.0 [Indirect] — npm: https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz
+- nu-ansi-term 0.50.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- nwsapi 2.2.22 [Indirect] — npm: https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz
+- objc-sys 0.3.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2 0.6.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-encode 4.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-foundation 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-foundation 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-metal 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- objc2-quartz-core 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- object-inspect 1.13.4 [Indirect] — npm: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz
+- object-keys 1.1.1 [Indirect] — npm: https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz
+- object.assign 4.1.7 [Indirect] — npm: https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz
+- object.fromentries 2.0.8 [Indirect] — npm: https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz
+- object.groupby 1.0.3 [Indirect] — npm: https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz
+- object.values 1.2.1 [Indirect] — npm: https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz
+- onetime 6.0.0 [Indirect] — npm: https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz
+- open 5.3.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- optionator 0.9.4 [Indirect] — npm: https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz
+- os_pipe 1.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- own-keys 1.0.1 [Indirect] — npm: https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz
+- p-limit 3.1.0 [Indirect] — npm: https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz
+- p-limit 5.0.0 [Indirect] — npm: https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz
+- p-locate 5.0.0 [Indirect] — npm: https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz
+- pango 0.18.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- pango-sys 0.18.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- parent-module 1.0.1 [Indirect] — npm: https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz
+- parse5 7.3.0 [Indirect] — npm: https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz
+- path-exists 4.0.0 [Indirect] — npm: https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz
+- path-is-absolute 1.0.1 [Indirect] — npm: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz
+- path-key 3.1.1 [Indirect] — npm: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz
+- path-key 4.0.0 [Indirect] — npm: https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz
+- path-parse 1.0.7 [Indirect] — npm: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz
+- pathe 1.1.2 [Indirect] — npm: https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz
+- pathe 2.0.3 [Indirect] — npm: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz
+- pathval 1.1.1 [Indirect] — npm: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
+- phf 0.10.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_codegen 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_codegen 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_generator 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_macros 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_macros 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.11.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.12.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- phf_shared 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- picomatch 2.3.1 [Indirect] — npm: https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz
+- picomatch 4.0.3 [Indirect] — npm: https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz
+- pkg-types 1.3.1 [Indirect] — npm: https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz
+- plist 1.7.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- possible-typed-array-names 1.1.0 [Indirect] — npm: https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz
+- postcss 8.5.6 [Indirect] — npm: https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz
+- prebuild-install 7.1.3 [Indirect] — npm: https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz
+- precomputed-hash 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- prelude-ls 1.2.1 [Indirect] — npm: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz
+- pretty-format 29.7.0 [Indirect] — npm: https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz
+- pump 3.0.3 [Indirect] — npm: https://registry.npmjs.org/pump/-/pump-3.0.3.tgz
+- punycode 2.3.1 [Indirect] — npm: https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz
+- queue-microtask 1.2.3 [Indirect] — npm: https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz
+- quick-xml 0.37.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- quick-xml 0.38.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- react-is 18.3.1 [Indirect] — npm: https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz
+- readable-stream 3.6.2 [Indirect] — npm: https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz
+- readdirp 4.1.2 [Indirect] — npm: https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz
+- redox_syscall 0.5.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- redox_users 0.4.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- redox_users 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- reflect.getprototypeof 1.0.10 [Indirect] — npm: https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz
+- regexp-tree 0.1.27 [Indirect] — npm: https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz
+- regexp.prototype.flags 1.5.4 [Indirect] — npm: https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz
+- require-from-string 2.0.2 [Indirect] — npm: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz
+- resolve 1.22.10 [Indirect] — npm: https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz
+- resolve-from 4.0.0 [Indirect] — npm: https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz
+- resolve-pkg-maps 1.0.0 [Indirect] — npm: https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz
+- reusify 1.1.0 [Indirect] — npm: https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz
+- rfd 0.15.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- rollup 4.50.0 [Indirect] — npm: https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz
+- rrweb-cssom 0.8.0 [Indirect] — npm: https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz
+- run-parallel 1.2.0 [Indirect] — npm: https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz
+- rusqlite 0.32.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- safe-array-concat 1.1.3 [Indirect] — npm: https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz
+- safe-buffer 5.2.1 [Indirect] — npm: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz
+- safe-push-apply 1.0.0 [Indirect] — npm: https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz
+- safe-regex 2.1.1 [Indirect] — npm: https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz
+- safe-regex-test 1.1.0 [Indirect] — npm: https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz
+- safer-buffer 2.1.2 [Indirect] — npm: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz
+- sass 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass/-/sass-1.91.0.tgz
+- sass-embedded 1.91.0 [Direct] — npm: https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.91.0.tgz
+- sass-embedded-all-unknown 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.91.0.tgz
+- sass-embedded-android-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.91.0.tgz
+- sass-embedded-android-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.91.0.tgz
+- sass-embedded-android-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.91.0.tgz
+- sass-embedded-android-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.91.0.tgz
+- sass-embedded-darwin-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.91.0.tgz
+- sass-embedded-darwin-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.91.0.tgz
+- sass-embedded-linux-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.91.0.tgz
+- sass-embedded-linux-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.91.0.tgz
+- sass-embedded-linux-musl-arm 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.91.0.tgz
+- sass-embedded-linux-musl-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.91.0.tgz
+- sass-embedded-linux-musl-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.91.0.tgz
+- sass-embedded-linux-musl-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.91.0.tgz
+- sass-embedded-linux-riscv64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.91.0.tgz
+- sass-embedded-linux-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.91.0.tgz
+- sass-embedded-unknown-all 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.91.0.tgz
+- sass-embedded-win32-arm64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.91.0.tgz
+- sass-embedded-win32-x64 1.91.0 [Indirect] — npm: https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.91.0.tgz
+- schemars 0.8.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars 0.9.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars 1.0.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- schemars_derive 0.8.22 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- set-function-length 1.2.2 [Indirect] — npm: https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz
+- set-function-name 2.0.2 [Indirect] — npm: https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz
+- set-proto 1.0.0 [Indirect] — npm: https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz
+- sharded-slab 0.1.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- shebang-command 2.0.0 [Indirect] — npm: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz
+- shebang-regex 3.0.0 [Indirect] — npm: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz
+- side-channel 1.1.0 [Indirect] — npm: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz
+- side-channel-list 1.0.0 [Indirect] — npm: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz
+- side-channel-map 1.0.1 [Indirect] — npm: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz
+- side-channel-weakmap 1.0.2 [Indirect] — npm: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz
+- simd-adler32 0.3.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- simple-concat 1.0.1 [Indirect] — npm: https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz
+- simple-get 4.0.1 [Indirect] — npm: https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz
+- slab 0.4.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- soup3 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- soup3-sys 0.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- spdx-expression-parse 4.0.0 [Direct] — npm: https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz
+- spin 0.9.8 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- stackback 0.0.2 [Indirect] — npm: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz
+- std-env 3.9.0 [Indirect] — npm: https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz
+- stop-iteration-iterator 1.1.0 [Indirect] — npm: https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz
+- string_decoder 1.3.0 [Indirect] — npm: https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz
+- string.prototype.includes 2.0.1 [Indirect] — npm: https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz
+- string.prototype.trim 1.2.10 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz
+- string.prototype.trimend 1.0.9 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz
+- string.prototype.trimstart 1.0.8 [Indirect] — npm: https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz
+- strip-ansi 6.0.1 [Indirect] — npm: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz
+- strip-bom 3.0.0 [Indirect] — npm: https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz
+- strip-final-newline 3.0.0 [Indirect] — npm: https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz
+- strip-json-comments 2.0.1 [Indirect] — npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz
+- strip-json-comments 3.1.1 [Indirect] — npm: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz
+- strip-literal 2.1.1 [Indirect] — npm: https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz
+- strsim 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- supports-color 7.2.0 [Indirect] — npm: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
+- supports-color 8.1.1 [Indirect] — npm: https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz
+- supports-preserve-symlinks-flag 1.0.0 [Indirect] — npm: https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz
+- symbol-tree 3.2.4 [Indirect] — npm: https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz
+- sync-child-process 1.0.2 [Indirect] — npm: https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz
+- sync-message-port 1.1.3 [Indirect] — npm: https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.1.3.tgz
+- synstructure 0.13.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tar-fs 2.1.3 [Indirect] — npm: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz
+- tar-stream 2.2.0 [Indirect] — npm: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz
+- tauri-winres 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- termtree 0.5.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- text-table 0.2.0 [Indirect] — npm: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz
+- tiff 0.10.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinybench 2.9.0 [Indirect] — npm: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz
+- tinyglobby 0.2.14 [Indirect] — npm: https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz
+- tinypool 0.8.4 [Indirect] — npm: https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz
+- tinyspy 2.2.1 [Indirect] — npm: https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz
+- tldts 6.1.86 [Indirect] — npm: https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz
+- tldts-core 6.1.86 [Indirect] — npm: https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz
+- to-regex-range 5.0.1 [Indirect] — npm: https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz
+- tokio 1.47.1 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-macros 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-stream 0.1.17 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tokio-util 0.7.16 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower 0.5.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-http 0.6.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-layer 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tower-service 0.3.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tr46 5.1.1 [Indirect] — npm: https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz
+- tracing 0.1.41 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-appender 0.2.3 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-attributes 0.1.30 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-core 0.1.34 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-log 0.2.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-serde 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tracing-subscriber 0.3.20 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tree_magic_mini 3.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- try-lock 0.2.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ts-api-utils 2.1.0 [Indirect] — npm: https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz
+- ts-node 10.9.2 [Direct] — npm: https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz
+- ts-rs 10.1.0 [Direct] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ts-rs-macros 10.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tsconfig-paths 3.15.0 [Direct] — npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz
+- tsconfig-paths 4.2.0 [Direct] — npm: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz
+- tsx 4.20.5 [Direct] — npm: https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz
+- type-check 0.4.0 [Indirect] — npm: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz
+- type-detect 4.1.0 [Indirect] — npm: https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz
+- typed-array-buffer 1.0.3 [Indirect] — npm: https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz
+- typed-array-byte-length 1.0.3 [Indirect] — npm: https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz
+- typed-array-byte-offset 1.0.4 [Indirect] — npm: https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz
+- typed-array-length 1.0.7 [Indirect] — npm: https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz
+- uds_windows 1.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- ufo 1.6.1 [Indirect] — npm: https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz
+- unbox-primitive 1.1.0 [Indirect] — npm: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz
+- undici-types 7.10.0 [Indirect] — npm: https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz
+- urlpattern 0.3.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- util-deprecate 1.0.2 [Indirect] — npm: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz
+- v8-compile-cache-lib 3.0.1 [Indirect] — npm: https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz
+- valuable 0.1.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- varint 6.0.0 [Indirect] — npm: https://registry.npmjs.org/varint/-/varint-6.0.0.tgz
+- version-compare 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vite 5.4.20 [Direct] — npm: https://registry.npmjs.org/vite/-/vite-5.4.20.tgz
+- vite 6.3.5 [Direct] — npm: https://registry.npmjs.org/vite/-/vite-6.3.5.tgz
+- vite-node 1.6.1 [Indirect] — npm: https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz
+- vitest 1.6.1 [Direct] — npm: https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz
+- vswhom 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- vswhom-sys 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- w3c-xmlserializer 5.0.0 [Indirect] — npm: https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz
+- want 0.3.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-backend 0.3.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-client 0.31.11 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-protocols 0.32.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-protocols-wlr 0.3.9 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-scanner 0.31.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- wayland-sys 0.31.7 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webkit2gtk 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webkit2gtk-sys 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com 0.38.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com-macros 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- webview2-com-sys 0.38.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- whatwg-encoding 3.1.1 [Indirect] — npm: https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz
+- whatwg-mimetype 4.0.0 [Indirect] — npm: https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz
+- whatwg-url 14.2.0 [Indirect] — npm: https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz
+- which-boxed-primitive 1.1.1 [Indirect] — npm: https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz
+- which-builtin-type 1.2.1 [Indirect] — npm: https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz
+- which-collection 1.0.2 [Indirect] — npm: https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz
+- which-typed-array 1.1.19 [Indirect] — npm: https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz
+- why-is-node-running 2.3.0 [Indirect] — npm: https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz
+- winnow 0.5.40 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winnow 0.7.13 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winreg 0.50.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winreg 0.55.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- word-wrap 1.2.5 [Indirect] — npm: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz
+- ws 8.18.3 [Indirect] — npm: https://registry.npmjs.org/ws/-/ws-8.18.3.tgz
+- x11 2.21.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- x11-dl 2.21.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- xmlchars 2.2.0 [Indirect] — npm: https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz
+- yn 3.1.1 [Indirect] — npm: https://registry.npmjs.org/yn/-/yn-3.1.1.tgz
+- yocto-queue 0.1.0 [Indirect] — npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz
+- yocto-queue 1.2.1 [Indirect] — npm: https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz
+- zbus 5.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zbus_macros 5.10.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zbus_names 4.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant 5.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant_derive 5.7.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zvariant_utils 3.2.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+MIT OR Unlicense
+----------------
+- aho-corasick 1.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- byteorder 1.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- byteorder-lite 0.1.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- memchr 2.7.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- same-file 1.0.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- termcolor 1.4.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- walkdir 2.5.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- winapi-util 0.1.10 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+MIT OR WTFPL
+------------
+- expand-template 2.0.3 [Indirect] — npm: https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz
+
+MIT-0
+-----
+- @csstools/color-helpers 5.1.0 [Indirect] — npm: https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz
+
+MPL-2.0
+-------
+- @axe-core/playwright 4.10.2 [Direct] — npm: https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz
+- axe-core 4.10.3 [Indirect] — npm: https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz
+- cssparser 0.29.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- cssparser-macros 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- dtoa-short 0.3.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- option-ext 0.2.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- selectors 0.24.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Python-2.0
+----------
+- argparse 2.0.1 [Indirect] — npm: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz
+
+Unicode-3.0
+-----------
+- icu_collections 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_locale_core 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_normalizer 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_normalizer_data 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_properties 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_properties_data 2.0.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- icu_provider 2.0.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- litemap 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- potential_utf 0.1.3 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- tinystr 0.8.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- writeable 0.6.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- yoke 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- yoke-derive 0.8.0 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerofrom 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerofrom-derive 0.1.6 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerotrie 0.2.2 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerovec 0.11.4 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+- zerovec-derive 0.11.1 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Zlib
+----
+- foldhash 0.1.5 [Indirect] — registry (https://github.com/rust-lang/crates.io-index): registry+https://github.com/rust-lang/crates.io-index
+
+Fonts and Icons
+---------------
+
+Font Awesome Free icons are distributed with Arklowdun for in-application visuals. Font Awesome Free is licensed under the Creative Commons Attribution 4.0 International license for icons and the SIL Open Font License 1.1 for fonts. Attribution text:
+
+"Font Awesome Free by @fontawesome - https://fontawesome.com", CC BY 4.0 / SIL OFL 1.1.
+
+Questions & Contact
+-------------------
+
+For questions about licensing or attribution, contact the Arklowdun team at compliance@arklowdun.local.
+
+--
+This file is generated automatically; run "npm run generate:notice" after updating dependencies to refresh it.

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -45,7 +45,9 @@
       "icons/icon.ico"
     ],
     "resources": [
-      "resources/docs/diagnostics.md"
+      "resources/docs/diagnostics.md",
+      "resources/licenses/NOTICE.txt",
+      "resources/licenses/CREDITS.txt"
     ]
   },
 


### PR DESCRIPTION
## Summary
- add a TypeScript generator, templates, and manual sections for producing NOTICE/CREDITS artifacts from the merged licensing inventory
- check in the generated NOTICE/CREDITS outputs, plaintext bundle resources, and a checksum manifest while wiring the bundler to ship them
- update overrides, npm tooling, CI, and documentation so developers can regenerate the disclosures and CI enforces drift checks

## Testing
- npm run generate:notice -- --check

------
https://chatgpt.com/codex/tasks/task_e_68d6a86611d4832aa0356c27470180b2