### PR TITLE
Add custom macOS-style toolbar and window controls

### DIFF
--- a/src-tauri/capabilities/window-management.json
+++ b/src-tauri/capabilities/window-management.json
@@ -6,6 +6,11 @@
     "core:window:allow-set-min-size",
     "core:window:allow-set-size",
     "core:window:allow-inner-size",
-    "core:window:allow-scale-factor"
+    "core:window:allow-scale-factor",
+    "core:window:allow-start-dragging",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-maximize",
+    "core:window:allow-unmaximize"
   ]
 }

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -16,7 +16,10 @@
     "windows": [
       {
         "label": "main",
-        "title": "Arklowdun - Home Management",
+        "title": "Arklowdun",
+        "decorations": false,
+        "resizable": true,
+        "transparent": false,
         "width": 800,
         "height": 600,
         "backgroundColor": "#ffffffff"

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -18,6 +18,7 @@
         "label": "main",
         "title": "Arklowdun",
         "decorations": false,
+        "acceptFirstMouse": true, // macOS: let first click both focus and interact
         "resizable": true,
         "transparent": false,
         "width": 800,

--- a/src/layout/Page.ts
+++ b/src/layout/Page.ts
@@ -28,13 +28,24 @@ export function Page({ sidebar, content, footer, toolbar }: PageProps): PageInst
       content.element.prepend(toolbar.element);
     }
 
-    target.replaceChildren(
+    const nextChildren: Node[] = [];
+
+    const customToolbar =
+      target.querySelector<HTMLElement>(".app-toolbar") ??
+      document.querySelector<HTMLElement>(".app-toolbar");
+    if (customToolbar) {
+      nextChildren.push(customToolbar);
+    }
+
+    nextChildren.push(
       sidebar.element,
       content.element,
       footer.element,
       modalRoot,
       liveRegion,
     );
+
+    target.replaceChildren(...nextChildren);
   }
 
   return { mount };

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { initTheme } from "@ui/ThemeToggle";
 import { getStartupWindow } from "@lib/ipc/startup";
 import { ensureDbHealthReport, recheckDbHealth } from "./services/dbHealth";
 import { recoveryText } from "@strings/recovery";
+import { mountMacToolbar } from "@ui/AppToolbar";
 
 const appWindow = getStartupWindow();
 
@@ -401,6 +402,9 @@ async function handleRouteChange() {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  const root = document.getElementById("app") ?? document.body;
+  mountMacToolbar(root);
+
   log.debug("app booted");
   defaultHouseholdId().catch((e) => console.error("DB init failed:", e));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -403,7 +403,7 @@ async function handleRouteChange() {
 
 window.addEventListener("DOMContentLoaded", () => {
   const root = document.getElementById("app") ?? document.body;
-  void mountMacToolbar(root);
+  mountMacToolbar(root);
 
   log.debug("app booted");
   defaultHouseholdId().catch((e) => console.error("DB init failed:", e));

--- a/src/main.ts
+++ b/src/main.ts
@@ -403,7 +403,7 @@ async function handleRouteChange() {
 
 window.addEventListener("DOMContentLoaded", () => {
   const root = document.getElementById("app") ?? document.body;
-  mountMacToolbar(root);
+  void mountMacToolbar(root);
 
   log.debug("app booted");
   defaultHouseholdId().catch((e) => console.error("DB init failed:", e));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2781,7 +2781,8 @@ mark.search-hit {
 
 .app-toolbar {
   position: fixed;
-  inset: 0 auto auto 0;
+  top: 0;
+  left: 0;
   right: 0;
   height: 32px;
   min-height: 32px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2776,5 +2776,62 @@ mark.search-hit {
 }
 
 /* ========================================================================== */
+/* MAC TOOLBAR                                                                */
+/* ========================================================================== */
+
+.app-toolbar {
+  height: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  background: var(--color-panel, #fff);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  -webkit-user-select: none;
+  user-select: none;
+  z-index: 1000;
+}
+
+.traffic {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.traffic__btn {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  padding: 0;
+  margin: 0;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.5);
+  -webkit-app-region: no-drag;
+}
+
+.traffic__close {
+  background: #ff5f57;
+}
+
+.traffic__min {
+  background: #ffbd2e;
+}
+
+.traffic__max {
+  background: #28c940;
+}
+
+.traffic__btn:hover {
+  filter: brightness(1.05);
+}
+
+#app,
+#content,
+#view,
+.container {
+  padding-top: 32px;
+}
+
+/* ========================================================================== */
 /* END                                                                        */
 /* ========================================================================== */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,7 +5,6 @@
   --z-index-dropdown: 200;
   --layout-sidebar-collapsed: 72px;
   --layout-sidebar-collapsed-sm: 56px;
-  --app-toolbar-height: 64px;
 }
 
 [hidden] {
@@ -532,14 +531,14 @@ textarea:focus-visible {
 .sidebar {
   inline-size: max-content;
   padding: var(--space-4) var(--space-4) var(--space-5);
-  padding-block-start: calc(var(--space-4) + var(--app-toolbar-height));
+  padding-block-start: calc(var(--space-4) + 32px);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   background-color: var(--color-sidebar-bg);
   border-inline-end: 1px solid var(--color-sidebar-border);
   color: var(--color-text);
-  min-height: calc(100vh - var(--app-toolbar-height));
+  min-height: calc(100vh - 32px);
 }
 
 .sidebar__top {
@@ -2782,23 +2781,23 @@ mark.search-hit {
 /* MAC TOOLBAR                                                                */
 /* ========================================================================== */
 
+
 .app-toolbar {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  height: var(--app-toolbar-height);
-  min-height: var(--app-toolbar-height);
+  height: 32px;
+  min-height: 32px;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 16px;
-  z-index: 10000;
+  padding: 0 10px;
   background: var(--color-panel, #fff);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
   -webkit-user-select: none;
   user-select: none;
-  -webkit-app-region: drag;
+  z-index: 1000;
 }
 
 .traffic {
@@ -2807,40 +2806,14 @@ mark.search-hit {
 }
 
 .traffic__btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 15px;
-  height: 15px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   padding: 0;
   margin: 0;
   border: 1px solid rgba(0, 0, 0, 0.15);
-  box-shadow:
-    inset 0 0 0 0.5px rgba(255, 255, 255, 0.6),
-    0 0 0 1px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.5);
   -webkit-app-region: no-drag;
-}
-
-.traffic__btn::after {
-  content: "";
-  color: rgba(0, 0, 0, 0.65);
-  font-size: 10px;
-  line-height: 1;
-}
-
-.traffic__close:hover::after {
-  content: "×";
-}
-
-.traffic__min:hover::after {
-  content: "–";
-}
-
-.traffic__max:hover::after {
-  content: "‹›";
-  letter-spacing: -1px;
 }
 
 .traffic__close {
@@ -2855,11 +2828,15 @@ mark.search-hit {
   background: #28c940;
 }
 
+.traffic__btn:hover {
+  filter: brightness(1.05);
+}
+
 #app,
 #content,
 #view,
 .container {
-  padding-top: var(--app-toolbar-height);
+  padding-top: 32px;
 }
 
 /* ========================================================================== */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,7 @@
   --z-index-dropdown: 200;
   --layout-sidebar-collapsed: 72px;
   --layout-sidebar-collapsed-sm: 56px;
+  --app-toolbar-height: 64px;
 }
 
 [hidden] {
@@ -531,12 +532,14 @@ textarea:focus-visible {
 .sidebar {
   inline-size: max-content;
   padding: var(--space-4) var(--space-4) var(--space-5);
+  padding-block-start: calc(var(--space-4) + var(--app-toolbar-height));
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   background-color: var(--color-sidebar-bg);
   border-inline-end: 1px solid var(--color-sidebar-border);
   color: var(--color-text);
+  min-height: calc(100vh - var(--app-toolbar-height));
 }
 
 .sidebar__top {
@@ -2784,8 +2787,8 @@ mark.search-hit {
   top: 0;
   left: 0;
   right: 0;
-  height: 64px;
-  min-height: 64px;
+  height: var(--app-toolbar-height);
+  min-height: var(--app-toolbar-height);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2856,12 +2859,7 @@ mark.search-hit {
 #content,
 #view,
 .container {
-  padding-top: 64px;
-}
-
-.sidebar {
-  top: 64px;
-  height: calc(100vh - 64px);
+  padding-top: var(--app-toolbar-height);
 }
 
 /* ========================================================================== */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2795,6 +2795,7 @@ mark.search-hit {
   border-bottom: 1px solid var(--color-border, #e5e7eb);
   -webkit-user-select: none;
   user-select: none;
+  -webkit-app-region: drag;
 }
 
 .traffic {
@@ -2825,10 +2826,6 @@ mark.search-hit {
 
 .traffic__max {
   background: #28c940;
-}
-
-.traffic__toast {
-  background: #007aff;
 }
 
 #app,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2784,12 +2784,12 @@ mark.search-hit {
   top: 0;
   left: 0;
   right: 0;
-  height: 32px;
-  min-height: 32px;
+  height: 64px;
+  min-height: 64px;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 10px;
+  padding: 0 16px;
   z-index: 10000;
   background: var(--color-panel, #fff);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
@@ -2804,8 +2804,12 @@ mark.search-hit {
 }
 
 .traffic__btn {
-  width: 12px;
-  height: 12px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
   border-radius: 50%;
   padding: 0;
   margin: 0;
@@ -2814,6 +2818,26 @@ mark.search-hit {
     inset 0 0 0 0.5px rgba(255, 255, 255, 0.6),
     0 0 0 1px rgba(0, 0, 0, 0.08);
   -webkit-app-region: no-drag;
+}
+
+.traffic__btn::after {
+  content: "";
+  color: rgba(0, 0, 0, 0.65);
+  font-size: 10px;
+  line-height: 1;
+}
+
+.traffic__close:hover::after {
+  content: "×";
+}
+
+.traffic__min:hover::after {
+  content: "–";
+}
+
+.traffic__max:hover::after {
+  content: "‹›";
+  letter-spacing: -1px;
 }
 
 .traffic__close {
@@ -2832,12 +2856,12 @@ mark.search-hit {
 #content,
 #view,
 .container {
-  padding-top: 32px;
+  padding-top: 64px;
 }
 
 .sidebar {
-  top: 32px;
-  height: calc(100vh - 32px);
+  top: 64px;
+  height: calc(100vh - 64px);
 }
 
 /* ========================================================================== */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2780,17 +2780,20 @@ mark.search-hit {
 /* ========================================================================== */
 
 .app-toolbar {
+  position: fixed;
+  inset: 0 auto auto 0;
+  right: 0;
   height: 32px;
   min-height: 32px;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 0 10px;
+  z-index: 10000;
   background: var(--color-panel, #fff);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
   -webkit-user-select: none;
   user-select: none;
-  z-index: 1000;
 }
 
 .traffic {
@@ -2805,7 +2808,9 @@ mark.search-hit {
   padding: 0;
   margin: 0;
   border: 1px solid rgba(0, 0, 0, 0.15);
-  box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.5);
+  box-shadow:
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.6),
+    0 0 0 1px rgba(0, 0, 0, 0.08);
   -webkit-app-region: no-drag;
 }
 
@@ -2821,15 +2826,16 @@ mark.search-hit {
   background: #28c940;
 }
 
-.traffic__btn:hover {
-  filter: brightness(1.05);
-}
-
 #app,
 #content,
 #view,
 .container {
   padding-top: 32px;
+}
+
+.sidebar {
+  top: 32px;
+  height: calc(100vh - 32px);
 }
 
 /* ========================================================================== */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2827,6 +2827,10 @@ mark.search-hit {
   background: #28c940;
 }
 
+.traffic__toast {
+  background: #007aff;
+}
+
 #app,
 #content,
 #view,

--- a/src/ui/AppToolbar.ts
+++ b/src/ui/AppToolbar.ts
@@ -1,5 +1,7 @@
 // src/ui/AppToolbar.ts
 
+import { toast } from "@ui/Toast";
+
 type TauriWin = {
   isMaximized: () => Promise<boolean>;
   maximize: () => Promise<void>;
@@ -56,6 +58,7 @@ export async function mountMacToolbar(host: HTMLElement): Promise<void> {
       <button class="traffic__btn traffic__close" title="Close" data-tauri-drag-region="false" aria-label="Close"></button>
       <button class="traffic__btn traffic__min" title="Minimize" data-tauri-drag-region="false" aria-label="Minimize"></button>
       <button class="traffic__btn traffic__max" title="Zoom" data-tauri-drag-region="false" aria-label="Zoom"></button>
+      <button class="traffic__btn traffic__toast" title="Say hi" data-tauri-drag-region="false" aria-label="Say hi"></button>
     </div>
   `;
 
@@ -82,6 +85,10 @@ export async function mountMacToolbar(host: HTMLElement): Promise<void> {
 
   query(".traffic__max").addEventListener("click", async () => {
     (await win.isMaximized()) ? await win.unmaximize() : await win.maximize();
+  });
+
+  query(".traffic__toast").addEventListener("click", () => {
+    toast.show({ kind: "info", message: "Hi from my new toolbar" });
   });
 
   host.prepend(bar);

--- a/src/ui/AppToolbar.ts
+++ b/src/ui/AppToolbar.ts
@@ -1,3 +1,4 @@
+// src/ui/AppToolbar.ts
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 export function mountMacToolbar(host: HTMLElement): void {
@@ -15,16 +16,24 @@ export function mountMacToolbar(host: HTMLElement): void {
     </div>
   `;
 
+  // === Programmatic drag fallback (works even if drag-region is ignored) ===
+  // Only start dragging when clicking empty toolbar space (not on a button/input/etc.)
+  bar.addEventListener("mousedown", (e) => {
+    const target = e.target as HTMLElement;
+    const interactive = target.closest(
+      "button, a, input, textarea, select, [data-tauri-drag-region='false']"
+    );
+
+    if (!interactive && e.button === 0) {
+      void win.startDragging();
+    }
+  });
+
+  // Hook up the three mac buttons
   const query = (selector: string) => bar.querySelector<HTMLButtonElement>(selector)!;
 
-  query(".traffic__close").addEventListener("click", () => {
-    void win.close();
-  });
-
-  query(".traffic__min").addEventListener("click", () => {
-    void win.minimize();
-  });
-
+  query(".traffic__close").addEventListener("click", () => void win.close());
+  query(".traffic__min").addEventListener("click", () => void win.minimize());
   query(".traffic__max").addEventListener("click", async () => {
     (await win.isMaximized()) ? await win.unmaximize() : await win.maximize();
   });

--- a/src/ui/AppToolbar.ts
+++ b/src/ui/AppToolbar.ts
@@ -1,51 +1,8 @@
 // src/ui/AppToolbar.ts
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
-type TauriWin = {
-  isMaximized: () => Promise<boolean>;
-  maximize: () => Promise<void>;
-  unmaximize: () => Promise<void>;
-  minimize: () => Promise<void>;
-  close: () => Promise<void>;
-  startDragging: () => Promise<void>;
-  isDecorated?: () => Promise<boolean>;
-};
-
-async function resolveWindow(): Promise<TauriWin> {
-  try {
-    const mod: any = await import("@tauri-apps/api/window");
-    if (typeof mod.getCurrent === "function") {
-      return mod.getCurrent() as TauriWin;
-    }
-    if (typeof mod.getCurrentWindow === "function") {
-      return mod.getCurrentWindow() as TauriWin;
-    }
-  } catch {
-    // ignore — fallback below
-  }
-
-  const globalWindow = (window as unknown as {
-    __TAURI__?: { window?: Record<string, () => TauriWin> };
-  }).__TAURI__?.window;
-
-  if (typeof globalWindow?.getCurrent === "function") {
-    return globalWindow.getCurrent();
-  }
-
-  if (typeof globalWindow?.getCurrentWindow === "function") {
-    return globalWindow.getCurrentWindow();
-  }
-
-  throw new Error("Cannot resolve Tauri window API (ESM and global both unavailable).");
-}
-
-export async function mountMacToolbar(host: HTMLElement): Promise<void> {
-  let win: TauriWin;
-  try {
-    win = await resolveWindow();
-  } catch (error) {
-    console.error("[AppToolbar] window API not available:", error);
-    return;
-  }
+export function mountMacToolbar(host: HTMLElement): void {
+  const win = getCurrentWindow();
 
   const bar = document.createElement("header");
   bar.className = "app-toolbar";
@@ -53,38 +10,11 @@ export async function mountMacToolbar(host: HTMLElement): Promise<void> {
 
   bar.innerHTML = `
     <div class="traffic" aria-label="Window controls">
-      <button class="traffic__btn traffic__close" title="Close" data-tauri-drag-region="false" aria-label="Close"></button>
-      <button class="traffic__btn traffic__min" title="Minimize" data-tauri-drag-region="false" aria-label="Minimize"></button>
-      <button class="traffic__btn traffic__max" title="Zoom" data-tauri-drag-region="false" aria-label="Zoom"></button>
+      <button class="traffic__btn traffic__close" title="Close" data-tauri-drag-region="false"></button>
+      <button class="traffic__btn traffic__min" title="Minimize" data-tauri-drag-region="false"></button>
+      <button class="traffic__btn traffic__max" title="Zoom" data-tauri-drag-region="false"></button>
     </div>
   `;
-
-  bar.addEventListener("pointerdown", (event) => {
-    const target = event.target as HTMLElement;
-    const interactive = target.closest(
-      "button, a, input, textarea, select, [data-tauri-drag-region='false']",
-    );
-    if (interactive || event.button !== 0) return;
-
-    event.preventDefault();
-    requestAnimationFrame(() => {
-      void win.startDragging().catch(() => {
-        // no-op: dragging may fail if window API becomes unavailable mid-gesture
-      });
-    });
-  });
-
-  bar.addEventListener("dblclick", async (event) => {
-    if (
-      (event.target as HTMLElement).closest(
-        "[data-tauri-drag-region='false']",
-      )
-    ) {
-      return;
-    }
-
-    (await win.isMaximized()) ? await win.unmaximize() : await win.maximize();
-  });
 
   const query = (selector: string) => bar.querySelector<HTMLButtonElement>(selector)!;
 
@@ -101,13 +31,4 @@ export async function mountMacToolbar(host: HTMLElement): Promise<void> {
   });
 
   host.prepend(bar);
-
-  void (async () => {
-    try {
-      const decorated = await (win.isDecorated?.() ?? Promise.resolve(undefined));
-      console.log("[AppToolbar] mounted. decorated?:", decorated);
-    } catch {
-      // no-op
-    }
-  })();
 }

--- a/src/ui/AppToolbar.ts
+++ b/src/ui/AppToolbar.ts
@@ -1,0 +1,33 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export function mountMacToolbar(host: HTMLElement): void {
+  const win = getCurrentWindow();
+
+  const bar = document.createElement("header");
+  bar.className = "app-toolbar";
+  bar.setAttribute("data-tauri-drag-region", "true");
+
+  bar.innerHTML = `
+    <div class="traffic" aria-label="Window controls">
+      <button class="traffic__btn traffic__close"  title="Close"    data-tauri-drag-region="false"></button>
+      <button class="traffic__btn traffic__min"    title="Minimize" data-tauri-drag-region="false"></button>
+      <button class="traffic__btn traffic__max"    title="Zoom"     data-tauri-drag-region="false"></button>
+    </div>
+  `;
+
+  const query = (selector: string) => bar.querySelector<HTMLButtonElement>(selector)!;
+
+  query(".traffic__close").addEventListener("click", () => {
+    void win.close();
+  });
+
+  query(".traffic__min").addEventListener("click", () => {
+    void win.minimize();
+  });
+
+  query(".traffic__max").addEventListener("click", async () => {
+    (await win.isMaximized()) ? await win.unmaximize() : await win.maximize();
+  });
+
+  host.prepend(bar);
+}

--- a/src/ui/AppToolbar.ts
+++ b/src/ui/AppToolbar.ts
@@ -1,8 +1,51 @@
 // src/ui/AppToolbar.ts
-import { getCurrentWindow } from "@tauri-apps/api/window";
 
-export function mountMacToolbar(host: HTMLElement): void {
-  const win = getCurrentWindow();
+type TauriWin = {
+  isMaximized: () => Promise<boolean>;
+  maximize: () => Promise<void>;
+  unmaximize: () => Promise<void>;
+  minimize: () => Promise<void>;
+  close: () => Promise<void>;
+  startDragging: () => Promise<void>;
+  isDecorated?: () => Promise<boolean>;
+};
+
+async function resolveWindow(): Promise<TauriWin> {
+  try {
+    const mod: any = await import("@tauri-apps/api/window");
+    if (typeof mod.getCurrent === "function") {
+      return mod.getCurrent() as TauriWin;
+    }
+    if (typeof mod.getCurrentWindow === "function") {
+      return mod.getCurrentWindow() as TauriWin;
+    }
+  } catch {
+    // ignore — fallback below
+  }
+
+  const globalWindow = (window as unknown as {
+    __TAURI__?: { window?: Record<string, () => TauriWin> };
+  }).__TAURI__?.window;
+
+  if (typeof globalWindow?.getCurrent === "function") {
+    return globalWindow.getCurrent();
+  }
+
+  if (typeof globalWindow?.getCurrentWindow === "function") {
+    return globalWindow.getCurrentWindow();
+  }
+
+  throw new Error("Cannot resolve Tauri window API (ESM and global both unavailable).");
+}
+
+export async function mountMacToolbar(host: HTMLElement): Promise<void> {
+  let win: TauriWin;
+  try {
+    win = await resolveWindow();
+  } catch (error) {
+    console.error("[AppToolbar] window API not available:", error);
+    return;
+  }
 
   const bar = document.createElement("header");
   bar.className = "app-toolbar";
@@ -10,33 +53,45 @@ export function mountMacToolbar(host: HTMLElement): void {
 
   bar.innerHTML = `
     <div class="traffic" aria-label="Window controls">
-      <button class="traffic__btn traffic__close"  title="Close"    data-tauri-drag-region="false"></button>
-      <button class="traffic__btn traffic__min"    title="Minimize" data-tauri-drag-region="false"></button>
-      <button class="traffic__btn traffic__max"    title="Zoom"     data-tauri-drag-region="false"></button>
+      <button class="traffic__btn traffic__close" title="Close" data-tauri-drag-region="false" aria-label="Close"></button>
+      <button class="traffic__btn traffic__min" title="Minimize" data-tauri-drag-region="false" aria-label="Minimize"></button>
+      <button class="traffic__btn traffic__max" title="Zoom" data-tauri-drag-region="false" aria-label="Zoom"></button>
     </div>
   `;
 
-  // === Programmatic drag fallback (works even if drag-region is ignored) ===
-  // Only start dragging when clicking empty toolbar space (not on a button/input/etc.)
-  bar.addEventListener("mousedown", (e) => {
-    const target = e.target as HTMLElement;
+  bar.addEventListener("mousedown", (event) => {
+    const target = event.target as HTMLElement;
     const interactive = target.closest(
-      "button, a, input, textarea, select, [data-tauri-drag-region='false']"
+      "button, a, input, textarea, select, [data-tauri-drag-region='false']",
     );
 
-    if (!interactive && e.button === 0) {
+    if (!interactive && event.button === 0) {
       void win.startDragging();
     }
   });
 
-  // Hook up the three mac buttons
   const query = (selector: string) => bar.querySelector<HTMLButtonElement>(selector)!;
 
-  query(".traffic__close").addEventListener("click", () => void win.close());
-  query(".traffic__min").addEventListener("click", () => void win.minimize());
+  query(".traffic__close").addEventListener("click", () => {
+    void win.close();
+  });
+
+  query(".traffic__min").addEventListener("click", () => {
+    void win.minimize();
+  });
+
   query(".traffic__max").addEventListener("click", async () => {
     (await win.isMaximized()) ? await win.unmaximize() : await win.maximize();
   });
 
   host.prepend(bar);
+
+  void (async () => {
+    try {
+      const decorated = await (win.isDecorated?.() ?? Promise.resolve(undefined));
+      console.log("[AppToolbar] mounted. decorated?:", decorated);
+    } catch {
+      // no-op
+    }
+  })();
 }


### PR DESCRIPTION
## Summary
- disable native window decorations in the Tauri configuration so the app can render its own chrome
- add a reusable toolbar helper that mounts macOS-style traffic-light controls and wires them to window actions
- style the custom toolbar and ensure content is offset to avoid overlap with the new chrome

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d821f18244832a962cd7a93ef8174d