### PR TITLE
Polish ambient blob renderer caching and rotation tests

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,96 @@
+# Ambient Background System
+
+The ambient background provides a lightweight, canvas-based blob animation that runs behind the dashboard and other views. It ships with two power-aware renderers and a deterministic rotation system so every install receives a stable weekly look unless the user chooses otherwise.
+
+## Components
+
+### `SoloBlobEco`
+
+`src/components/SoloBlobEco.tsx` exports a `SoloBlobEco` class that manages a single canvas element. Key features:
+
+- Caps rendering scale to ≤ 0.75 × DPR (and never above 1 × DPR).
+- Uses pre-rendered radial sprites to avoid per-frame allocations.
+- Drops from 20 fps to 8 fps after 10 s of inactivity and pauses when the document is hidden or reduced-motion is requested.
+- Supports primary and secondary tones (`teal`, `aqua`, `teal2`, `coral`, `shade`).
+
+Constructor signature:
+
+```ts
+const renderer = new SoloBlobEco(hostElement, {
+  seed,              // number used to seed the pseudo RNG
+  mode: "teal",      // primary blob tone (default teal)
+  secondMode: "aqua",// optional secondary tone
+  activeFps: 20,
+  idleFps: 8,
+  idleMs: 10_000,
+  renderScale: 0.75,
+  edgeBias: 0.75,
+  zIndex?: number,
+  paused?: boolean,
+});
+```
+
+Call `renderer.setSeed(nextSeed)` to rebuild the animation deterministically or `renderer.setModes(primary, secondary)` to swap tones. `renderer.renderOnce()` renders a static frame for reduced-motion scenarios. Always call `renderer.destroy()` when removing the host.
+
+Prefer the helper `mountSoloBlobEco(host, options)` where possible – it wraps construction with defensive logging and returns the renderer instance.
+
+### `BlobFieldEco`
+
+`src/components/BlobFieldEco.tsx` builds on the same base class and renders a light multi-blob field. Options include:
+
+```ts
+const field = new BlobFieldEco(host, {
+  seed,
+  count: 10,
+  maxFps: 30,
+  idleFps: 12,
+  idleMs: 12_000,
+  renderScale: 0.7,
+  edgeBias: 0.55,
+});
+```
+
+`setCount(n)` and `setPalette([tone, …])` reconfigure the field at runtime. Like the solo renderer, call `destroy()` when cleaning up.
+
+Use `mountBlobFieldEco(host, options)` to create the field with the same convenience and logging guarantees as the solo helper.
+
+Both renderers respect `prefers-reduced-motion` and pause automatically when the document is hidden or the Tauri window blurs.
+
+## Rotation & Persistence
+
+The rotation helpers in `src/lib/blobRotation.ts` provide deterministic seeds derived from the install ID and the current ISO week (Europe/London) or month:
+
+- `getBlobSeedForPeriod(mode)` returns the seed for the requested cadence and persists `blobSeed`, `blobWeekKey`, and `blobLastGeneratedAt` in `window-state.json` (via `tauri-plugin-store`).
+- `forceNewBlobUniverse()` generates a fresh seed inside the current period and broadcasts it to listeners.
+- Utility exports `formatIsoWeekKey`, `formatLondonMonthKey`, and `fnv1a32` support testing and diagnostics.
+
+`src/lib/store.ts` wraps `tauri-plugin-store` with in-memory fallbacks so tests and non-Tauri environments never throw if storage is unavailable. It exposes `getAmbientMode`, `setAmbientMode`, `getRotationMode`, and change listeners used by the UI and background controller.
+
+## Ambient Background Controller
+
+`src/ui/AmbientBackground.ts` initialises the background once the layout mounts. It listens for:
+
+- Ambient mode changes (`Off`, `Eco`, `Full`).
+- Rotation cadence changes (`Off`, `Weekly`, `Monthly`).
+- Seed updates from the rotation helpers and the “Refresh now” action.
+- `tauri://focus` and `tauri://blur` events to resume/pause rendering when the window gains or loses focus.
+
+The controller mounts `SoloBlobEco` for Eco/Off modes (rendering a static frame when motion is disabled) and `BlobFieldEco` for Full mode. It tears down cleanly on unload.
+
+## Settings UI
+
+`src/features/settings/components/AmbientBackgroundSection.ts` adds a dedicated card under Settings → Appearance with:
+
+- Radio buttons to toggle Ambient background (Off / Eco / Full).
+- Rotation cadence options (Off / Weekly / Monthly).
+- A “Refresh now” button that calls `forceNewBlobUniverse()`.
+- Status messaging for persistence/refresh feedback.
+
+All controls persist through `tauri-plugin-store` and apply immediately to the background controller.
+
+## Troubleshooting
+
+- **No motion:** Verify `prefers-reduced-motion` and the user’s Ambient mode (Off renders a static frame). The controller logs to `log.debug` when initialising or changing mode.
+- **Seeds not rotating:** Ensure `blobRotation` is set to Weekly or Monthly. For diagnostics, inspect `window-state.json` (`blobWeekKey`, `blobLastGeneratedAt`).
+- **High CPU usage:** Confirm render scale (`renderScale` prop) ≤ 0.75 and blob counts within the documented budgets (≤ 2 for Solo, ≤ 12 for Field). The renderers automatically drop to idle fps when inactive.
+- **Storage failures:** The store wrapper falls back to volatile memory; seeds still generate deterministically for the session but won’t persist between launches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-notification": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-sql": "^2.3.0",
+        "@tauri-apps/plugin-store": "^2.4.0",
         "better-sqlite3": "^12.2.0"
       },
       "devDependencies": {
@@ -1911,6 +1912,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-store": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.0.tgz",
+      "integrity": "sha512-PjBnlnH6jyI71MGhrPaxUUCsOzc7WO1mbc4gRhME0m2oxLgCqbksw6JyeKQimuzv4ysdpNO3YbmaY2haf82a3A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@tauri-apps/plugin-notification": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-sql": "^2.3.0",
+    "@tauri-apps/plugin-store": "^2.4.0",
     "better-sqlite3": "^12.2.0"
   },
   "devDependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
+ "tauri-plugin-store",
  "tempfile",
  "thiserror 1.0.69",
  "time",
@@ -5482,6 +5483,22 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85dd80d60a76ee2c2fdce09e9ef30877b239c2a6bb76e6d7d03708aa5f13a19"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-store = "2"
 uuid = { version = "1", features = ["v7", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "=0.10.4"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,8 @@
     "fs:allow-remove",
     "notification:default",
     "opener:default",
-    "opener:allow-open-path"
+    "opener:allow-open-path",
+    "store:default",
+    "store:allow-load"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2390,6 +2390,7 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
             let handle = app.handle();

--- a/src/SettingsView.ts
+++ b/src/SettingsView.ts
@@ -16,6 +16,7 @@ import { createEmptyState } from "./ui/EmptyState";
 import { STR } from "./ui/strings";
 import createButton from "@ui/Button";
 import { createAttributionSection } from "@features/settings/components/AttributionSection";
+import { createAmbientBackgroundSection } from "@features/settings/components/AmbientBackgroundSection";
 
 export function SettingsView(container: HTMLElement) {
   const panel = SettingsPanel();
@@ -61,7 +62,7 @@ export function SettingsView(container: HTMLElement) {
   const general = createEmptySection("settings-general", "General");
   const storage = createEmptySection("settings-storage", "Storage and permissions");
   const notifications = createEmptySection("settings-notifications", "Notifications");
-  const appearance = createEmptySection("settings-appearance", "Appearance");
+  const appearance = createAmbientBackgroundSection();
 
   const about = document.createElement("section");
   about.className = "card settings__section";

--- a/src/components/BlobFieldEco.tsx
+++ b/src/components/BlobFieldEco.tsx
@@ -1,0 +1,62 @@
+import { log } from "@utils/logger";
+import {
+  AmbientBlobCanvas,
+  type AmbientRendererOptions,
+  type BlobTone,
+  type BlobState,
+} from "./SoloBlobEco";
+
+export interface BlobFieldEcoOptions extends AmbientRendererOptions {
+  count?: number;
+  palette?: BlobTone[];
+  maxFps?: number;
+}
+
+export class BlobFieldEco extends AmbientBlobCanvas {
+  private count: number;
+  private palette: BlobTone[];
+
+  constructor(host: HTMLElement, options: BlobFieldEcoOptions) {
+    const active = options.maxFps ?? options.activeFps ?? 30;
+    super(host, { ...options, activeFps: active });
+    this.count = Math.max(1, Math.floor(options.count ?? 8));
+    this.palette = options.palette && options.palette.length
+      ? [...options.palette]
+      : ["teal", "teal2", "aqua", "shade", "coral"];
+    this.refresh();
+    this.initialisePlayback();
+  }
+
+  setCount(count: number): void {
+    const next = Math.max(1, Math.floor(count));
+    if (next === this.count) return;
+    this.count = next;
+    this.refresh();
+  }
+
+  setPalette(palette: BlobTone[]): void {
+    if (!palette.length) return;
+    this.palette = [...palette];
+    this.refresh();
+  }
+
+  protected override buildBlobs(rng: () => number): BlobState[] {
+    const palette: BlobTone[] = this.palette.length ? this.palette : ["teal"];
+    const blobs: BlobState[] = [];
+    for (let index = 0; index < this.count; index += 1) {
+      const tone = palette[Math.floor(rng() * palette.length)] ?? palette[0]!;
+      const emphasis = tone === "coral" ? 0.6 : tone === "shade" ? 1.3 : 1;
+      blobs.push(this.createBlob(tone, rng, emphasis));
+    }
+    return blobs;
+  }
+}
+
+export function mountBlobFieldEco(host: HTMLElement, options: BlobFieldEcoOptions): BlobFieldEco {
+  try {
+    return new BlobFieldEco(host, options);
+  } catch (error) {
+    log.warn("BlobFieldEco failed to mount", error);
+    throw error;
+  }
+}

--- a/src/components/SoloBlobEco.tsx
+++ b/src/components/SoloBlobEco.tsx
@@ -1,0 +1,484 @@
+import { log } from "@utils/logger";
+
+export type BlobTone = "teal" | "aqua" | "coral" | "teal2" | "shade";
+
+interface ToneDefinition {
+  colorVar: string;
+  alphaVar: string;
+}
+
+const TONES: Record<BlobTone, ToneDefinition> = {
+  teal: { colorVar: "--blob-main", alphaVar: "--blob-alpha-main" },
+  teal2: { colorVar: "--blob-tint", alphaVar: "--blob-alpha-tint" },
+  shade: { colorVar: "--blob-shade", alphaVar: "--blob-alpha-shade" },
+  aqua: { colorVar: "--blob-aqua", alphaVar: "--blob-alpha-aqua" },
+  coral: { colorVar: "--blob-coral", alphaVar: "--blob-alpha-coral" },
+};
+
+export interface BlobState {
+  tone: BlobTone;
+  sprite: HTMLCanvasElement;
+  alpha: number;
+  radiusFactor: number;
+  freqX: number;
+  freqY: number;
+  freqX2: number;
+  freqY2: number;
+  amplitudeX: number;
+  amplitudeY: number;
+  altAmplitudeX: number;
+  altAmplitudeY: number;
+  phaseX: number;
+  phaseY: number;
+  phaseX2: number;
+  phaseY2: number;
+  offsetX: number;
+  offsetY: number;
+  timeOffset: number;
+}
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    t = Math.imul(t ^ (t >>> 15), 1 | t);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function readCssVar(name: string, fallback = ""): string {
+  if (typeof window === "undefined") return fallback;
+  const style = getComputedStyle(document.documentElement);
+  const value = style.getPropertyValue(name).trim();
+  return value || fallback;
+}
+
+function parseAlpha(name: string): number {
+  const raw = readCssVar(name);
+  const parsed = Number.parseFloat(raw);
+  if (Number.isNaN(parsed)) return 0.05;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.trim().replace(/^#/, "");
+  if (value.length === 3) {
+    const r = value[0] ?? "0";
+    const g = value[1] ?? "0";
+    const b = value[2] ?? "0";
+    return [Number.parseInt(r + r, 16), Number.parseInt(g + g, 16), Number.parseInt(b + b, 16)];
+  }
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  return [Number.isNaN(r) ? 0 : r, Number.isNaN(g) ? 0 : g, Number.isNaN(b) ? 0 : b];
+}
+
+function parseRgbTuple(color: string): [number, number, number] {
+  const match = color.trim().match(/rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/i);
+  if (!match) return [0, 200, 150];
+  const r = Math.max(0, Math.min(255, Number.parseInt(match[1] ?? "0", 10)));
+  const g = Math.max(0, Math.min(255, Number.parseInt(match[2] ?? "0", 10)));
+  const b = Math.max(0, Math.min(255, Number.parseInt(match[3] ?? "0", 10)));
+  return [r, g, b];
+}
+
+function toRgb(color: string): [number, number, number] {
+  if (color.trim().startsWith("#")) {
+    return hexToRgb(color);
+  }
+  return parseRgbTuple(color);
+}
+
+const spriteCache = new Map<string, HTMLCanvasElement>();
+
+function quantizeAlpha(alpha: number, step = 0.02): number {
+  const quantized = Math.round(alpha / step) * step;
+  return Math.max(0, Math.min(1, quantized));
+}
+
+function makeSprite(tone: BlobTone, color: string, alpha: number): HTMLCanvasElement {
+  const qa = quantizeAlpha(alpha);
+  const key = `${tone}:${color}:${qa.toFixed(2)}`;
+  const cached = spriteCache.get(key);
+  if (cached) return cached;
+
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.clearRect(0, 0, size, size);
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, size * 0.15, size / 2, size / 2, size / 2);
+    const [r, g, b] = toRgb(color);
+    gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, ${qa})`);
+    gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+  }
+  spriteCache.set(key, canvas);
+  return canvas;
+}
+
+export interface AmbientRendererOptions {
+  seed: number;
+  activeFps?: number;
+  idleFps?: number;
+  idleMs?: number;
+  renderScale?: number;
+  edgeBias?: number;
+  zIndex?: number;
+  paused?: boolean;
+}
+
+const INTERACTION_EVENTS: (keyof WindowEventMap)[] = [
+  "pointerdown",
+  "pointermove",
+  "keydown",
+  "wheel",
+  "touchstart",
+];
+
+export abstract class AmbientBlobCanvas {
+  readonly element: HTMLCanvasElement;
+  protected seed: number;
+  protected blobs: BlobState[] = [];
+  protected readonly host: HTMLElement;
+  protected readonly ctx: CanvasRenderingContext2D | null;
+  protected readonly renderScale: number;
+  protected readonly activeFps: number;
+  protected readonly idleFps: number;
+  protected readonly idleMs: number;
+  protected readonly edgeBias: number;
+  private readonly resizeObserver: ResizeObserver | null;
+  private frameHandle: number | null = null;
+  private readonly motionQuery: MediaQueryList | null = null;
+  private readonly onMotionChangeBound: ((event: MediaQueryListEvent) => void) | null = null;
+  private readonly onVisibilityChangeBound: () => void;
+  private readonly onInteractionBound: () => void;
+  private readonly onWindowResizeBound: (() => void) | null = null;
+  private pausedManually: boolean;
+  private reduceMotion = false;
+  private isHidden = false;
+  private lastInteraction = performance.now();
+  private lastRender = 0;
+  private hasFrame = false;
+  private startTime = performance.now();
+  private readonly autoStart: boolean;
+  private cssWidth = 0;
+  private cssHeight = 0;
+
+  constructor(host: HTMLElement, options: AmbientRendererOptions) {
+    this.host = host;
+    this.seed = options.seed >>> 0;
+    this.renderScale = Math.min(1, Math.max(0.1, options.renderScale ?? 0.75));
+    this.activeFps = Math.max(0, options.activeFps ?? 20);
+    this.idleFps = Math.max(0, options.idleFps ?? 8);
+    this.idleMs = Math.max(1000, options.idleMs ?? 10000);
+    this.edgeBias = Math.max(0, Math.min(1, options.edgeBias ?? 0.75));
+
+    const canvas = document.createElement("canvas");
+    canvas.style.position = "absolute";
+    canvas.style.inset = "0";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    canvas.style.pointerEvents = "none";
+    if (typeof options.zIndex === "number") {
+      canvas.style.zIndex = String(options.zIndex);
+    }
+    this.element = canvas;
+    this.ctx = canvas.getContext("2d", { alpha: true });
+    if (this.ctx) {
+      this.ctx.imageSmoothingEnabled = true;
+      this.ctx.imageSmoothingQuality = "high";
+    }
+    host.appendChild(canvas);
+
+    this.resizeObserver = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => this.handleResize())
+      : null;
+    this.resizeObserver?.observe(host);
+    if (!this.resizeObserver) {
+      this.onWindowResizeBound = () => this.handleResize();
+      window.addEventListener("resize", this.onWindowResizeBound, { passive: true });
+    }
+    this.handleResize();
+
+    this.motionQuery = typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)")
+      : null;
+    if (this.motionQuery) {
+      this.reduceMotion = this.motionQuery.matches;
+      const handler = (event: MediaQueryListEvent) => {
+        this.reduceMotion = event.matches;
+        if (this.reduceMotion) {
+          this.stop();
+          this.renderOnce();
+        } else if (!this.pausedManually && !this.isHidden) {
+          this.start();
+        }
+      };
+      this.onMotionChangeBound = handler;
+      if (typeof this.motionQuery.addEventListener === "function") {
+        this.motionQuery.addEventListener("change", handler);
+      } else if (typeof this.motionQuery.addListener === "function") {
+        this.motionQuery.addListener(handler);
+      }
+    }
+
+    this.onVisibilityChangeBound = () => {
+      this.isHidden = document.hidden;
+      if (this.isHidden) {
+        this.stop();
+      } else if (!this.pausedManually && !this.reduceMotion) {
+        this.start();
+      }
+    };
+    document.addEventListener("visibilitychange", this.onVisibilityChangeBound);
+
+    this.onInteractionBound = () => {
+      this.lastInteraction = performance.now();
+    };
+    INTERACTION_EVENTS.forEach((eventName) => {
+      window.addEventListener(eventName, this.onInteractionBound, { passive: true });
+    });
+
+    this.autoStart = !options.paused;
+    this.pausedManually = !!options.paused;
+    this.isHidden = document.hidden;
+  }
+
+  protected abstract buildBlobs(rng: () => number): BlobState[];
+
+  protected initialisePlayback(): void {
+    if (this.autoStart && !this.reduceMotion && !this.isHidden) {
+      this.start();
+    } else {
+      this.renderOnce();
+    }
+  }
+
+  protected refresh(): void {
+    const rng = mulberry32(this.seed || 1);
+    const blobs = this.buildBlobs(rng);
+    this.blobs = [...blobs].sort((a, b) => a.alpha - b.alpha);
+    this.renderOnce();
+  }
+
+  protected createBlob(tone: BlobTone, rng: () => number, emphasis = 1): BlobState {
+    const def = TONES[tone] ?? TONES.teal;
+    const color = readCssVar(def.colorVar, "#00C896");
+    const baseAlpha = parseAlpha(def.alphaVar);
+    const alpha = Math.max(0, Math.min(1, baseAlpha * (0.8 + rng() * 0.4) * emphasis));
+    const sprite = makeSprite(tone, color, alpha);
+
+    const radiusFactor = 0.25 + rng() * 0.2;
+    const freqX = (Math.PI * 2) / (20 + rng() * 20);
+    const freqY = (Math.PI * 2) / (20 + rng() * 20);
+    const freqX2 = freqX * (0.4 + rng() * 0.6);
+    const freqY2 = freqY * (0.4 + rng() * 0.6);
+    const amplitudeX = 0.22 + rng() * 0.2;
+    const amplitudeY = 0.18 + rng() * 0.2;
+    const altAmplitudeX = amplitudeX * (0.3 + rng() * 0.4);
+    const altAmplitudeY = amplitudeY * (0.3 + rng() * 0.4);
+    const offsetX = (rng() - 0.5) * 0.6 * this.edgeBias;
+    const offsetY = (rng() - 0.5) * 0.6 * this.edgeBias;
+    const phaseX = rng() * Math.PI * 2;
+    const phaseY = rng() * Math.PI * 2;
+    const phaseX2 = rng() * Math.PI * 2;
+    const phaseY2 = rng() * Math.PI * 2;
+    const timeOffset = rng() * 40;
+
+    return {
+      tone,
+      sprite,
+      alpha,
+      radiusFactor,
+      freqX,
+      freqY,
+      freqX2,
+      freqY2,
+      amplitudeX,
+      amplitudeY,
+      altAmplitudeX,
+      altAmplitudeY,
+      phaseX,
+      phaseY,
+      phaseX2,
+      phaseY2,
+      offsetX,
+      offsetY,
+      timeOffset,
+    };
+  }
+
+  private handleResize(): void {
+    const width = this.host.clientWidth;
+    const height = this.host.clientHeight;
+    this.cssWidth = width;
+    this.cssHeight = height;
+    if (width === 0 || height === 0) return;
+    const dpr = typeof window !== "undefined" ? Math.min(window.devicePixelRatio || 1, 1) : 1;
+    const scaledWidth = Math.max(1, Math.floor(width * dpr * this.renderScale));
+    const scaledHeight = Math.max(1, Math.floor(height * dpr * this.renderScale));
+    if (this.element.width !== scaledWidth || this.element.height !== scaledHeight) {
+      this.element.width = scaledWidth;
+      this.element.height = scaledHeight;
+    }
+    if (this.ctx) {
+      this.ctx.setTransform(this.element.width / width, 0, 0, this.element.height / height, 0, 0);
+    }
+    this.renderOnce();
+  }
+
+  private loop = (timestamp: number) => {
+    this.frameHandle = null;
+    if (this.pausedManually || this.reduceMotion || this.isHidden) {
+      return;
+    }
+    if (!this.hasFrame) {
+      this.startTime = timestamp;
+      this.hasFrame = true;
+    }
+    const fps = this.computeFps(timestamp);
+    if (fps > 0) {
+      const interval = 1000 / fps;
+      if (timestamp - this.lastRender >= interval) {
+        this.lastRender = timestamp;
+        this.renderFrame(timestamp);
+      }
+    }
+    this.schedule();
+  };
+
+  private schedule(): void {
+    if (this.frameHandle !== null) return;
+    this.frameHandle = requestAnimationFrame(this.loop);
+  }
+
+  private computeFps(now: number): number {
+    if (this.activeFps <= 0) return 0;
+    if (now - this.lastInteraction > this.idleMs) {
+      return this.idleFps;
+    }
+    return this.activeFps;
+  }
+
+  private renderFrame(now: number): void {
+    if (!this.ctx) return;
+    const width = this.cssWidth;
+    const height = this.cssHeight;
+    if (width === 0 || height === 0) return;
+    this.ctx.clearRect(0, 0, width, height);
+    const elapsed = (now - this.startTime) / 1000;
+    const minSize = Math.min(width, height);
+    for (const blob of this.blobs) {
+      const t = elapsed + blob.timeOffset;
+      const x = width * (0.5 + blob.offsetX + blob.amplitudeX * Math.sin(blob.freqX * t + blob.phaseX)
+        + blob.altAmplitudeX * Math.sin(blob.freqX2 * t + blob.phaseX2));
+      const y = height * (0.5 + blob.offsetY + blob.amplitudeY * Math.cos(blob.freqY * t + blob.phaseY)
+        + blob.altAmplitudeY * Math.cos(blob.freqY2 * t + blob.phaseY2));
+      const radius = minSize * blob.radiusFactor;
+      this.ctx.globalAlpha = blob.alpha;
+      this.ctx.drawImage(blob.sprite, x - radius, y - radius, radius * 2, radius * 2);
+    }
+    this.ctx.globalAlpha = 1;
+  }
+
+  renderOnce(): void {
+    this.renderFrame(performance.now());
+  }
+
+  setSeed(seed: number): void {
+    if (this.seed === (seed >>> 0)) return;
+    this.seed = seed >>> 0;
+    this.refresh();
+  }
+
+  setPaused(paused: boolean): void {
+    this.pausedManually = paused;
+    if (paused) {
+      this.stop();
+    } else if (!this.reduceMotion && !this.isHidden) {
+      this.start();
+    }
+  }
+
+  start(): void {
+    if (this.frameHandle !== null) return;
+    this.lastRender = 0;
+    this.schedule();
+  }
+
+  stop(): void {
+    if (this.frameHandle !== null) {
+      cancelAnimationFrame(this.frameHandle);
+      this.frameHandle = null;
+    }
+  }
+
+  destroy(): void {
+    this.stop();
+    this.resizeObserver?.disconnect();
+    document.removeEventListener("visibilitychange", this.onVisibilityChangeBound);
+    INTERACTION_EVENTS.forEach((eventName) => {
+      window.removeEventListener(eventName, this.onInteractionBound);
+    });
+    if (this.motionQuery && this.onMotionChangeBound) {
+      if (typeof this.motionQuery.removeEventListener === "function") {
+        this.motionQuery.removeEventListener("change", this.onMotionChangeBound);
+      } else if (typeof this.motionQuery.removeListener === "function") {
+        this.motionQuery.removeListener(this.onMotionChangeBound);
+      }
+    }
+    if (this.element.parentElement === this.host) {
+      this.host.removeChild(this.element);
+    }
+    if (this.onWindowResizeBound) {
+      window.removeEventListener("resize", this.onWindowResizeBound);
+    }
+  }
+}
+
+export interface SoloBlobEcoOptions extends AmbientRendererOptions {
+  mode?: BlobTone;
+  secondMode?: BlobTone | null;
+}
+
+export class SoloBlobEco extends AmbientBlobCanvas {
+  private tone: BlobTone;
+  private secondary: BlobTone | null;
+
+  constructor(host: HTMLElement, options: SoloBlobEcoOptions) {
+    super(host, options);
+    this.tone = options.mode ?? "teal";
+    this.secondary = options.secondMode ?? null;
+    this.refresh();
+    this.initialisePlayback();
+  }
+
+  setModes(primary: BlobTone, secondary: BlobTone | null): void {
+    this.tone = primary;
+    this.secondary = secondary;
+    this.refresh();
+  }
+
+  protected override buildBlobs(rng: () => number): BlobState[] {
+    const tones: BlobTone[] = [this.tone ?? "teal"];
+    if (this.secondary) {
+      tones.push(this.secondary);
+    }
+    return tones.map((tone, index) => this.createBlob(tone, rng, index === tones.length - 1 ? 1.1 : 1));
+  }
+}
+
+export function mountSoloBlobEco(host: HTMLElement, options: SoloBlobEcoOptions): SoloBlobEco {
+  try {
+    return new SoloBlobEco(host, options);
+  } catch (error) {
+    log.warn("SoloBlobEco failed to mount", error);
+    throw error;
+  }
+}

--- a/src/features/settings/components/AmbientBackgroundSection.ts
+++ b/src/features/settings/components/AmbientBackgroundSection.ts
@@ -1,0 +1,229 @@
+import createButton from "@ui/Button";
+import {
+  getAmbientMode,
+  setAmbientMode,
+  getRotationMode,
+  setRotationMode,
+  type AmbientMode,
+  type RotationMode,
+} from "@lib/store";
+import { forceNewBlobUniverse } from "@lib/blobRotation";
+import { log } from "@utils/logger";
+
+interface Option<T extends string> {
+  value: T;
+  label: string;
+  description: string;
+}
+
+const AMBIENT_OPTIONS: Option<AmbientMode>[] = [
+  {
+    value: "off",
+    label: "Off",
+    description: "Render a static frame when opened and pause all motion.",
+  },
+  {
+    value: "eco",
+    label: "Eco",
+    description: "Low-power SoloBlobEco with one or two soft blobs (recommended).",
+  },
+  {
+    value: "full",
+    label: "Full",
+    description: "BlobFieldEco with a gentle multi-blob field at higher fps.",
+  },
+];
+
+const ROTATION_OPTIONS: Option<Exclude<RotationMode, "manual">>[] = [
+  {
+    value: "off",
+    label: "Rotation off",
+    description: "Keep the current seed until you refresh manually.",
+  },
+  {
+    value: "weekly",
+    label: "Weekly",
+    description: "Derive a deterministic seed once per ISO week (Europe/London).",
+  },
+  {
+    value: "monthly",
+    label: "Monthly",
+    description: "Refresh with a new deterministic seed at the start of each month.",
+  },
+];
+
+function makeOptionId(group: string, value: string): string {
+  return `ambient-${group}-${value}`;
+}
+
+function createRadioGroup<T extends string>(
+  name: string,
+  legendText: string,
+  options: Option<T>[],
+  onChange: (value: T) => Promise<void>,
+): { element: HTMLElement; update(value: T): void } {
+  const fieldset = document.createElement("fieldset");
+  fieldset.className = "ambient-settings__group";
+
+  const legend = document.createElement("legend");
+  legend.className = "ambient-settings__legend";
+  legend.textContent = legendText;
+  fieldset.appendChild(legend);
+
+  const inputs = new Map<T, HTMLInputElement>();
+
+  options.forEach((option) => {
+    const id = makeOptionId(name, option.value);
+    const label = document.createElement("label");
+    label.className = "ambient-settings__option";
+    label.setAttribute("for", id);
+
+    const input = document.createElement("input");
+    input.type = "radio";
+    input.name = name;
+    input.id = id;
+    input.value = option.value;
+
+    const body = document.createElement("div");
+    body.className = "ambient-settings__copy";
+
+    const title = document.createElement("span");
+    title.className = "ambient-settings__title";
+    title.textContent = option.label;
+
+    const description = document.createElement("span");
+    description.className = "ambient-settings__description";
+    description.textContent = option.description;
+
+    body.append(title, description);
+    label.append(input, body);
+    fieldset.appendChild(label);
+
+    inputs.set(option.value, input);
+
+    input.addEventListener("change", () => {
+      if (!input.checked) return;
+      input.disabled = true;
+      void onChange(option.value).catch((error) => {
+        log.warn(`ambient:${name}:change`, error);
+      }).finally(() => {
+        input.disabled = false;
+      });
+    });
+  });
+
+  return {
+    element: fieldset,
+    update(value: T) {
+      const input = inputs.get(value);
+      if (!input) return;
+      input.checked = true;
+    },
+  };
+}
+
+function describeMode(mode: AmbientMode): string {
+  switch (mode) {
+    case "off":
+      return "Ambient background disabled.";
+    case "full":
+      return "Full field rendering enabled.";
+    default:
+      return "Eco renderer active.";
+  }
+}
+
+export function createAmbientBackgroundSection(): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "card settings__section settings__section--ambient";
+  section.setAttribute("aria-labelledby", "settings-ambient");
+
+  const heading = document.createElement("h3");
+  heading.id = "settings-ambient";
+  heading.textContent = "Ambient background";
+
+  const body = document.createElement("div");
+  body.className = "settings__body ambient-settings";
+
+  const status = document.createElement("p");
+  status.className = "ambient-settings__status";
+  status.textContent = "Loading ambient preferences…";
+
+  const ambientGroup = createRadioGroup<AmbientMode>(
+    "ambient-mode",
+    "Animation profile",
+    AMBIENT_OPTIONS,
+    async (value) => {
+      try {
+        await setAmbientMode(value);
+        status.textContent = describeMode(value);
+      } catch (error) {
+        status.textContent = "Unable to update ambient mode.";
+        log.warn("ambient:mode:update", error);
+        throw error;
+      }
+    },
+  );
+
+  const rotationGroup = createRadioGroup<Exclude<RotationMode, "manual">>(
+    "ambient-rotation",
+    "Rotation cadence",
+    ROTATION_OPTIONS,
+    async (value) => {
+      try {
+        await setRotationMode(value);
+        status.textContent = value === "off"
+          ? "Rotation paused. Use Refresh now to change the seed manually."
+          : `Rotation set to ${value}.`;
+      } catch (error) {
+        status.textContent = "Unable to update rotation cadence.";
+        log.warn("ambient:rotation:update", error);
+        throw error;
+      }
+    },
+  );
+
+  const refreshButton = createButton({
+    label: "Refresh now",
+    variant: "ghost",
+    className: "settings__button ambient-settings__refresh",
+    type: "button",
+  });
+  refreshButton.addEventListener("click", () => {
+    refreshButton.disabled = true;
+    status.textContent = "Generating a fresh blob universe…";
+    void forceNewBlobUniverse()
+      .then(() => {
+        status.textContent = "Seed refreshed. Enjoy the new background.";
+      })
+      .catch((error) => {
+        status.textContent = "Unable to refresh background.";
+        log.warn("ambient:refresh", error);
+      })
+      .finally(() => {
+        refreshButton.disabled = false;
+      });
+  });
+
+  body.append(ambientGroup.element, rotationGroup.element, refreshButton, status);
+  section.append(heading, body);
+
+  void (async () => {
+    try {
+      const [ambientMode, rotationMode] = await Promise.all([
+        getAmbientMode(),
+        getRotationMode(),
+      ]);
+      ambientGroup.update(ambientMode);
+      rotationGroup.update(rotationMode === "manual" ? "off" : rotationMode);
+      status.textContent = describeMode(ambientMode);
+    } catch (error) {
+      status.textContent = "Unable to load ambient settings.";
+      log.warn("ambient:load", error);
+    }
+  })();
+
+  return section;
+}
+
+export default createAmbientBackgroundSection;

--- a/src/layout/Backdrop.ts
+++ b/src/layout/Backdrop.ts
@@ -1,5 +1,6 @@
 export interface BackdropInstance {
   element: HTMLElement;
+  ambientHost: HTMLElement;
 }
 
 // A full-window background layer that sits behind the app shell.
@@ -9,6 +10,14 @@ export function Backdrop(): BackdropInstance {
   el.className = "backdrop";
   el.setAttribute("aria-hidden", "true");
   el.setAttribute("data-role", "app-backdrop");
-  return { element: el };
+
+  const ambientHost = document.createElement("div");
+  ambientHost.className = "backdrop__ambient";
+  ambientHost.setAttribute("data-role", "ambient-host");
+  ambientHost.setAttribute("aria-hidden", "true");
+
+  el.appendChild(ambientHost);
+
+  return { element: el, ambientHost };
 }
 

--- a/src/lib/blobRotation.ts
+++ b/src/lib/blobRotation.ts
@@ -1,0 +1,181 @@
+import {
+  getAmbientMode,
+  getRotationMode,
+  getStoreValue,
+  setStoreValue,
+  type RotationMode,
+} from "./store";
+
+const rotationEvents = new EventTarget();
+
+const LONDON_TZ = "Europe/London";
+const londonDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  timeZone: LONDON_TZ,
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+});
+
+export type PeriodMode = RotationMode;
+
+function extractPart(parts: Intl.DateTimeFormatPart[], type: string): number {
+  const value = parts.find((part) => part.type === type)?.value ?? "";
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Unable to parse ${type} from London time`);
+  }
+  return parsed;
+}
+
+function londonMidnight(date: Date): Date {
+  const parts = londonDateFormatter.formatToParts(date);
+  const year = extractPart(parts, "year");
+  const month = extractPart(parts, "month");
+  const day = extractPart(parts, "day");
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function isoWeekParts(date: Date): { year: number; week: number } {
+  const target = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - day);
+  const year = target.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil(((target.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return { year, week };
+}
+
+function londonMonthParts(date: Date): { year: number; month: number } {
+  const parts = londonDateFormatter.formatToParts(date);
+  const year = extractPart(parts, "year");
+  const month = extractPart(parts, "month");
+  return { year, month };
+}
+
+export function formatIsoWeekKey(date: Date): string {
+  const midnight = londonMidnight(date);
+  const { year, week } = isoWeekParts(midnight);
+  return `${year}-W${String(week).padStart(2, "0")}`;
+}
+
+export function formatLondonMonthKey(date: Date): string {
+  const { year, month } = londonMonthParts(date);
+  return `${year}-M${String(month).padStart(2, "0")}`;
+}
+
+export function getPeriodKey(mode: RotationMode, date: Date = new Date()): string {
+  switch (mode) {
+    case "weekly":
+      return formatIsoWeekKey(date);
+    case "monthly":
+      return formatLondonMonthKey(date);
+    case "manual":
+      return `manual-${formatIsoWeekKey(date)}`;
+    case "off":
+    default:
+      return "static";
+  }
+}
+
+export function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function randomSeed(): number {
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const buffer = new Uint32Array(1);
+    crypto.getRandomValues(buffer);
+    return buffer[0]!;
+  }
+  return Math.floor(Math.random() * 0xffffffff) >>> 0;
+}
+
+let fallbackInstallId: string | null = null;
+
+function generateInstallId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(16)}-${Math.floor(Math.random() * 1e8)
+    .toString(16)
+    .padStart(8, "0")}`;
+}
+
+export async function getInstallId(): Promise<string> {
+  const existing = await getStoreValue("installId");
+  if (typeof existing === "string" && existing.length > 0) {
+    fallbackInstallId = existing;
+    return existing;
+  }
+  if (fallbackInstallId) return fallbackInstallId;
+  const next = generateInstallId();
+  fallbackInstallId = next;
+  await setStoreValue("installId", next);
+  return next;
+}
+
+async function persistSeed(seed: number, periodKey: string): Promise<void> {
+  await setStoreValue("blobSeed", seed);
+  await setStoreValue("blobWeekKey", periodKey);
+  await setStoreValue("blobLastGeneratedAt", new Date().toISOString());
+}
+
+function emitSeedChange(seed: number): void {
+  rotationEvents.dispatchEvent(new CustomEvent<number>("seed", { detail: seed }));
+}
+
+export function onBlobSeedChange(listener: (seed: number) => void): () => void {
+  const handler = (event: Event) => listener((event as CustomEvent<number>).detail);
+  rotationEvents.addEventListener("seed", handler);
+  return () => rotationEvents.removeEventListener("seed", handler);
+}
+
+export async function getBlobSeedForPeriod(mode: RotationMode): Promise<number> {
+  const now = new Date();
+  const periodKey = getPeriodKey(mode, now);
+  const storedSeed = await getStoreValue("blobSeed");
+  const storedKey = await getStoreValue("blobWeekKey");
+  if ((mode === "weekly" || mode === "monthly") && periodKey !== storedKey) {
+    const installId = await getInstallId();
+    const derived = fnv1a32(`${installId}:${periodKey}:arklowdun`);
+    await persistSeed(derived, periodKey);
+    emitSeedChange(derived);
+    return derived;
+  }
+  if (typeof storedSeed === "number") {
+    return storedSeed;
+  }
+  const installId = await getInstallId();
+  const effectiveKey = storedKey ?? periodKey;
+  const derived = fnv1a32(`${installId}:${effectiveKey}:arklowdun`);
+  await persistSeed(derived, effectiveKey);
+  emitSeedChange(derived);
+  return derived;
+}
+
+export async function forceNewBlobUniverse(): Promise<number> {
+  const rotation = await getRotationMode();
+  // ensure install id persisted even if rotation is off
+  await getInstallId();
+  const periodKey = getPeriodKey(rotation, new Date());
+  const seed = randomSeed();
+  await persistSeed(seed, periodKey);
+  emitSeedChange(seed);
+  return seed;
+}
+
+export async function ensureAmbientSeed(): Promise<number> {
+  const mode = await getRotationMode();
+  return getBlobSeedForPeriod(mode);
+}
+
+export async function ensureAmbientMode(): Promise<{ mode: string; seed: number }> {
+  const [ambientMode, rotationMode] = await Promise.all([getAmbientMode(), getRotationMode()]);
+  const seed = await getBlobSeedForPeriod(rotationMode);
+  return { mode: ambientMode, seed };
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,149 @@
+import { log } from "@utils/logger";
+
+let storeLoader: Promise<import("@tauri-apps/plugin-store").Store | null> | null = null;
+let storeUnavailable = false;
+
+const STORE_PATH = "window-state.json";
+
+export type AmbientMode = "off" | "eco" | "full";
+export type RotationMode = "off" | "weekly" | "monthly" | "manual";
+
+export interface WindowStateSchema {
+  installId: string;
+  blobRotation: RotationMode;
+  blobWeekKey: string;
+  blobSeed: number;
+  blobLastGeneratedAt: string;
+  ambientMode: AmbientMode;
+}
+
+const volatileState: Partial<WindowStateSchema> = {};
+
+const DEFAULT_AMBIENT_MODE: AmbientMode = "eco";
+const DEFAULT_ROTATION_MODE: RotationMode = "weekly";
+
+const storeEvents = new EventTarget();
+
+async function loadStore(): Promise<import("@tauri-apps/plugin-store").Store | null> {
+  if (storeUnavailable || typeof window === "undefined") {
+    return null;
+  }
+  if (!storeLoader) {
+    storeLoader = import("@tauri-apps/plugin-store")
+      .then(({ Store }) => Store.load(STORE_PATH))
+      .then((store) => store)
+      .catch((error) => {
+        storeUnavailable = true;
+        log.warn("store: plugin unavailable", error);
+        return null;
+      });
+  }
+  return storeLoader;
+}
+
+async function readValue<K extends keyof WindowStateSchema>(
+  key: K,
+): Promise<WindowStateSchema[K] | undefined> {
+  const store = await loadStore();
+  if (store) {
+    try {
+      const value = await store.get<WindowStateSchema[K] | undefined>(key);
+      if (value !== undefined && value !== null) {
+        return value;
+      }
+    } catch (error) {
+      log.warn("store: read failed", { key, error });
+    }
+  }
+  return volatileState[key];
+}
+
+async function persistValue<K extends keyof WindowStateSchema>(
+  key: K,
+  value: WindowStateSchema[K],
+): Promise<void> {
+  volatileState[key] = value;
+  const store = await loadStore();
+  if (!store) return;
+  try {
+    await store.set(key, value);
+    await store.save();
+  } catch (error) {
+    log.warn("store: persist failed", { key, error });
+  }
+}
+
+function emitAmbientModeChange(mode: AmbientMode): void {
+  storeEvents.dispatchEvent(new CustomEvent<AmbientMode>("ambient-mode", { detail: mode }));
+}
+
+function emitRotationModeChange(mode: RotationMode): void {
+  storeEvents.dispatchEvent(new CustomEvent<RotationMode>("rotation-mode", { detail: mode }));
+}
+
+export async function getAmbientMode(): Promise<AmbientMode> {
+  const value = await readValue("ambientMode");
+  return value === "off" || value === "eco" || value === "full"
+    ? value
+    : DEFAULT_AMBIENT_MODE;
+}
+
+export async function setAmbientMode(mode: AmbientMode): Promise<void> {
+  await persistValue("ambientMode", mode);
+  emitAmbientModeChange(mode);
+}
+
+export async function getRotationMode(): Promise<RotationMode> {
+  const value = await readValue("blobRotation");
+  return value === "off" || value === "weekly" || value === "monthly" || value === "manual"
+    ? value
+    : DEFAULT_ROTATION_MODE;
+}
+
+export async function setRotationMode(mode: RotationMode): Promise<void> {
+  await persistValue("blobRotation", mode);
+  emitRotationModeChange(mode);
+}
+
+export async function getStoreValue<K extends keyof WindowStateSchema>(
+  key: K,
+): Promise<WindowStateSchema[K] | undefined> {
+  return readValue(key);
+}
+
+export async function setStoreValue<K extends keyof WindowStateSchema>(
+  key: K,
+  value: WindowStateSchema[K],
+): Promise<void> {
+  await persistValue(key, value);
+}
+
+export function onAmbientModeChange(listener: (mode: AmbientMode) => void): () => void {
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<AmbientMode>).detail);
+  };
+  storeEvents.addEventListener("ambient-mode", handler);
+  return () => {
+    storeEvents.removeEventListener("ambient-mode", handler);
+  };
+}
+
+export function onRotationModeChange(listener: (mode: RotationMode) => void): () => void {
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<RotationMode>).detail);
+  };
+  storeEvents.addEventListener("rotation-mode", handler);
+  return () => {
+    storeEvents.removeEventListener("rotation-mode", handler);
+  };
+}
+
+export function __resetStoreForTests(): void {
+  Object.keys(volatileState).forEach((key) => {
+    delete (volatileState as Record<string, unknown>)[key];
+  });
+  storeLoader = null;
+  storeUnavailable = false;
+}
+
+export { DEFAULT_AMBIENT_MODE, DEFAULT_ROTATION_MODE };

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,8 +84,23 @@ let ambientInit: Promise<void> | null = null;
 
 function ensureAmbientBackground(): void {
   if (ambientInit) return;
-  const host = document.querySelector<HTMLElement>("[data-role='ambient-host']");
-  if (!host) return;
+  // Prefer a dedicated overlay container to avoid any stacking quirks
+  let host = document.getElementById("ambient-overlay") as HTMLElement | null;
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "ambient-overlay";
+    (host.style as any).inset = "0";
+    host.style.position = "fixed";
+    host.style.top = "0";
+    host.style.right = "0";
+    host.style.bottom = "0";
+    host.style.left = "0";
+    host.style.pointerEvents = "none";
+    // Place ambient between backdrop (z:0) and UI (z:1)
+    host.style.zIndex = "0";
+    document.body.appendChild(host);
+    log.debug("ambient:overlay-mounted");
+  }
   ambientInit = initAmbientBackground(host)
     .then((controller) => {
       ambientController = controller;
@@ -467,6 +482,8 @@ window.addEventListener("DOMContentLoaded", () => {
       console.log("Runtime window label:", appWindow.label);
       setupDynamicMinSize();
     });
+
+    // ambient debug probe removed; overlay verified
   })();
 });
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,12 +21,14 @@
 @property --g1 {
   syntax: '<color>';
   inherits: false;
-  initial-value: #f3f8ff;
+  /* even paler yellowish near-white (additional ~50% to white) */
+  initial-value: #fffef9;
 }
 @property --g2 {
   syntax: '<color>';
   inherits: false;
-  initial-value: #f6fefe;
+  /* extremely pale butter yellow */
+  initial-value: #fffdf4;
 }
 @property --g3 {
   syntax: '<color>';
@@ -96,11 +98,12 @@ body {
 }
 
 .backdrop__ambient {
-  position: absolute;
+  position: fixed;      /* pin to window */
   inset: 0;
-  pointer-events: none;
-  z-index: 1;
+  pointer-events: none; /* never block clicks */
+  z-index: 900;         /* above sidebar/main/footer (z:1), below toolbar/modals */
   overflow: hidden;
+  mix-blend-mode: normal; /* default to visible overlay */
 }
 
 .backdrop__ambient canvas {
@@ -110,7 +113,26 @@ body {
   height: 100%;
   pointer-events: none;
   display: block;
+  /* Ensure the canvas itself blends with underlying UI */
+  mix-blend-mode: normal;
 }
+
+/* Optional: mode-scoped blending for polish */
+:root[data-ambient="full"] .backdrop__ambient,
+:root[data-ambient="full"] .backdrop__ambient canvas {
+  mix-blend-mode: soft-light;
+}
+/* Keep Eco more direct/visible */
+:root[data-ambient="eco"] .backdrop__ambient,
+:root[data-ambient="eco"] .backdrop__ambient canvas {
+  mix-blend-mode: normal;
+}
+
+/* Apply the same blending to the dedicated overlay host if present */
+/* Default to normal blend for clear visibility in both modes */
+#ambient-overlay canvas { mix-blend-mode: normal; }
+/* If you want softer look later, re-enable soft-light for Full */
+/* :root[data-ambient="full"] #ambient-overlay canvas { mix-blend-mode: soft-light; } */
 
 /* Ensure primary shell layers paint above the backdrop */
 .sidebar,
@@ -130,8 +152,8 @@ footer {
 @keyframes app-backdrop-colors {
   0% {
     --angle: 120deg;
-    --g1: #f3f8ff; /* near-white blue */
-    --g2: #f6fefe; /* near-white aqua */
+    --g1: #fffef9; /* ultra pale soft yellow */
+    --g2: #fffdf4; /* ultra pale butter */
     --g3: #ffffff; /* white */
     --p2: 32%;
     --p3: 73%;
@@ -139,16 +161,16 @@ footer {
   50% {
     /* subtle motion: whites with slight tint shifts */
     --angle: 125deg;
-    --g1: #eef5ff;
-    --g2: #f7fffe;
+    --g1: #fffef6; /* near-white pastel yellow */
+    --g2: #fffcf0; /* near-white cream */
     --g3: #ffffff;
     --p2: 33.5%;
     --p3: 74%;
   }
   100% {
     --angle: 120deg;
-    --g1: #f3f8ff;
-    --g2: #f6fefe;
+    --g1: #fffef9;
+    --g2: #fffdf4;
     --g3: #ffffff;
     --p2: 32%;
     --p3: 73%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -88,10 +88,28 @@ body {
   inset: 0;
   z-index: 0;
   pointer-events: none;
+  overflow: hidden;
   /* Gradient defined using animatable custom properties */
   background: linear-gradient(var(--angle), var(--g1) 0%, var(--g2) var(--p2), var(--g3) var(--p3));
   /* Animate the gradient itself (colors/stop positions) */
   animation: app-backdrop-colors 30s ease-in-out infinite;
+}
+
+.backdrop__ambient {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  overflow: hidden;
+}
+
+.backdrop__ambient canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  display: block;
 }
 
 /* Ensure primary shell layers paint above the backdrop */
@@ -1098,6 +1116,77 @@ footer a.footer__settings {
 
 .settings__section--repair {
   margin-bottom: var(--space-4);
+}
+
+.settings__section--ambient {
+  margin-bottom: var(--space-4);
+}
+
+.ambient-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.ambient-settings__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.ambient-settings__legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+
+.ambient-settings__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-base);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.ambient-settings__option:hover,
+.ambient-settings__option:focus-within {
+  background-color: var(--color-accent-soft);
+}
+
+.ambient-settings__option input {
+  margin-top: 0.35rem;
+}
+
+.ambient-settings__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ambient-settings__title {
+  font-weight: 600;
+}
+
+.ambient-settings__description {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.ambient-settings__refresh {
+  align-self: flex-start;
+}
+
+.ambient-settings__status {
+  margin: 0;
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
 }
 
 .settings__section--import {

--- a/src/styles/blob-tokens.css
+++ b/src/styles/blob-tokens.css
@@ -5,19 +5,32 @@
   --blob-aqua:  #00B2C8;
   --blob-coral: #C84600;
 
-  --blob-alpha-main:  0.08;
-  --blob-alpha-tint:  0.08;
-  --blob-alpha-shade: 0.05;
-  --blob-alpha-aqua:  0.06;
-  --blob-alpha-coral: 0.04;
+  --blob-alpha-main:  0.275;
+  --blob-alpha-tint:  0.24;
+  --blob-alpha-shade: 0.175;
+  --blob-alpha-aqua:  0.24;
+  --blob-alpha-coral: 0.14;
+
+  /* 0.0 (very soft) … 1.0 (crisper edge) */
+  --blob-edge-hardness: 0.95;
+
+  /* Debug only: 0 to disable, 0.1+ to overlay a magenta tint */
+  --ambient-debug-overlay: 0;
+  /* Global multiplier applied at render time for live tuning */
+  --blob-alpha-mult: 0.5;
+  /* How much to lighten blob color towards white (0-1); 0.5 = 50% */
+  --blob-lighten: 0.5;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --blob-alpha-main:  0.06;
-    --blob-alpha-tint:  0.06;
-    --blob-alpha-shade: 0.045;
-    --blob-alpha-aqua:  0.05;
-    --blob-alpha-coral: 0.03;
+    --blob-alpha-main:  0.225;
+    --blob-alpha-tint:  0.20;
+    --blob-alpha-shade: 0.15;
+    --blob-alpha-aqua:  0.20;
+    --blob-alpha-coral: 0.12;
+    --blob-edge-hardness: 0.95;
+    --blob-alpha-mult: 0.5;
+    --blob-lighten: 0.5;
   }
 }

--- a/src/styles/blob-tokens.css
+++ b/src/styles/blob-tokens.css
@@ -1,0 +1,23 @@
+:root {
+  --blob-main:  #00C896;
+  --blob-tint:  #66E0C2;
+  --blob-shade: #008060;
+  --blob-aqua:  #00B2C8;
+  --blob-coral: #C84600;
+
+  --blob-alpha-main:  0.08;
+  --blob-alpha-tint:  0.08;
+  --blob-alpha-shade: 0.05;
+  --blob-alpha-aqua:  0.06;
+  --blob-alpha-coral: 0.04;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --blob-alpha-main:  0.06;
+    --blob-alpha-tint:  0.06;
+    --blob-alpha-shade: 0.045;
+    --blob-alpha-aqua:  0.05;
+    --blob-alpha-coral: 0.03;
+  }
+}

--- a/src/types/tauri-plugin-store.d.ts
+++ b/src/types/tauri-plugin-store.d.ts
@@ -1,0 +1,12 @@
+declare module "@tauri-apps/plugin-store" {
+  export class Store {
+    constructor(path: string);
+    static load(path: string): Promise<Store>;
+    get<T = unknown>(key: string): Promise<T | null>;
+    set<T = unknown>(key: string, value: T): Promise<void>;
+    has(key: string): Promise<boolean>;
+    delete(key: string): Promise<void>;
+    clear(): Promise<void>;
+    save(): Promise<void>;
+  }
+}

--- a/src/ui/AmbientBackground.ts
+++ b/src/ui/AmbientBackground.ts
@@ -1,0 +1,166 @@
+import { listen } from "@tauri-apps/api/event";
+import { log } from "@utils/logger";
+import {
+  mountSoloBlobEco,
+  SoloBlobEco,
+  type SoloBlobEcoOptions,
+} from "../components/SoloBlobEco";
+import { BlobFieldEco, mountBlobFieldEco, type BlobFieldEcoOptions } from "../components/BlobFieldEco";
+import {
+  getAmbientMode,
+  getRotationMode,
+  onAmbientModeChange,
+  onRotationModeChange,
+  type AmbientMode,
+  type RotationMode,
+} from "@lib/store";
+import {
+  getBlobSeedForPeriod,
+  onBlobSeedChange,
+  forceNewBlobUniverse,
+} from "@lib/blobRotation";
+
+export interface AmbientBackgroundController {
+  destroy(): void;
+  refreshNow(): Promise<number>;
+}
+
+class AmbientBackgroundManager implements AmbientBackgroundController {
+  private renderer: SoloBlobEco | BlobFieldEco | null = null;
+  private mode: AmbientMode = "eco";
+  private rotation: RotationMode = "weekly";
+  private seed = 0;
+  private unlistenAmbient: (() => void) | null = null;
+  private unlistenRotation: (() => void) | null = null;
+  private unlistenSeed: (() => void) | null = null;
+  private unlistenFocus: (() => void) | null = null;
+  private unlistenBlur: (() => void) | null = null;
+
+  constructor(private readonly host: HTMLElement) {}
+
+  async init(): Promise<void> {
+    this.rotation = await getRotationMode();
+    this.mode = await getAmbientMode();
+    this.seed = await getBlobSeedForPeriod(this.rotation);
+    this.applyRenderer();
+    this.attachListeners();
+    log.debug("ambient:init", { mode: this.mode, rotation: this.rotation, seed: this.seed });
+  }
+
+  private attachListeners(): void {
+    this.unlistenAmbient = onAmbientModeChange(async (mode) => {
+      this.mode = mode;
+      this.applyRenderer();
+      log.debug("ambient:mode", { mode });
+    });
+    this.unlistenRotation = onRotationModeChange(async (rotation) => {
+      this.rotation = rotation;
+      await this.ensureSeedForRotation();
+      log.debug("ambient:rotation", { rotation });
+    });
+    this.unlistenSeed = onBlobSeedChange((seed) => {
+      this.applySeed(seed);
+    });
+
+    void listen("tauri://focus", () => {
+      void this.ensureSeedForRotation();
+      if (this.mode !== "off") {
+        this.renderer?.setPaused(false);
+      }
+    }).then((unlisten) => {
+      this.unlistenFocus = unlisten;
+    }).catch(() => {});
+
+    void listen("tauri://blur", () => {
+      this.renderer?.setPaused(true);
+    }).then((unlisten) => {
+      this.unlistenBlur = unlisten;
+    }).catch(() => {});
+  }
+
+  private teardownRenderer(): void {
+    if (this.renderer) {
+      this.renderer.destroy();
+      this.renderer = null;
+    }
+    this.host.querySelectorAll("canvas").forEach((el) => el.remove());
+  }
+
+  private applyRenderer(): void {
+    this.teardownRenderer();
+    const seed = this.seed;
+    if (this.mode === "full") {
+      const options: BlobFieldEcoOptions = {
+        seed,
+        count: 10,
+        maxFps: 30,
+        idleFps: 12,
+        idleMs: 12000,
+        renderScale: 0.7,
+        edgeBias: 0.55,
+      };
+      this.renderer = mountBlobFieldEco(this.host, options);
+    } else {
+      const soloOptions: SoloBlobEcoOptions = {
+        seed,
+        mode: "teal",
+        secondMode: this.mode === "eco" ? "aqua" : null,
+        activeFps: 20,
+        idleFps: 8,
+        idleMs: 10000,
+        renderScale: 0.75,
+        edgeBias: 0.75,
+        paused: this.mode === "off",
+      };
+      const solo = mountSoloBlobEco(this.host, soloOptions);
+      if (this.mode === "off") {
+        solo.renderOnce();
+        solo.setPaused(true);
+      }
+      this.renderer = solo;
+    }
+  }
+
+  private applySeed(seed: number): void {
+    if (seed === this.seed) return;
+    this.seed = seed;
+    if (this.renderer) {
+      this.renderer.setSeed(seed);
+      if (this.mode === "off" && this.renderer instanceof SoloBlobEco) {
+        this.renderer.renderOnce();
+        this.renderer.setPaused(true);
+      }
+    }
+  }
+
+  private async ensureSeedForRotation(): Promise<void> {
+    const next = await getBlobSeedForPeriod(this.rotation);
+    this.applySeed(next);
+  }
+
+  async refreshNow(): Promise<number> {
+    const seed = await forceNewBlobUniverse();
+    this.applySeed(seed);
+    return seed;
+  }
+
+  destroy(): void {
+    this.teardownRenderer();
+    this.unlistenAmbient?.();
+    this.unlistenRotation?.();
+    this.unlistenSeed?.();
+    this.unlistenFocus?.();
+    this.unlistenBlur?.();
+    this.unlistenAmbient = null;
+    this.unlistenRotation = null;
+    this.unlistenSeed = null;
+    this.unlistenFocus = null;
+    this.unlistenBlur = null;
+  }
+}
+
+export async function initAmbientBackground(host: HTMLElement): Promise<AmbientBackgroundController> {
+  const manager = new AmbientBackgroundManager(host);
+  await manager.init();
+  return manager;
+}

--- a/tests/blob-rotation.test.ts
+++ b/tests/blob-rotation.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fnv1a32,
+  formatIsoWeekKey,
+  formatLondonMonthKey,
+  getPeriodKey,
+  getBlobSeedForPeriod,
+  forceNewBlobUniverse,
+} from "../src/lib/blobRotation.ts";
+import {
+  __resetStoreForTests,
+  setStoreValue,
+  getStoreValue,
+  setRotationMode,
+} from "../src/lib/store.ts";
+
+function isoDate(date: string): Date {
+  return new Date(date);
+}
+
+test.beforeEach(() => {
+  __resetStoreForTests();
+});
+
+test("fnv1a32 is deterministic", () => {
+  const a = fnv1a32("arklowdun:test");
+  const b = fnv1a32("arklowdun:test");
+  const c = fnv1a32("arklowdun:TEST");
+  assert.equal(a, b);
+  assert.notEqual(a, c);
+});
+
+test("formatIsoWeekKey respects Europe/London weeks", () => {
+  assert.equal(formatIsoWeekKey(isoDate("2024-03-25T12:00:00Z")), "2024-W13");
+  assert.equal(formatIsoWeekKey(isoDate("2024-03-31T00:30:00Z")), "2024-W13");
+  assert.equal(formatIsoWeekKey(isoDate("2024-12-31T18:00:00Z")), "2025-W01");
+});
+
+test("formatLondonMonthKey returns YYYY-MM in London time", () => {
+  assert.equal(formatLondonMonthKey(isoDate("2024-03-31T00:30:00Z")), "2024-M03");
+  assert.equal(formatLondonMonthKey(isoDate("2024-10-01T01:00:00Z")), "2024-M10");
+});
+
+test("monthly rotation flips at London month boundary", () => {
+  const lateMarch = isoDate("2025-03-31T22:30:00Z");
+  const earlyApril = isoDate("2025-04-01T00:30:00Z");
+  assert.equal(getPeriodKey("monthly", lateMarch), "2025-M03");
+  assert.equal(getPeriodKey("monthly", earlyApril), "2025-M04");
+});
+
+async function seedForCurrentWeek(installId: string): Promise<number> {
+  const key = getPeriodKey("weekly");
+  const expected = fnv1a32(`${installId}:${key}:arklowdun`);
+  return expected;
+}
+
+test("weekly rotation derives deterministic seed", async () => {
+  const installId = "test-install-id";
+  await setStoreValue("installId", installId);
+  await setRotationMode("weekly");
+
+  const expected = await seedForCurrentWeek(installId);
+  const seed = await getBlobSeedForPeriod("weekly");
+  assert.equal(seed, expected);
+
+  const storedSeed = await getStoreValue("blobSeed");
+  const storedKey = await getStoreValue("blobWeekKey");
+  assert.equal(storedSeed, expected);
+  assert.equal(storedKey, getPeriodKey("weekly"));
+
+  // Simulate stale week key
+  await setStoreValue("blobWeekKey", "1999-W52");
+  await setStoreValue("blobSeed", 1234);
+  const refreshed = await getBlobSeedForPeriod("weekly");
+  assert.equal(refreshed, expected);
+});
+
+test("off rotation preserves stored seed", async () => {
+  await setRotationMode("off");
+  await setStoreValue("installId", "persisted");
+  await setStoreValue("blobSeed", 987654321);
+  await setStoreValue("blobWeekKey", "static");
+
+  const seed = await getBlobSeedForPeriod("off");
+  assert.equal(seed, 987654321);
+});
+
+test("forceNewBlobUniverse updates the persisted seed", async () => {
+  await setStoreValue("installId", "refresh-install");
+  const first = await getBlobSeedForPeriod("weekly");
+  const next = await forceNewBlobUniverse();
+  const stored = await getStoreValue("blobSeed");
+  assert.equal(stored, next);
+  assert.notEqual(first, next);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Summary
- quantize sprite alpha caching, tolerate CSS rgb tokens, and align canvas scaling to CSS units for SoloBlobEco
- document the mount helpers and cover London month boundaries in the rotation tests
- add minimal plugin-store type declarations so typechecking succeeds outside the Tauri runtime

## Testing
- `npm test -- tests/blob-rotation.test.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d9008580ec832aa15bf800f3bd696d