### PR TITLE
Harden household lifecycle handling

### DIFF
--- a/docs/baseline-schema.md
+++ b/docs/baseline-schema.md
@@ -71,6 +71,12 @@ use deterministic values to keep fixture diffs stable.
   `household:changed` event.
 - The default household remains undeletable and attempts are mapped to the
   stable error code `DEFAULT_UNDELETABLE`.
+- A soft-deleted household cannot be made active until restored and the IPC
+  surface responds with `HOUSEHOLD_DELETED`. Requests to activate the current
+  household return `HOUSEHOLD_ALREADY_ACTIVE` so the UI can short-circuit
+  without reloading state.
+- `deleted_at` is `NULL` for active rows; restores clear the timestamp and
+  update `updated_at`.
 
 ## Schema fingerprint
 

--- a/docs/integrity-rules.md
+++ b/docs/integrity-rules.md
@@ -85,8 +85,11 @@ surface a selection flow so the user can choose a household explicitly.
 
 - The `household_delete` IPC command soft-deletes rows by setting
   `deleted_at`. If the target row is the current active household, the backend
-  immediately switches the active selection back to the default household
-  before emitting `household:changed`.
+  immediately switches the active selection back to the default household,
+  persists the new selection, and emits `household:changed`.
+- Attempts to activate a soft-deleted household are rejected with
+  `HOUSEHOLD_DELETED`. When the user targets the already-active household the
+  IPC layer short-circuits with `HOUSEHOLD_ALREADY_ACTIVE`.
 - SQLite triggers ensure the default household cannot be deleted or
   soft-deleted. The IPC layer maps attempts to stable error codes so the UI can
   present consistent messages.
@@ -96,6 +99,7 @@ surface a selection flow so the user can choose a household explicitly.
 | Delete default household | `DEFAULT_UNDELETABLE` |
 | Operate on a missing household id | `HOUSEHOLD_NOT_FOUND` |
 | Operate on a soft-deleted household (update/set active) | `HOUSEHOLD_DELETED` |
+| Attempt to set already-active household | `HOUSEHOLD_ALREADY_ACTIVE` |
 
 ## Notes & Shopping Soft Delete
 

--- a/src/api/households.ts
+++ b/src/api/households.ts
@@ -24,11 +24,15 @@ export interface HouseholdRecord {
 }
 
 function normalizeHousehold(record: HouseholdRecordRaw): HouseholdRecord {
-  const name = typeof record.name === "string" && record.name.trim().length > 0
-    ? record.name
-    : record.id;
+  const name =
+    typeof record.name === "string" && record.name.trim().length > 0
+      ? record.name
+      : record.id;
   const isDefault = Boolean(record.is_default);
-  const tz = typeof record.tz === "string" && record.tz.trim().length > 0 ? record.tz : null;
+  const tz =
+    typeof record.tz === "string" && record.tz.trim().length > 0
+      ? record.tz
+      : null;
   return {
     id: record.id,
     name,
@@ -37,13 +41,16 @@ function normalizeHousehold(record: HouseholdRecordRaw): HouseholdRecord {
     createdAt: typeof record.created_at === "number" ? record.created_at : null,
     updatedAt: typeof record.updated_at === "number" ? record.updated_at : null,
     deletedAt: typeof record.deleted_at === "number" ? record.deleted_at : null,
-    color: typeof record.color === "string" && record.color.trim().length > 0
-      ? record.color
-      : null,
+    color:
+      typeof record.color === "string" && record.color.trim().length > 0
+        ? record.color
+        : null,
   };
 }
 
-export async function listHouseholds(includeDeleted = false): Promise<HouseholdRecord[]> {
+export async function listHouseholds(
+  includeDeleted = false,
+): Promise<HouseholdRecord[]> {
   const rows = await call<HouseholdRecordRaw[]>("household_list", {
     includeDeleted,
   });
@@ -54,9 +61,23 @@ export async function getActiveHouseholdId(): Promise<string> {
   return call<string>("household_get_active");
 }
 
-export type SetActiveHouseholdErrorCode =
+export type HouseholdErrorCode =
+  | "DEFAULT_UNDELETABLE"
   | "HOUSEHOLD_NOT_FOUND"
-  | "HOUSEHOLD_DELETED";
+  | "HOUSEHOLD_DELETED"
+  | "HOUSEHOLD_ALREADY_ACTIVE";
+
+export const HOUSEHOLD_ERROR_MESSAGES: Record<HouseholdErrorCode, string> = {
+  DEFAULT_UNDELETABLE: "The default household cannot be deleted.",
+  HOUSEHOLD_NOT_FOUND: "The selected household could not be found.",
+  HOUSEHOLD_DELETED: "The selected household has been archived.",
+  HOUSEHOLD_ALREADY_ACTIVE: "The selected household is already active.",
+};
+
+export type SetActiveHouseholdErrorCode = Extract<
+  HouseholdErrorCode,
+  "HOUSEHOLD_NOT_FOUND" | "HOUSEHOLD_DELETED" | "HOUSEHOLD_ALREADY_ACTIVE"
+>;
 
 export type SetActiveHouseholdResult =
   | { ok: true }
@@ -78,20 +99,28 @@ function extractErrorCode(error: unknown): string {
   return "UNKNOWN";
 }
 
-export async function setActiveHouseholdId(id: string): Promise<SetActiveHouseholdResult> {
+export async function setActiveHouseholdId(
+  id: string,
+): Promise<SetActiveHouseholdResult> {
   try {
     await call("household_set_active", { id });
     return { ok: true };
   } catch (error) {
     const code = extractErrorCode(error);
-    if (code === "HOUSEHOLD_NOT_FOUND" || code === "HOUSEHOLD_DELETED") {
+    if (
+      code === "HOUSEHOLD_NOT_FOUND" ||
+      code === "HOUSEHOLD_DELETED" ||
+      code === "HOUSEHOLD_ALREADY_ACTIVE"
+    ) {
       return { ok: false, code };
     }
     throw error;
   }
 }
 
-export async function getHousehold(id: string): Promise<HouseholdRecord | null> {
+export async function getHousehold(
+  id: string,
+): Promise<HouseholdRecord | null> {
   const record = await call<HouseholdRecordRaw | null>("household_get", { id });
   return record ? normalizeHousehold(record) : null;
 }
@@ -128,8 +157,13 @@ export interface DeleteHouseholdResponse {
   fallbackId: string | null;
 }
 
-export async function deleteHousehold(id: string): Promise<DeleteHouseholdResponse> {
-  const result = await call<{ fallbackId?: string | null }>("household_delete", { id });
+export async function deleteHousehold(
+  id: string,
+): Promise<DeleteHouseholdResponse> {
+  const result = await call<{ fallbackId?: string | null }>(
+    "household_delete",
+    { id },
+  );
   return {
     fallbackId: result?.fallbackId ?? null,
   };

--- a/src/state/householdStore.spec.ts
+++ b/src/state/householdStore.spec.ts
@@ -1,19 +1,36 @@
 /* eslint-disable security/detect-object-injection -- test doubles index controlled listener maps */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const eventListeners: Record<string, (event: { payload: { id: string } }) => void> = {};
+const eventListeners: Record<
+  string,
+  (event: { payload: { id: string } }) => void
+> = {};
 
-const listenMock = vi.fn(async (event: string, callback: (event: { payload: { id: string } }) => void) => {
-  eventListeners[event] = callback;
-  return () => {
-    delete eventListeners[event];
-  };
-});
+const listenMock = vi.fn(
+  async (
+    event: string,
+    callback: (event: { payload: { id: string } }) => void,
+  ) => {
+    eventListeners[event] = callback;
+    return () => {
+      delete eventListeners[event];
+    };
+  },
+);
 
 const getActiveHouseholdIdMock = vi.fn<[], Promise<string>>();
 const setActiveHouseholdIdMock = vi.fn<
   [string],
-  Promise<{ ok: true } | { ok: false; code: "HOUSEHOLD_NOT_FOUND" | "HOUSEHOLD_DELETED" }>
+  Promise<
+    | { ok: true }
+    | {
+        ok: false;
+        code:
+          | "HOUSEHOLD_NOT_FOUND"
+          | "HOUSEHOLD_DELETED"
+          | "HOUSEHOLD_ALREADY_ACTIVE";
+      }
+  >
 >();
 const emitMock = vi.fn<[string, { householdId: string }], void>();
 
@@ -62,7 +79,9 @@ describe("householdStore", () => {
     const listener = eventListeners["household:changed"];
     expect(listener).toBeDefined();
     listener?.({ payload: { id: "hh-two" } });
-    expect(emitMock).toHaveBeenCalledWith("household:changed", { householdId: "hh-two" });
+    expect(emitMock).toHaveBeenCalledWith("household:changed", {
+      householdId: "hh-two",
+    });
     const next = await store.ensureActiveHousehold();
     expect(next).toBe("hh-two");
     expect(getActiveHouseholdIdMock).toHaveBeenCalledTimes(1);
@@ -70,7 +89,10 @@ describe("householdStore", () => {
 
   it("keeps existing cache when the native set fails", async () => {
     getActiveHouseholdIdMock.mockResolvedValue("hh-active");
-    setActiveHouseholdIdMock.mockResolvedValue({ ok: false, code: "HOUSEHOLD_DELETED" });
+    setActiveHouseholdIdMock.mockResolvedValue({
+      ok: false,
+      code: "HOUSEHOLD_DELETED",
+    });
     const store = await import("./householdStore");
     await store.ensureActiveHousehold();
     const result = await store.forceSetActiveHousehold("hh-deleted");


### PR DESCRIPTION
## Summary
- enforce structured error handling, actor-aware logging, and redundant activation guards in household IPC commands
- surface new household error codes to the UI, refresh store handling, and extend lifecycle unit tests
- document household lifecycle invariants for default, deleted, and active states

## Testing
- npm exec vitest run src/state/householdStore.spec.ts
- cargo test household_crud *(fails: glib-2.0 system dependency missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb74c0e9c832abcd16f3a9b35a1e6