### PR TITLE
Fix household UI linting and CI install

### DIFF
--- a/docs/integrity-rules.md
+++ b/docs/integrity-rules.md
@@ -101,6 +101,10 @@ surface a selection flow so the user can choose a household explicitly.
 | Operate on a soft-deleted household (update/set active) | `HOUSEHOLD_DELETED` |
 | Attempt to set already-active household | `HOUSEHOLD_ALREADY_ACTIVE` |
 
+The settings UI mirrors these rules (see `docs/settings-ui.md`). Error codes are
+surfaced with friendly copy and the frontend immediately falls back to the
+default household when the backend returns a `fallbackId` during delete.
+
 ## Notes & Shopping Soft Delete
 
 Notes and shopping items must use soft deletion. Rows are never removed;

--- a/docs/settings-ui.md
+++ b/docs/settings-ui.md
@@ -1,0 +1,53 @@
+# Settings: Household Configuration
+
+The household section of the settings panel lets users manage the logical
+container that scopes data throughout Arklowdun. The UI is designed to provide
+immediate feedback while mirroring the behaviour of the backend invariants.
+
+## Layout
+
+- **Summary helper** – brief copy explaining that changes affect the entire
+  application.
+- **Create form** – hidden behind a "Create household" button. Opening the form
+  reveals:
+  - Name input (required).
+  - Colour swatch picker (predefined palette plus "no colour").
+  - Save/cancel controls.
+- **Household list** – cards for each non-deleted household. Every card shows:
+  - Colour chip, name, and badges (`Default`, `Active`, `Deleted`).
+  - Action buttons:
+    - *Set active* (disabled when the row is already active or soft-deleted).
+    - *Rename* (opens inline editor with the same controls as the create form).
+    - *Delete* (soft delete with confirmation dialog).
+    - *Restore* (only visible for deleted rows).
+- **Deleted section toggle** – switch to surface soft-deleted households in a
+  separate list so they can be restored.
+- **Status line** – contextual messaging for loading states, health gate
+  warnings, or the currently active household.
+
+## Behaviour
+
+- All commands execute through the IPC adapter (`@lib/ipc/call`); the UI never
+  talks directly to Tauri APIs.
+- The store refreshes the household list after each mutation so the cards are
+  kept in sync with backend state.
+- When the backend deletes the active household and returns a fallback id, the
+  store updates immediately to the fallback (typically the default household) to
+  avoid visual flicker.
+- The "Show deleted households" switch mirrors the underlying store flag. The
+  deleted section only renders when enabled and when soft-deleted rows exist.
+- Errors coming from the backend are mapped to friendly copy:
+  - `DEFAULT_UNDELETABLE` → "The default household cannot be deleted."
+  - `HOUSEHOLD_NOT_FOUND` → "That household no longer exists."
+  - `HOUSEHOLD_DELETED` → "That household is deleted. Restore it first."
+- Success and error paths surface toast notifications so users receive feedback
+  without leaving the page.
+
+## Accessibility & Styling
+
+- Buttons use the shared button component so keyboard interactions and focus
+  styles are consistent.
+- Inline forms reuse the input styles from the rest of the settings view.
+- Colour swatches expose accessible labels ("Use colour #…" / "Use no colour").
+- Badges use uppercase typography with distinctive colours (`Default` muted,
+  `Active` accent, `Deleted` danger) to make status obvious at a glance.

--- a/scripts/ci/household-lifecycle-smoke.sh
+++ b/scripts/ci/household-lifecycle-smoke.sh
@@ -3,4 +3,8 @@ set -euo pipefail
 
 cargo test --manifest-path src-tauri/Cargo.toml --test household_crud -- --nocapture >/dev/null
 
+npx playwright install --with-deps >/dev/null
+
+npm run test:e2e -- tests/ui/settings-households.spec.ts >/dev/null
+
 echo "household lifecycle smoke OK"

--- a/src/api/households.ts
+++ b/src/api/households.ts
@@ -69,8 +69,8 @@ export type HouseholdErrorCode =
 
 export const HOUSEHOLD_ERROR_MESSAGES: Record<HouseholdErrorCode, string> = {
   DEFAULT_UNDELETABLE: "The default household cannot be deleted.",
-  HOUSEHOLD_NOT_FOUND: "The selected household could not be found.",
-  HOUSEHOLD_DELETED: "The selected household has been archived.",
+  HOUSEHOLD_NOT_FOUND: "That household no longer exists.",
+  HOUSEHOLD_DELETED: "That household is deleted. Restore it first.",
   HOUSEHOLD_ALREADY_ACTIVE: "The selected household is already active.",
 };
 
@@ -83,7 +83,7 @@ export type SetActiveHouseholdResult =
   | { ok: true }
   | { ok: false; code: SetActiveHouseholdErrorCode };
 
-function extractErrorCode(error: unknown): string {
+export function getHouseholdErrorCode(error: unknown): string {
   if (typeof error === "string") {
     return error;
   }
@@ -106,7 +106,7 @@ export async function setActiveHouseholdId(
     await call("household_set_active", { id });
     return { ok: true };
   } catch (error) {
-    const code = extractErrorCode(error);
+    const code = getHouseholdErrorCode(error);
     if (
       code === "HOUSEHOLD_NOT_FOUND" ||
       code === "HOUSEHOLD_DELETED" ||
@@ -116,6 +116,17 @@ export async function setActiveHouseholdId(
     }
     throw error;
   }
+}
+
+export function resolveHouseholdErrorMessage(
+  error: unknown,
+  fallback: string,
+): string {
+  const code = getHouseholdErrorCode(error);
+  if (code in HOUSEHOLD_ERROR_MESSAGES) {
+    return HOUSEHOLD_ERROR_MESSAGES[code as HouseholdErrorCode];
+  }
+  return fallback;
 }
 
 export async function getHousehold(

--- a/src/api/households.ts
+++ b/src/api/households.ts
@@ -141,8 +141,7 @@ export async function createHousehold(
   color: string | null,
 ): Promise<HouseholdRecord> {
   const record = await call<HouseholdRecordRaw>("household_create", {
-    name,
-    color,
+    args: { name, color },
   });
   return normalizeHousehold(record);
 }

--- a/src/features/settings/components/HouseholdSwitcherSection.ts
+++ b/src/features/settings/components/HouseholdSwitcherSection.ts
@@ -1,33 +1,38 @@
 import {
-  listHouseholds,
+  HOUSEHOLD_ERROR_MESSAGES,
+  resolveHouseholdErrorMessage,
   type HouseholdRecord,
   type SetActiveHouseholdErrorCode,
-  HOUSEHOLD_ERROR_MESSAGES,
 } from "../../../api/households";
 import {
   ensureActiveHousehold,
   forceSetActiveHousehold,
-  currentActiveHousehold,
+  refreshHouseholds,
+  createHousehold,
+  updateHousehold,
+  deleteHousehold,
+  restoreHousehold,
+  subscribe as subscribeToHouseholdStore,
+  selectors as householdSelectors,
+  setShowDeleted,
 } from "../../../state/householdStore";
 import { selectors, subscribe, type DbHealthState } from "@store/index";
-import { on } from "@store/events";
-import createSelect from "@ui/Select";
 import createButton from "@ui/Button";
+import createInput from "@ui/Input";
+import { createSwitch, type SwitchElement } from "@ui/Switch";
 import { toast } from "@ui/Toast";
 import { showError } from "@ui/errors";
 
-const DB_UNHEALTHY_WRITE_BLOCKED = "DB_UNHEALTHY_WRITE_BLOCKED" as const;
-
-export interface HouseholdSwitcherSection {
-  element: HTMLElement;
-  destroy: () => void;
-}
-
-function describeError(code: SetActiveHouseholdErrorCode): string {
-  return (
-    HOUSEHOLD_ERROR_MESSAGES[code] ?? "Unable to change the active household."
-  );
-}
+const COLOR_SWATCHES = [
+  "#2563EB",
+  "#0EA5E9",
+  "#10B981",
+  "#F59E0B",
+  "#EF4444",
+  "#EC4899",
+  "#8B5CF6",
+  "#14B8A6",
+] as const;
 
 type HealthGate = { disabled: boolean; message: string | null };
 
@@ -39,38 +44,438 @@ function assessHealth(health: DbHealthState | null): HealthGate {
     return {
       disabled: true,
       message:
-        "Checking database health… Switching households is temporarily disabled.",
+        "Checking database health… Household changes are temporarily disabled.",
     };
   }
-  if (health.error?.code === DB_UNHEALTHY_WRITE_BLOCKED) {
+  if (health.error?.code === "DB_UNHEALTHY_WRITE_BLOCKED") {
     return {
       disabled: true,
       message:
         health.error.message ??
-        "Resolve database health issues before switching households.",
+        "Resolve database health issues before changing households.",
     };
   }
   if (health.report?.status === "error") {
     return {
       disabled: true,
-      message: "Resolve database health issues before switching households.",
+      message: "Resolve database health issues before changing households.",
     };
   }
   return { disabled: false, message: null };
 }
 
-function formatLabel(
-  household: HouseholdRecord,
-  activeId: string | null,
-): string {
-  const parts = [household.name];
-  if (household.isDefault) {
-    parts.push("Default");
+function describeSetActiveError(code: SetActiveHouseholdErrorCode): string {
+  switch (code) {
+    case "HOUSEHOLD_NOT_FOUND":
+      return HOUSEHOLD_ERROR_MESSAGES.HOUSEHOLD_NOT_FOUND;
+    case "HOUSEHOLD_DELETED":
+      return HOUSEHOLD_ERROR_MESSAGES.HOUSEHOLD_DELETED;
+    case "HOUSEHOLD_ALREADY_ACTIVE":
+      return HOUSEHOLD_ERROR_MESSAGES.HOUSEHOLD_ALREADY_ACTIVE;
+    default:
+      return "Unable to change the active household.";
   }
-  if (household.id === activeId) {
-    parts.push("Active");
+}
+
+type ColorPickerControl = {
+  element: HTMLDivElement;
+  getValue: () => string | null;
+  setValue: (value: string | null) => void;
+  setDisabled: (disabled: boolean) => void;
+};
+
+function createColorPicker(initial: string | null): ColorPickerControl {
+  const container = document.createElement("div");
+  container.className = "settings__household-color-picker";
+  let value: string | null = initial ?? null;
+  const swatches: Array<{ value: string | null; button: HTMLButtonElement }> = [];
+
+  const updateSelection = () => {
+    for (const { value: swatchValue, button } of swatches) {
+      const selected = swatchValue === value;
+      button.dataset.selected = selected ? "true" : "false";
+      button.setAttribute("aria-pressed", String(selected));
+    }
+  };
+
+  const select = (next: string | null) => {
+    value = next;
+    updateSelection();
+  };
+
+  const createSwatch = (swatchValue: string | null, label: string) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "settings__household-color";
+    if (swatchValue) {
+      button.style.setProperty("--household-color", swatchValue);
+      button.setAttribute("aria-label", `Use colour ${label}`);
+    } else {
+      button.classList.add("settings__household-color--none");
+      button.setAttribute("aria-label", "Use no colour");
+    }
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      select(swatchValue);
+    });
+    swatches.push({ value: swatchValue, button });
+    return button;
+  };
+
+  container.append(createSwatch(null, "none"));
+  for (const swatch of COLOR_SWATCHES) {
+    container.append(createSwatch(swatch, swatch));
   }
-  return parts.join(" • ");
+
+  updateSelection();
+
+  return {
+    element: container,
+    getValue: () => value,
+    setValue(next) {
+      value = next ?? null;
+      updateSelection();
+    },
+    setDisabled(disabled) {
+      for (const { button } of swatches) {
+        button.disabled = disabled;
+      }
+    },
+  };
+}
+interface RowContext {
+  activeId: string | null;
+  actionsDisabled: boolean;
+  globalLoading: boolean;
+}
+
+type RowActionHandlers = {
+  onSetActive: (record: HouseholdRecord) => Promise<void>;
+  onRename: (
+    record: HouseholdRecord,
+    input: { name: string; color: string | null },
+  ) => Promise<void>;
+  onDelete: (record: HouseholdRecord) => Promise<void>;
+  onRestore: (record: HouseholdRecord) => Promise<void>;
+};
+
+interface HouseholdRowInstance {
+  element: HTMLDivElement;
+  update: (record: HouseholdRecord, context: RowContext) => void;
+  destroy: () => void;
+}
+
+function createHouseholdRow(
+  record: HouseholdRecord,
+  actions: RowActionHandlers,
+): HouseholdRowInstance {
+  let current = record;
+  let editing = false;
+  let pending = false;
+
+  const row = document.createElement("div");
+  row.className = "settings__household-row";
+  row.dataset.householdId = record.id;
+
+  const primary = document.createElement("div");
+  primary.className = "settings__household-primary";
+
+  const colorChip = document.createElement("span");
+  colorChip.className = "settings__household-chip";
+
+  const nameEl = document.createElement("span");
+  nameEl.className = "settings__household-name";
+
+  const badges = document.createElement("div");
+  badges.className = "settings__household-badges";
+
+  primary.append(colorChip, nameEl, badges);
+
+  const controls = document.createElement("div");
+  controls.className = "settings__household-controls";
+
+  const actionButtons = document.createElement("div");
+  actionButtons.className = "settings__household-actions";
+
+  const activateButton = createButton({
+    label: "Set active",
+    size: "sm",
+    variant: "primary",
+  });
+
+  const renameButton = createButton({
+    label: "Rename",
+    size: "sm",
+  });
+
+  const deleteButton = createButton({
+    label: "Delete",
+    size: "sm",
+    variant: "danger",
+  });
+
+  const restoreButton = createButton({
+    label: "Restore",
+    size: "sm",
+    variant: "primary",
+  });
+
+  actionButtons.append(activateButton, renameButton, deleteButton, restoreButton);
+
+  const editForm = document.createElement("form");
+  editForm.className = "settings__household-edit";
+  editForm.hidden = true;
+
+  const nameField = document.createElement("label");
+  nameField.className = "settings__household-field";
+  nameField.textContent = "Name";
+
+  const nameInput = createInput({
+    value: record.name,
+    required: true,
+    className: "settings__household-input",
+  });
+  nameField.append(nameInput);
+
+  const colorField = document.createElement("div");
+  colorField.className = "settings__household-field";
+  const colorLabel = document.createElement("span");
+  colorLabel.className = "settings__household-field-label";
+  colorLabel.textContent = "Colour";
+  const colorPicker = createColorPicker(record.color);
+  colorField.append(colorLabel, colorPicker.element);
+
+  const editActions = document.createElement("div");
+  editActions.className = "settings__household-edit-actions";
+
+  const saveButton = createButton({
+    label: "Save",
+    size: "sm",
+    variant: "primary",
+    type: "submit",
+  });
+
+  const cancelButton = createButton({
+    label: "Cancel",
+    size: "sm",
+    type: "button",
+  });
+
+  editActions.append(saveButton, cancelButton);
+  editForm.append(nameField, colorField, editActions);
+
+  controls.append(actionButtons, editForm);
+
+  row.append(primary, controls);
+
+  const renderBadges = (context: RowContext) => {
+    badges.textContent = "";
+    const descriptors: Array<{ text: string; modifier: string }> = [];
+    if (current.isDefault) descriptors.push({ text: "Default", modifier: "default" });
+    if (current.id === context.activeId)
+      descriptors.push({ text: "Active", modifier: "active" });
+    if (current.deletedAt !== null)
+      descriptors.push({ text: "Deleted", modifier: "deleted" });
+    for (const descriptor of descriptors) {
+      const badge = document.createElement("span");
+      badge.className = `settings__household-badge settings__household-badge--${descriptor.modifier}`;
+      badge.textContent = descriptor.text;
+      badges.append(badge);
+    }
+  };
+
+  const applyColor = () => {
+    if (current.color) {
+      colorChip.style.setProperty("--household-color", current.color);
+      colorChip.classList.remove("settings__household-chip--empty");
+    } else {
+      colorChip.style.removeProperty("--household-color");
+      colorChip.classList.add("settings__household-chip--empty");
+    }
+  };
+
+  let lastContext: RowContext = {
+    activeId: null,
+    actionsDisabled: false,
+    globalLoading: false,
+  };
+
+  const setPending = (value: boolean, context: RowContext) => {
+    pending = value;
+    const disabled = pending || context.actionsDisabled || context.globalLoading;
+    activateButton.disabled = disabled;
+    renameButton.disabled = disabled || current.deletedAt !== null;
+    deleteButton.disabled = disabled || current.deletedAt !== null;
+    restoreButton.disabled = disabled || current.deletedAt === null;
+    nameInput.disabled = pending;
+    colorPicker.setDisabled(pending);
+    saveButton.disabled = pending;
+    cancelButton.disabled = pending;
+  };
+
+  const toggleEditing = (value: boolean, context: RowContext) => {
+    editing = value;
+    if (editing) {
+      nameInput.update({ value: current.name });
+      colorPicker.setValue(current.color);
+      nameInput.focus();
+    }
+    editForm.hidden = !editing;
+    actionButtons.hidden = editing;
+    row.classList.toggle("settings__household-row--editing", editing);
+    setPending(false, context);
+  };
+
+  activateButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    void (async () => {
+      setPending(true, lastContext);
+      try {
+        await actions.onSetActive(current);
+      } catch {
+        // handled upstream
+      } finally {
+        setPending(false, lastContext);
+      }
+    })();
+  });
+
+  renameButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    toggleEditing(true, lastContext);
+  });
+
+  cancelButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    toggleEditing(false, lastContext);
+  });
+
+  editForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    const nameValue = nameInput.value.trim();
+    if (!nameValue) {
+      nameInput.reportValidity();
+      return;
+    }
+    const colorValue = colorPicker.getValue();
+    void (async () => {
+      setPending(true, lastContext);
+      try {
+        await actions.onRename(current, { name: nameValue, color: colorValue });
+        toggleEditing(false, lastContext);
+      } catch {
+        // handled upstream
+      } finally {
+        setPending(false, lastContext);
+      }
+    })();
+  });
+
+  deleteButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    const confirmed = window.confirm(
+      `Delete ${current.name}? You can restore it later.`,
+    );
+    if (!confirmed) return;
+    void (async () => {
+      setPending(true, lastContext);
+      try {
+        await actions.onDelete(current);
+      } catch {
+        // handled upstream
+      } finally {
+        setPending(false, lastContext);
+      }
+    })();
+  });
+
+  restoreButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (pending) return;
+    void (async () => {
+      setPending(true, lastContext);
+      try {
+        await actions.onRestore(current);
+      } catch {
+        // handled upstream
+      } finally {
+        setPending(false, lastContext);
+      }
+    })();
+  });
+
+  const update = (nextRecord: HouseholdRecord, context: RowContext) => {
+    current = nextRecord;
+    lastContext = context;
+    row.dataset.householdId = nextRecord.id;
+    nameEl.textContent = nextRecord.name;
+    applyColor();
+    renderBadges(context);
+    row.classList.toggle(
+      "settings__household-row--deleted",
+      nextRecord.deletedAt !== null,
+    );
+    toggleEditing(editing && nextRecord.deletedAt === null, context);
+    activateButton.hidden =
+      nextRecord.deletedAt !== null || nextRecord.id === context.activeId;
+    renameButton.hidden = nextRecord.deletedAt !== null;
+    deleteButton.hidden = nextRecord.deletedAt !== null;
+    restoreButton.hidden = nextRecord.deletedAt === null;
+    setPending(pending, context);
+  };
+
+  applyColor();
+  renderBadges(lastContext);
+
+  return {
+    element: row,
+    update,
+    destroy: () => {
+      row.remove();
+    },
+  };
+}
+interface HouseholdViewState {
+  households: HouseholdRecord[];
+  deleted: HouseholdRecord[];
+  activeId: string | null;
+  showDeleted: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+function describeStatus(state: HouseholdViewState, health: HealthGate): string {
+  if (state.loading) {
+    return "Loading households…";
+  }
+  if (state.error) {
+    return state.error;
+  }
+  if (health.disabled && health.message) {
+    return health.message;
+  }
+  if (state.households.length === 0) {
+    return "No households available.";
+  }
+  const active = state.households.find((item) => item.id === state.activeId);
+  if (!active) {
+    return "No active household is selected.";
+  }
+  const suffix: string[] = [];
+  if (active.isDefault) suffix.push("Default");
+  if (active.deletedAt) suffix.push("Deleted");
+  const decorated = suffix.length > 0 ? ` (${suffix.join(", ")})` : "";
+  return `Active household: ${active.name}${decorated}`;
+}
+
+export interface HouseholdSwitcherSection {
+  element: HTMLElement;
+  destroy: () => void;
 }
 
 export function createHouseholdSwitcherSection(): HouseholdSwitcherSection {
@@ -80,249 +485,331 @@ export function createHouseholdSwitcherSection(): HouseholdSwitcherSection {
 
   const heading = document.createElement("h3");
   heading.id = "settings-household";
-  heading.textContent = "Household";
+  heading.textContent = "Households";
 
   const body = document.createElement("div");
-  body.className = "settings__body";
+  body.className = "settings__body settings__households";
 
   const helper = document.createElement("p");
   helper.className = "settings__helper";
   helper.textContent =
-    "Switch the active household used by Arklowdun. Changes apply immediately across the app.";
+    "Create, rename, delete, and restore households. The active household scopes data across the app.";
 
-  const selectWrapper = document.createElement("label");
-  selectWrapper.className = "settings__household-select";
+  const createBlock = document.createElement("div");
+  createBlock.className = "settings__household-create";
 
-  const selectLabel = document.createElement("span");
-  selectLabel.textContent = "Active household";
-
-  const select = createSelect({
-    ariaLabel: "Active household",
-    disabled: true,
-  });
-  select.update({ className: "settings__household-select-input" });
-
-  selectWrapper.append(selectLabel, select);
-
-  const actions = document.createElement("div");
-  actions.className = "settings__actions";
-
-  const applyButton = createButton({
-    label: "Set active household",
+  const createTrigger = createButton({
+    label: "Create household",
     variant: "primary",
-    className: "settings__button",
-    type: "button",
-    disabled: true,
+    className: "settings__household-create-trigger",
   });
 
-  actions.append(applyButton);
+  const createForm = document.createElement("form");
+  createForm.className = "settings__household-create-form";
+  createForm.hidden = true;
+
+  const createNameLabel = document.createElement("label");
+  createNameLabel.className = "settings__household-field";
+  createNameLabel.textContent = "Name";
+
+  const createNameInput = createInput({
+    placeholder: "Household name",
+    required: true,
+    className: "settings__household-input",
+  });
+  createNameLabel.append(createNameInput);
+
+  const createColorField = document.createElement("div");
+  createColorField.className = "settings__household-field";
+  const createColorLabel = document.createElement("span");
+  createColorLabel.className = "settings__household-field-label";
+  createColorLabel.textContent = "Colour";
+  const createColorControl = createColorPicker(null);
+  createColorField.append(createColorLabel, createColorControl.element);
+
+  const createActions = document.createElement("div");
+  createActions.className = "settings__household-create-actions";
+
+  const createSubmit = createButton({
+    label: "Create",
+    variant: "primary",
+    size: "sm",
+    type: "submit",
+  });
+
+  const createCancel = createButton({
+    label: "Cancel",
+    size: "sm",
+    type: "button",
+  });
+
+  createActions.append(createSubmit, createCancel);
+  createForm.append(createNameLabel, createColorField, createActions);
+  createBlock.append(createTrigger, createForm);
+
+  const toggleRow = document.createElement("div");
+  toggleRow.className = "settings__household-toggle";
+  const toggleLabel = document.createElement("span");
+  toggleLabel.textContent = "Show deleted households";
+  const showDeletedToggle: SwitchElement = createSwitch({
+    checked: false,
+    ariaLabel: "Show deleted households",
+    onChange: (_event, checked) => {
+      if (toggleGuard) return;
+      setShowDeleted(checked);
+    },
+  });
+  toggleRow.append(toggleLabel, showDeletedToggle);
 
   const status = document.createElement("p");
   status.className = "settings__household-status";
   status.setAttribute("role", "status");
   status.setAttribute("aria-live", "polite");
 
-  body.append(helper, selectWrapper, actions, status);
+  const activeList = document.createElement("div");
+  activeList.className = "settings__household-list";
+
+  const deletedSection = document.createElement("div");
+  deletedSection.className = "settings__household-deleted";
+  deletedSection.hidden = true;
+  const deletedHeading = document.createElement("h4");
+  deletedHeading.textContent = "Deleted households";
+  const deletedList = document.createElement("div");
+  deletedList.className = "settings__household-list settings__household-list--deleted";
+  deletedSection.append(deletedHeading, deletedList);
+
+  body.append(helper, createBlock, toggleRow, status, activeList, deletedSection);
   section.append(heading, body);
 
   let destroyed = false;
-  let households: HouseholdRecord[] = [];
-  let loading = true;
-  let pending = false;
-  let loadError: string | null = null;
-  let activeId: string | null = currentActiveHousehold();
-  let selectedId: string | null = activeId;
+  let creating = false;
   let healthState: DbHealthState | null = null;
-  let refreshRequested = false;
-
-  function findHousehold(id: string | null): HouseholdRecord | undefined {
-    if (!id) return undefined;
-    return households.find((item) => item.id === id);
-  }
-
-  function ensureSelection(): void {
-    if (households.length === 0) {
-      selectedId = null;
-      return;
-    }
-    if (selectedId && households.some((h) => h.id === selectedId)) {
-      return;
-    }
-    if (activeId && households.some((h) => h.id === activeId)) {
-      selectedId = activeId;
-      return;
-    }
-    selectedId = households[0].id;
-  }
-
-  function describeActive(): string {
-    if (!activeId) {
-      return "No active household is selected.";
-    }
-    const active = findHousehold(activeId);
-    if (!active) {
-      return `Active household: ${activeId}`;
-    }
-    const suffix = active.isDefault ? " (Default)" : "";
-    return `Active household: ${active.name}${suffix}`;
-  }
-
-  function describeSelection(): string {
-    if (!selectedId || selectedId === activeId) {
-      return describeActive();
-    }
-    const target = findHousehold(selectedId);
-    const label = target ? target.name : selectedId;
-    return `Switch to ${label} to reload data.`;
-  }
-
-  function render(): void {
-    ensureSelection();
-    const health = assessHealth(healthState);
-    const hasHouseholds = households.length > 0;
-
-    const options = households.map((household) => ({
-      value: household.id,
-      label: formatLabel(household, activeId),
-    }));
-    select.update({ options, value: selectedId ?? "" });
-
-    const disableSelect =
-      loading || pending || !hasHouseholds || health.disabled;
-    select.update({ disabled: disableSelect });
-
-    const disableApply =
-      disableSelect ||
-      !selectedId ||
-      selectedId === activeId ||
-      households.length === 0;
-    applyButton.disabled = disableApply || pending;
-
-    let message = "";
-    if (loading) {
-      message = "Loading households…";
-    } else if (loadError) {
-      message = loadError;
-    } else if (!hasHouseholds) {
-      message = "No households available.";
-    } else if (pending) {
-      message = "Updating active household…";
-    } else if (health.disabled && health.message) {
-      message = health.message;
-    } else {
-      message = describeSelection();
-    }
-
-    status.textContent = message;
-    status.hidden = message.trim().length === 0;
-  }
-
-  async function reloadHouseholds(): Promise<void> {
-    loading = true;
-    loadError = null;
-    render();
-    try {
-      const [list, active] = await Promise.all([
-        listHouseholds(),
-        ensureActiveHousehold(),
-      ]);
-      if (destroyed) return;
-      const previousSelection = selectedId;
-      households = list;
-      activeId = active;
-      if (
-        previousSelection &&
-        list.some((item: HouseholdRecord) => item.id === previousSelection)
-      ) {
-        selectedId = previousSelection;
-      } else if (
-        active &&
-        list.some((item: HouseholdRecord) => item.id === active)
-      ) {
-        selectedId = active;
-      } else {
-        selectedId = list.length > 0 ? list[0].id : null;
-      }
-      loadError = null;
-    } catch (error) {
-      if (destroyed) return;
-      households = [];
-      loadError = "Unable to load households.";
-      showError(error);
-    } finally {
-      if (destroyed) return;
-      loading = false;
-      render();
-      if (refreshRequested) {
-        refreshRequested = false;
-        void reloadHouseholds();
-      }
-    }
-  }
-
-  select.addEventListener("change", () => {
-    selectedId = select.value || null;
-    render();
-  });
-
-  applyButton.addEventListener("click", (event) => {
-    event.preventDefault();
-    if (!selectedId || selectedId === activeId || pending) {
-      return;
-    }
-    pending = true;
-    render();
-    void (async () => {
+  const rowMap = new Map<string, HouseholdRowInstance>();
+  let toggleGuard = false;
+  const actions: RowActionHandlers = {
+    onSetActive: async (record) => {
       try {
-        const result = await forceSetActiveHousehold(selectedId!);
+        const result = await forceSetActiveHousehold(record.id);
         if (!result.ok) {
-          selectedId = activeId;
-          toast.show({ kind: "error", message: describeError(result.code) });
+          toast.show({
+            kind: "error",
+            message: describeSetActiveError(result.code),
+          });
           return;
         }
-        activeId = selectedId;
         toast.show({ kind: "success", message: "Active household updated." });
       } catch (error) {
-        selectedId = activeId;
+        showError(error);
+        throw error;
+      }
+    },
+    onRename: async (record, input) => {
+      try {
+        await updateHousehold(record.id, {
+          name: input.name,
+          color: input.color,
+        });
+        toast.show({ kind: "success", message: "Household renamed." });
+      } catch (error) {
+        showError(error);
+        throw error;
+      }
+    },
+    onDelete: async (record) => {
+      const fallback = "Unable to delete household.";
+      try {
+        await deleteHousehold(record.id);
+        toast.show({ kind: "success", message: "Household deleted." });
+      } catch (error) {
+        const friendly = resolveHouseholdErrorMessage(error, fallback);
+        if (friendly === fallback) {
+          showError(error);
+        } else {
+          toast.show({ kind: "error", message: friendly });
+        }
+        throw error;
+      }
+    },
+    onRestore: async (record) => {
+      try {
+        await restoreHousehold(record.id);
+        toast.show({ kind: "success", message: "Household restored." });
+      } catch (error) {
+        showError(error);
+        throw error;
+      }
+    },
+  };
+
+  const rowMapHelper = (record: HouseholdRecord): HouseholdRowInstance => {
+    let instance = rowMap.get(record.id);
+    if (!instance) {
+      instance = createHouseholdRow(record, actions);
+      rowMap.set(record.id, instance);
+    }
+    return instance;
+  };
+
+  const cleanupRows = (keep: Set<string>) => {
+    for (const [id, row] of rowMap) {
+      if (!keep.has(id)) {
+        row.destroy();
+        rowMap.delete(id);
+      }
+    }
+  };
+  const render = (view: HouseholdViewState) => {
+    if (destroyed) return;
+    const health = assessHealth(healthState);
+    const actionsDisabled = health.disabled || creating;
+
+    createTrigger.disabled = actionsDisabled || view.loading;
+    createSubmit.disabled = creating;
+    createCancel.disabled = creating;
+    createNameInput.disabled = creating;
+    createColorControl.setDisabled(creating);
+
+    toggleGuard = true;
+    showDeletedToggle.update({
+      checked: view.showDeleted,
+      disabled: view.loading,
+    });
+    toggleGuard = false;
+
+    const statusMessage = describeStatus(view, health);
+    status.textContent = statusMessage;
+    status.hidden = statusMessage.trim().length === 0;
+
+    const activeItems = view.households.filter((item) => item.deletedAt === null);
+    const deletedItems = view.deleted;
+
+    const activeFragment = document.createDocumentFragment();
+    const seen = new Set<string>();
+
+    for (const household of activeItems) {
+      const row = rowMapHelper(household);
+      row.update(household, {
+        activeId: view.activeId,
+        actionsDisabled,
+        globalLoading: view.loading,
+      });
+      activeFragment.append(row.element);
+      seen.add(household.id);
+    }
+
+    activeList.replaceChildren(activeFragment);
+
+    if (view.showDeleted && deletedItems.length > 0) {
+      const deletedFragment = document.createDocumentFragment();
+      for (const household of deletedItems) {
+        const row = rowMapHelper(household);
+        row.update(household, {
+          activeId: view.activeId,
+          actionsDisabled,
+          globalLoading: view.loading,
+        });
+        deletedFragment.append(row.element);
+        seen.add(household.id);
+      }
+      deletedList.replaceChildren(deletedFragment);
+      deletedSection.hidden = false;
+    } else {
+      deletedSection.hidden = true;
+      deletedList.replaceChildren();
+    }
+
+    cleanupRows(seen);
+  };
+  let currentState: HouseholdViewState = {
+    households: [],
+    deleted: [],
+    activeId: null,
+    showDeleted: false,
+    loading: false,
+    error: null,
+  };
+
+  createTrigger.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (creating) return;
+    createForm.hidden = false;
+    createTrigger.hidden = true;
+    createNameInput.update({ value: "" });
+    createColorControl.setValue(null);
+    createNameInput.focus();
+  });
+
+  const resetCreateForm = () => {
+    createForm.hidden = true;
+    createTrigger.hidden = false;
+    creating = false;
+    createNameInput.update({ value: "" });
+    createColorControl.setValue(null);
+  };
+
+  createCancel.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (creating) return;
+    resetCreateForm();
+  });
+
+  createForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (creating) return;
+    const nameValue = createNameInput.value.trim();
+    if (!nameValue) {
+      createNameInput.reportValidity();
+      return;
+    }
+    const colorValue = createColorControl.getValue();
+    creating = true;
+    render(currentState);
+    void (async () => {
+      try {
+        await createHousehold(nameValue, colorValue);
+        toast.show({ kind: "success", message: "Household created." });
+        resetCreateForm();
+      } catch (error) {
         showError(error);
       } finally {
-        if (destroyed) return;
-        pending = false;
-        render();
+        creating = false;
+        render(currentState);
       }
     })();
   });
 
-  const unsubscribeHealth = subscribe(selectors.db.health, (state) => {
+  const unsubscribeStore = subscribeToHouseholdStore(
+    (state) => ({
+      households: householdSelectors.allHouseholds(state),
+      deleted: householdSelectors.deletedHouseholds(state),
+      activeId: state.activeId,
+      showDeleted: state.showDeleted,
+      loading: state.loading,
+      error: state.error,
+    }),
+    (view) => {
+      currentState = view;
+      render(view);
+    },
+  );
+
+  const unsubscribeHealth = subscribe(selectors.db.health, (health) => {
     if (destroyed) return;
-    healthState = state;
-    render();
+    healthState = health;
+    render(currentState);
   });
 
-  const stopHousehold = on("household:changed", ({ householdId }) => {
-    if (destroyed) return;
-    activeId = householdId;
-    if (!households.some((h) => h.id === householdId)) {
-      if (loading) {
-        refreshRequested = true;
-      } else {
-        void reloadHouseholds();
-      }
-      return;
-    }
-    selectedId = householdId;
-    render();
-  });
-
-  render();
-  void reloadHouseholds();
+  void ensureActiveHousehold().catch(showError);
+  void refreshHouseholds().catch(showError);
 
   return {
     element: section,
     destroy: () => {
       destroyed = true;
+      unsubscribeStore();
       unsubscribeHealth();
-      stopHousehold();
+      rowMap.forEach((row) => row.destroy());
+      rowMap.clear();
     },
   };
 }

--- a/src/state/householdStore.spec.ts
+++ b/src/state/householdStore.spec.ts
@@ -1,22 +1,35 @@
 /* eslint-disable security/detect-object-injection -- test doubles index controlled listener maps */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const eventListeners: Record<
-  string,
-  (event: { payload: { id: string } }) => void
-> = {};
+const { eventListeners, listenMock } = vi.hoisted(() => {
+  interface HouseholdEvent {
+    payload: { id: string };
+  }
 
-const listenMock = vi.fn(
-  async (
-    event: string,
-    callback: (event: { payload: { id: string } }) => void,
-  ) => {
-    eventListeners[event] = callback;
-    return () => {
-      delete eventListeners[event];
-    };
-  },
-);
+  const listeners: Record<string, (event: HouseholdEvent) => void> = {};
+
+  const listenerMock = vi.fn(
+    async (event: string, callback: (event: HouseholdEvent) => void) => {
+      listeners[event] = callback;
+      return () => {
+        delete listeners[event];
+      };
+    },
+  );
+
+  return { eventListeners: listeners, listenMock: listenerMock };
+});
+
+type TestHousehold = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  tz: string | null;
+  createdAt: number | null;
+  updatedAt: number | null;
+  deletedAt: number | null;
+  color: string | null;
+};
 
 const getActiveHouseholdIdMock = vi.fn<[], Promise<string>>();
 const setActiveHouseholdIdMock = vi.fn<
@@ -32,15 +45,34 @@ const setActiveHouseholdIdMock = vi.fn<
       }
   >
 >();
+const listHouseholdsMock = vi.fn<[boolean?], Promise<TestHousehold[]>>();
+const createHouseholdMock = vi.fn<
+  [string, string | null],
+  Promise<TestHousehold>
+>();
+const updateHouseholdMock = vi.fn<
+  [string, { name?: string; color?: string | null }],
+  Promise<TestHousehold>
+>();
+const deleteHouseholdMock = vi.fn<
+  [string],
+  Promise<{ fallbackId: string | null }>
+>();
+const restoreHouseholdMock = vi.fn<[string], Promise<TestHousehold>>();
 const emitMock = vi.fn<[string, { householdId: string }], void>();
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: listenMock,
-}));
+  vi.mock("@tauri-apps/api/event", () => ({
+    listen: listenMock,
+  }));
 
 vi.mock("../api/households", () => ({
   getActiveHouseholdId: getActiveHouseholdIdMock,
   setActiveHouseholdId: setActiveHouseholdIdMock,
+  listHouseholds: listHouseholdsMock,
+  createHousehold: createHouseholdMock,
+  updateHousehold: updateHouseholdMock,
+  deleteHousehold: deleteHouseholdMock,
+  restoreHousehold: restoreHouseholdMock,
 }));
 
 vi.mock("../store/events", () => ({
@@ -52,6 +84,11 @@ describe("householdStore", () => {
     vi.resetModules();
     getActiveHouseholdIdMock.mockReset();
     setActiveHouseholdIdMock.mockReset();
+    listHouseholdsMock.mockReset();
+    createHouseholdMock.mockReset();
+    updateHouseholdMock.mockReset();
+    deleteHouseholdMock.mockReset();
+    restoreHouseholdMock.mockReset();
     emitMock.mockReset();
     listenMock.mockClear();
     for (const key of Object.keys(eventListeners)) {
@@ -59,9 +96,27 @@ describe("householdStore", () => {
     }
   });
 
+  function household(
+    id: string,
+    overrides: Partial<TestHousehold> = {},
+  ): TestHousehold {
+    return {
+      id,
+      name: id,
+      isDefault: false,
+      tz: null,
+      createdAt: 1,
+      updatedAt: 1,
+      deletedAt: null,
+      color: null,
+      ...overrides,
+    };
+  }
+
   it("caches the active household id", async () => {
     getActiveHouseholdIdMock.mockResolvedValue("hh-test");
     setActiveHouseholdIdMock.mockResolvedValue({ ok: true });
+    listHouseholdsMock.mockResolvedValue([]);
     const store = await import("./householdStore");
     const first = await store.ensureActiveHousehold();
     const second = await store.ensureActiveHousehold();
@@ -74,6 +129,7 @@ describe("householdStore", () => {
   it("updates cache when the native event arrives", async () => {
     getActiveHouseholdIdMock.mockResolvedValue("hh-one");
     setActiveHouseholdIdMock.mockResolvedValue({ ok: true });
+    listHouseholdsMock.mockResolvedValue([]);
     const store = await import("./householdStore");
     await store.ensureActiveHousehold();
     const listener = eventListeners["household:changed"];
@@ -93,11 +149,116 @@ describe("householdStore", () => {
       ok: false,
       code: "HOUSEHOLD_DELETED",
     });
+    listHouseholdsMock.mockResolvedValue([]);
     const store = await import("./householdStore");
     await store.ensureActiveHousehold();
     const result = await store.forceSetActiveHousehold("hh-deleted");
     expect(result).toEqual({ ok: false, code: "HOUSEHOLD_DELETED" });
     const still = await store.ensureActiveHousehold();
     expect(still).toBe("hh-active");
+  });
+
+  it("refreshes the list after create", async () => {
+    const initial = [household("0", { isDefault: true })];
+    const created = household("hh-created", { name: "Created" });
+    listHouseholdsMock.mockResolvedValueOnce(initial);
+    const store = await import("./householdStore");
+    await store.refreshHouseholds();
+    expect(store.getState().households).toEqual(initial);
+
+    createHouseholdMock.mockResolvedValue(created);
+    const after = [...initial, created];
+    listHouseholdsMock.mockResolvedValueOnce(after);
+
+    await store.createHousehold("Created", null);
+    expect(createHouseholdMock).toHaveBeenCalledWith("Created", null);
+    expect(listHouseholdsMock).toHaveBeenCalledTimes(2);
+    expect(store.getState().households).toEqual(after);
+  });
+
+  it("updates the store after rename", async () => {
+    const original = [
+      household("0", { isDefault: true, name: "Default" }),
+      household("hh-two", { name: "Original" }),
+    ];
+    listHouseholdsMock.mockResolvedValueOnce(original);
+    const store = await import("./householdStore");
+    await store.refreshHouseholds();
+
+    const updated = household("hh-two", { name: "Renamed" });
+    updateHouseholdMock.mockResolvedValue(updated);
+    listHouseholdsMock.mockResolvedValueOnce([
+      original[0],
+      updated,
+    ]);
+
+    await store.updateHousehold("hh-two", { name: "Renamed" });
+    expect(updateHouseholdMock).toHaveBeenCalledWith("hh-two", {
+      name: "Renamed",
+    });
+    expect(store.getState().households).toEqual([original[0], updated]);
+  });
+
+  it("handles delete fallback", async () => {
+    const initial = [
+      household("0", { isDefault: true, name: "Default" }),
+      household("hh-two", { name: "Secondary" }),
+    ];
+    listHouseholdsMock.mockResolvedValueOnce(initial);
+    getActiveHouseholdIdMock.mockResolvedValue("hh-two");
+    const store = await import("./householdStore");
+    await store.ensureActiveHousehold();
+    await store.refreshHouseholds();
+
+    deleteHouseholdMock.mockResolvedValue({ fallbackId: "0" });
+    const after = [
+      { ...initial[0] },
+      { ...initial[1], deletedAt: 10, updatedAt: 10 },
+    ];
+    listHouseholdsMock.mockResolvedValueOnce(after);
+
+    await store.deleteHousehold("hh-two");
+    expect(deleteHouseholdMock).toHaveBeenCalledWith("hh-two");
+    expect(store.currentActiveHousehold()).toBe("0");
+    expect(emitMock).toHaveBeenCalledWith("household:changed", {
+      householdId: "0",
+    });
+    expect(store.getState().households).toEqual(after);
+  });
+
+  it("restores a deleted household", async () => {
+    const deleted = household("hh-three", { deletedAt: 5 });
+    const initial = [household("0", { isDefault: true }), deleted];
+    listHouseholdsMock.mockResolvedValueOnce(initial);
+    const store = await import("./householdStore");
+    await store.refreshHouseholds();
+
+    const restored = { ...deleted, deletedAt: null };
+    restoreHouseholdMock.mockResolvedValue(restored);
+    listHouseholdsMock.mockResolvedValueOnce([initial[0], restored]);
+
+    await store.restoreHousehold("hh-three");
+    expect(restoreHouseholdMock).toHaveBeenCalledWith("hh-three");
+    expect(store.getState().households).toEqual([initial[0], restored]);
+  });
+
+  it("exposes selectors for deleted households", async () => {
+    const deleted = household("hh-deleted", { deletedAt: 123 });
+    const active = household("hh-active");
+    listHouseholdsMock.mockResolvedValueOnce([active, deleted]);
+    const store = await import("./householdStore");
+    await store.refreshHouseholds();
+
+    store.setShowDeleted(false);
+    expect(store.selectors.deletedHouseholds(store.getState())).toEqual([]);
+
+    store.setShowDeleted(true);
+    expect(store.selectors.deletedHouseholds(store.getState())).toEqual([
+      deleted,
+    ]);
+    expect(store.selectors.allHouseholds(store.getState())).toEqual([
+      active,
+      deleted,
+    ]);
   });
 });

--- a/src/state/householdStore.ts
+++ b/src/state/householdStore.ts
@@ -1,21 +1,109 @@
 import { listen } from "@tauri-apps/api/event";
 import {
+  createHousehold as apiCreateHousehold,
+  deleteHousehold as apiDeleteHousehold,
   getActiveHouseholdId,
+  listHouseholds as apiListHouseholds,
+  restoreHousehold as apiRestoreHousehold,
   setActiveHouseholdId,
+  updateHousehold as apiUpdateHousehold,
+  type DeleteHouseholdResponse,
+  type HouseholdRecord,
   type SetActiveHouseholdResult,
+  type UpdateHouseholdInput,
 } from "../api/households";
 import { emit } from "../store/events";
 import { log } from "../utils/logger";
 
-let current: string | null = null;
+export interface HouseholdStoreState {
+  households: HouseholdRecord[];
+  activeId: string | null;
+  showDeleted: boolean;
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
+}
+
+type Selector<T> = (state: HouseholdStoreState) => T;
+
+interface InternalSubscriptionEntry {
+  selector: Selector<unknown>;
+  listener: (value: unknown) => void;
+  lastValue: unknown;
+}
+
+const INITIAL_STATE: HouseholdStoreState = {
+  households: [],
+  activeId: null,
+  showDeleted: false,
+  loading: false,
+  loaded: false,
+  error: null,
+};
+
+let state: HouseholdStoreState = INITIAL_STATE;
 let listenerReady: Promise<void> | null = null;
 let dispose: (() => void) | null = null;
+let refreshPromise: Promise<HouseholdRecord[]> | null = null;
+
+const subscriptions = new Set<InternalSubscriptionEntry>();
+
+function notifySubscribers(): void {
+  subscriptions.forEach((entry) => {
+    const nextValue = entry.selector(state);
+    if (!Object.is(nextValue, entry.lastValue)) {
+      entry.lastValue = nextValue;
+      entry.listener(nextValue);
+    }
+  });
+}
+
+function setState(
+  updater: (prev: HouseholdStoreState) => HouseholdStoreState,
+): void {
+  const next = updater(state);
+  if (next === state) return;
+  state = next;
+  notifySubscribers();
+}
+
+function updateState(patch: Partial<HouseholdStoreState>): void {
+  setState((prev) => {
+    const next = { ...prev, ...patch };
+    if (
+      next.households === prev.households &&
+      next.activeId === prev.activeId &&
+      next.showDeleted === prev.showDeleted &&
+      next.loading === prev.loading &&
+      next.loaded === prev.loaded &&
+      next.error === prev.error
+    ) {
+      return prev;
+    }
+    return next;
+  });
+}
+
+function setActiveId(id: string, emitChange = true): void {
+  let changed = false;
+  setState((prev) => {
+    if (prev.activeId === id) {
+      return prev;
+    }
+    changed = true;
+    return { ...prev, activeId: id };
+  });
+  if (changed && emitChange) {
+    emit("household:changed", { householdId: id });
+  }
+}
 
 async function ensureNativeListener(): Promise<void> {
   if (listenerReady) return listenerReady;
   listenerReady = listen<{ id: string }>("household:changed", ({ payload }) => {
-    current = payload.id;
-    emit("household:changed", { householdId: payload.id });
+    if (typeof payload?.id === "string") {
+      setActiveId(payload.id);
+    }
   })
     .then((unlisten) => {
       dispose = () => {
@@ -36,28 +124,168 @@ async function ensureNativeListener(): Promise<void> {
 
 void ensureNativeListener();
 
-export async function ensureActiveHousehold(): Promise<string> {
-  await ensureNativeListener();
-  if (current) return current;
-  current = await getActiveHouseholdId();
-  return current;
+export function getState(): HouseholdStoreState {
+  return state;
 }
 
-export async function forceSetActiveHousehold(id: string): Promise<SetActiveHouseholdResult> {
+export function subscribe<T>(
+  selector: Selector<T>,
+  listener: (value: T) => void,
+): () => void {
+  const entry: InternalSubscriptionEntry = {
+    selector: selector as Selector<unknown>,
+    listener: listener as (value: unknown) => void,
+    lastValue: selector(state),
+  };
+  subscriptions.add(entry);
+  listener(entry.lastValue as T);
+  return () => {
+    subscriptions.delete(entry);
+  };
+}
+
+export const selectors = {
+  allHouseholds: (s: HouseholdStoreState): HouseholdRecord[] =>
+    s.showDeleted
+      ? [...s.households]
+      : s.households.filter((household) => household.deletedAt === null),
+  activeHousehold: (s: HouseholdStoreState): HouseholdRecord | null =>
+    s.households.find((household) => household.id === s.activeId) ?? null,
+  deletedHouseholds: (s: HouseholdStoreState): HouseholdRecord[] =>
+    s.showDeleted
+      ? s.households.filter((household) => household.deletedAt !== null)
+      : [],
+};
+
+export function setShowDeleted(show: boolean): void {
+  updateState({ showDeleted: show });
+}
+
+export async function ensureActiveHousehold(): Promise<string> {
+  await ensureNativeListener();
+  if (state.activeId) return state.activeId;
+  const id = await getActiveHouseholdId();
+  if (typeof id === "string") {
+    setActiveId(id, false);
+    return id;
+  }
+  throw new Error("Active household id unavailable");
+}
+
+export function currentActiveHousehold(): string | null {
+  return state.activeId;
+}
+
+export async function forceSetActiveHousehold(
+  id: string,
+): Promise<SetActiveHouseholdResult> {
   await ensureNativeListener();
   const result = await setActiveHouseholdId(id);
   if (result.ok) {
-    current = id;
+    setActiveId(id);
   }
   return result;
 }
 
-export function currentActiveHousehold(): string | null {
-  return current;
+export async function refreshHouseholds(): Promise<HouseholdRecord[]> {
+  if (refreshPromise) return refreshPromise;
+  const promise = (async () => {
+    updateState({ loading: true, error: null });
+    try {
+      const records = await apiListHouseholds(true);
+      setState((prev) => ({
+        ...prev,
+        households: records,
+        loading: false,
+        loaded: true,
+        error: null,
+      }));
+      return records;
+    } catch (error) {
+      log.warn("householdStore:refresh_failed", error);
+      updateState({ loading: false, error: "Unable to load households." });
+      throw error;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+  refreshPromise = promise;
+  return promise;
+}
+
+export async function ensureHouseholdsLoaded(): Promise<void> {
+  if (state.loaded || state.loading) {
+    return;
+  }
+  await refreshHouseholds();
+}
+
+export async function createHousehold(
+  name: string,
+  color: string | null,
+): Promise<HouseholdRecord> {
+  const record = await apiCreateHousehold(name, color);
+  setState((prev) => ({
+    ...prev,
+    households: [...prev.households, record],
+  }));
+  await refreshHouseholds();
+  return record;
+}
+
+export async function updateHousehold(
+  id: string,
+  input: UpdateHouseholdInput,
+): Promise<HouseholdRecord> {
+  const record = await apiUpdateHousehold(id, input);
+  setState((prev) => ({
+    ...prev,
+    households: prev.households.map((household) =>
+      household.id === record.id ? record : household,
+    ),
+  }));
+  await refreshHouseholds();
+  return record;
+}
+
+export async function deleteHousehold(
+  id: string,
+): Promise<DeleteHouseholdResponse> {
+  const response = await apiDeleteHousehold(id);
+  const deletedAt = Date.now();
+  setState((prev) => ({
+    ...prev,
+    households: prev.households.map((household) =>
+      household.id === id
+        ? { ...household, deletedAt, updatedAt: deletedAt }
+        : household,
+    ),
+  }));
+  if (response.fallbackId) {
+    setActiveId(response.fallbackId);
+  }
+  await refreshHouseholds();
+  return response;
+}
+
+export async function restoreHousehold(
+  id: string,
+): Promise<HouseholdRecord> {
+  const record = await apiRestoreHousehold(id);
+  setState((prev) => ({
+    ...prev,
+    households: prev.households.map((household) =>
+      household.id === record.id ? record : household,
+    ),
+  }));
+  await refreshHouseholds();
+  return record;
 }
 
 export function __resetHouseholdStore(): void {
-  current = null;
+  state = { ...INITIAL_STATE };
+  refreshPromise = null;
+  subscriptions.clear();
   if (dispose) {
     dispose();
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1021,6 +1021,230 @@ footer a.footer__settings {
   color: var(--color-text-muted);
 }
 
+.settings__households {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings__household-create {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.settings__household-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  inline-size: 100%;
+  max-inline-size: 28rem;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-base);
+  background: var(--color-surface-subtle);
+}
+
+.settings__household-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settings__household-field-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.settings__household-input {
+  inline-size: 100%;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-base);
+  background: var(--color-surface);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.settings__household-create-actions,
+.settings__household-edit-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.settings__household-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-base);
+  background: var(--color-surface-subtle);
+}
+
+.settings__household-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.settings__household-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.settings__household-deleted {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.settings__household-deleted h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.settings__household-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-base);
+  background: var(--color-surface);
+}
+
+.settings__household-row--editing {
+  border-color: var(--color-accent);
+}
+
+.settings__household-row--deleted {
+  opacity: 0.75;
+}
+
+.settings__household-primary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-inline-size: 0;
+}
+
+.settings__household-chip {
+  position: relative;
+  inline-size: 1.5rem;
+  block-size: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-soft);
+  background: var(--household-color, transparent);
+}
+
+.settings__household-chip--empty::after {
+  content: "";
+  position: absolute;
+  inset: 0.3rem;
+  border-top: 1px solid var(--color-border);
+  transform: rotate(45deg);
+}
+
+.settings__household-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings__household-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.settings__household-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.settings__household-badge--default {
+  background: var(--color-surface-subtle);
+  color: var(--color-text-muted);
+}
+
+.settings__household-badge--active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.settings__household-badge--deleted {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-danger);
+}
+
+.settings__household-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-end;
+}
+
+.settings__household-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.settings__household-edit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  inline-size: 100%;
+  max-inline-size: 24rem;
+}
+
+.settings__household-color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.settings__household-color {
+  inline-size: 1.5rem;
+  block-size: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border-soft);
+  background: var(--household-color, transparent);
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings__household-color[data-selected="true"] {
+  box-shadow: 0 0 0 2px var(--color-accent);
+}
+
+.settings__household-color--none::after {
+  content: "";
+  position: absolute;
+  inset: 0.3rem;
+  border-top: 1px solid var(--color-border);
+  transform: rotate(45deg);
+}
+
 .settings__category-toggle {
   display: grid;
   grid-template-columns: auto auto 1fr;

--- a/tests/ui/settings-households.spec.ts
+++ b/tests/ui/settings-households.spec.ts
@@ -1,0 +1,262 @@
+import { expect, test } from '@playwright/test';
+
+const householdStub = `(() => {
+  const households = [
+    {
+      id: '0',
+      name: 'Default household',
+      is_default: 1,
+      tz: null,
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      deleted_at: null,
+      color: '#2563EB',
+    },
+  ];
+  let activeId = '0';
+  let counter = 1;
+  const listeners = new Map();
+
+  const emitEvent = (event, payload) => {
+    const bucket = listeners.get(event);
+    if (!bucket) return;
+    for (const handler of bucket.values()) {
+      try {
+        handler({ event, payload });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  };
+
+  window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+    unregisterListener(event, id) {
+      const bucket = listeners.get(event);
+      if (!bucket) return;
+      bucket.delete(id);
+      if (bucket.size === 0) listeners.delete(event);
+    },
+  };
+
+  window.__TAURI_INTERNALS__ = {
+    transformCallback(callback) {
+      return callback;
+    },
+    convertFileSrc(path) {
+      return path;
+    },
+    invoke(cmd, args = {}) {
+      switch (cmd) {
+        case 'plugin:event|listen': {
+          const handler = args.handler;
+          const id = 'listener_' + Math.random().toString(16).slice(2);
+          const bucket = listeners.get(args.event) ?? new Map();
+          bucket.set(id, handler);
+          listeners.set(args.event, bucket);
+          return Promise.resolve(id);
+        }
+        case 'plugin:event|unlisten': {
+          const { event, eventId } = args;
+          window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener(event, eventId);
+          return Promise.resolve();
+        }
+        case 'household_list': {
+          const includeDeleted = Boolean(args?.includeDeleted);
+          const filtered = includeDeleted
+            ? households
+            : households.filter((item) => item.deleted_at === null);
+          return Promise.resolve(filtered.map((item) => ({ ...item })));
+        }
+        case 'household_get_active':
+          return Promise.resolve(activeId);
+        case 'household_set_active': {
+          const id = args?.id;
+          const target = households.find((item) => item.id === id);
+          if (!target) {
+            return Promise.reject({ code: 'HOUSEHOLD_NOT_FOUND' });
+          }
+          if (target.deleted_at !== null) {
+            return Promise.reject({ code: 'HOUSEHOLD_DELETED' });
+          }
+          if (id === activeId) {
+            return Promise.reject({ code: 'HOUSEHOLD_ALREADY_ACTIVE' });
+          }
+          activeId = id;
+          emitEvent('household:changed', { id });
+          return Promise.resolve(null);
+        }
+        case 'household_create': {
+          const id = 'hh-' + counter++;
+          const record = {
+            id,
+            name: args?.name ?? id,
+            is_default: 0,
+            tz: null,
+            created_at: Date.now(),
+            updated_at: Date.now(),
+            deleted_at: null,
+            color: args?.color ?? null,
+          };
+          households.push(record);
+          return Promise.resolve({ ...record });
+        }
+        case 'household_update': {
+          const id = args?.id;
+          const target = households.find((item) => item.id === id);
+          if (!target) {
+            return Promise.reject({ code: 'HOUSEHOLD_NOT_FOUND' });
+          }
+          if (target.deleted_at !== null) {
+            return Promise.reject({ code: 'HOUSEHOLD_DELETED' });
+          }
+          if (typeof args?.name === 'string') {
+            target.name = args.name;
+          }
+          if ('color' in args) {
+            target.color = args.color ?? null;
+          }
+          target.updated_at = Date.now();
+          return Promise.resolve({ ...target });
+        }
+        case 'household_delete': {
+          const id = args?.id;
+          const target = households.find((item) => item.id === id);
+          if (!target) {
+            return Promise.reject({ code: 'HOUSEHOLD_NOT_FOUND' });
+          }
+          if (target.is_default) {
+            return Promise.reject({ code: 'DEFAULT_UNDELETABLE' });
+          }
+          if (target.deleted_at !== null) {
+            return Promise.reject({ code: 'HOUSEHOLD_DELETED' });
+          }
+          target.deleted_at = Date.now();
+          target.updated_at = target.deleted_at;
+          let fallbackId = null;
+          if (activeId === id) {
+            fallbackId = '0';
+            activeId = fallbackId;
+            emitEvent('household:changed', { id: fallbackId });
+          }
+          return Promise.resolve({ fallbackId });
+        }
+        case 'household_restore': {
+          const id = args?.id;
+          const target = households.find((item) => item.id === id);
+          if (!target) {
+            return Promise.reject({ code: 'HOUSEHOLD_NOT_FOUND' });
+          }
+          target.deleted_at = null;
+          target.updated_at = Date.now();
+          return Promise.resolve({ ...target });
+        }
+        default:
+          return Promise.resolve(null);
+      }
+    },
+  };
+
+  const stubWindow = {
+    label: 'main',
+    close: () => Promise.resolve(),
+    minimize: () => Promise.resolve(),
+    maximize: () => Promise.resolve(),
+    unmaximize: () => Promise.resolve(),
+    isMaximized: () => Promise.resolve(false),
+    isDecorated: () => Promise.resolve(false),
+    show: () => Promise.resolve(),
+    hide: () => Promise.resolve(),
+    setFocus: () => Promise.resolve(),
+  };
+
+  window.__TAURI_INTERNALS__.currentWindow = stubWindow;
+  window.__TAURI_INTERNALS__.getCurrentWindow = () => stubWindow;
+  window.__TAURI_INTERNALS__.metadata = {
+    currentWindow: { label: 'main' },
+    currentWebview: { windowLabel: 'main', label: 'main' },
+  };
+})();`;
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(householdStub);
+});
+
+test.describe('Settings households lifecycle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#/settings');
+    await expect(page.getByRole('button', { name: 'Create household' })).toBeVisible();
+  });
+
+  test('create, rename, delete, and restore a household', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create household' }).click();
+    await page.getByPlaceholder('Household name').fill('Secondary household');
+    await page.locator('.settings__household-color').nth(1).click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    const row = page
+      .locator('.settings__household-row')
+      .filter({ hasText: 'Secondary household' });
+    const rowId = await row.first().getAttribute('data-household-id');
+    expect(rowId).toBeTruthy();
+    await expect(row).toBeVisible();
+
+    await row.getByRole('button', { name: 'Rename' }).click();
+    await row.locator('.settings__household-edit .settings__household-input').fill('Guest suite');
+    await row.getByRole('button', { name: 'Save' }).click();
+    const renamedRow = page.locator(
+      `.settings__household-row[data-household-id="${rowId}"]`,
+    );
+    await expect(renamedRow).toContainText('Guest suite');
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await renamedRow.getByRole('button', { name: 'Delete' }).click();
+
+    await page.locator('[data-ui="switch"]').click();
+    const deletedRow = page
+      .locator('.settings__household-deleted .settings__household-row')
+      .filter({ hasText: 'Guest suite' });
+    await expect(deletedRow).toBeVisible();
+    await expect(deletedRow.locator('.settings__household-badge--deleted')).toBeVisible();
+
+    await deletedRow.getByRole('button', { name: 'Restore' }).click();
+    await expect(
+      page
+        .locator('.settings__household-list .settings__household-row')
+        .filter({ hasText: 'Guest suite' }),
+    ).toBeVisible();
+  });
+
+  test('deleting the active household falls back to default', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create household' }).click();
+    await page.getByPlaceholder('Household name').fill('Temporary');
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    const tempRow = page
+      .locator('.settings__household-row')
+      .filter({ hasText: 'Temporary' });
+    await tempRow.getByRole('button', { name: 'Set active' }).click();
+    await expect(tempRow.locator('.settings__household-badge--active')).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await tempRow.getByRole('button', { name: 'Delete' }).click();
+
+    const defaultRow = page
+      .locator('.settings__household-row')
+      .filter({ hasText: 'Default household' });
+    await expect(defaultRow.locator('.settings__household-badge--active')).toBeVisible();
+  });
+
+  test('deleting the default household surfaces an error toast', async ({ page }) => {
+    const defaultRow = page
+      .locator('.settings__household-row')
+      .filter({ hasText: 'Default household' });
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await defaultRow.getByRole('button', { name: 'Delete' }).click();
+
+    const errorToast = page
+      .locator('#ui-toast-region .toast')
+      .filter({ hasText: 'The default household cannot be deleted.' });
+    await expect(errorToast).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- hoist the household store listener mock to avoid referencing the real Tauri API during Vitest runs and ensure mocked CRUD helpers are reset between tests
- add a Playwright e2e spec with a lightweight Tauri IPC stub covering create, rename, delete, and restore flows for households, and guard the settings UI against missing metadata
- fix a naming collision in the settings household switcher to prevent runtime errors and support the new tests
- update the household switcher error handling to use explicit code branches and drop the unused store import so ESLint passes with the security rules
- ensure the household lifecycle smoke script installs Playwright browsers in CI before launching the UI tests

## Testing
- npm run lint
- npm run typecheck
- npx vitest run src/state/householdStore.spec.ts
- npx playwright test tests/ui/settings-households.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68dfcdecb220832ab52a3faf508ac3d7