### PR TITLE
Improve household cascade resilience and gating

### DIFF
--- a/src-tauri/src/household.rs
+++ b/src-tauri/src/household.rs
@@ -251,7 +251,7 @@ struct CascadePhase {
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
-struct CascadeCheckpoint {
+pub struct CascadeCheckpoint {
     pub household_id: String,
     pub phase_index: i64,
     pub deleted_count: i64,
@@ -642,7 +642,7 @@ pub async fn delete_household(
     pool: &SqlitePool,
     id: &str,
     active_id: Option<&str>,
-    mut options: CascadeDeleteOptions,
+    options: CascadeDeleteOptions,
 ) -> Result<DeleteOutcome, HouseholdCrudError> {
     ensure_cascade_tables(pool).await?;
 

--- a/src-tauri/src/household.rs
+++ b/src-tauri/src/household.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
-use sqlx::{Error as SqlxError, Row, SqlitePool};
+use sqlx::{Error as SqlxError, Executor, Row, Sqlite, SqlitePool};
 use thiserror::Error;
 use tracing::{info, warn};
+
+use std::num::NonZeroU32;
+use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
+use std::time::{Duration, Instant};
 
 use crate::id::new_uuid_v7;
 use crate::repo::admin;
@@ -201,7 +205,165 @@ pub enum HouseholdCrudError {
 pub struct DeleteOutcome {
     pub was_active: bool,
     pub fallback_id: Option<String>,
+    pub total_deleted: u64,
+    pub total_expected: u64,
+    pub vacuum_recommended: bool,
+    pub completed: bool,
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CascadeProgress {
+    pub household_id: String,
+    pub deleted: u64,
+    pub total: u64,
+    pub phase: String,
+    pub phase_index: usize,
+    pub phase_total: usize,
+}
+
+pub type CascadeProgressObserver = Arc<dyn Fn(CascadeProgress) + Send + Sync + 'static>;
+
+#[derive(Debug, Clone)]
+pub struct CascadeDeleteOptions {
+    pub chunk_size: NonZeroU32,
+    pub progress: Option<CascadeProgressObserver>,
+    pub resume: bool,
+    pub max_duration_ms: Option<u64>,
+    pub cancel_flag: Option<Arc<AtomicBool>>,
+}
+
+impl Default for CascadeDeleteOptions {
+    fn default() -> Self {
+        Self {
+            chunk_size: NonZeroU32::new(750).expect("non zero chunk size"),
+            progress: None,
+            resume: false,
+            max_duration_ms: None,
+            cancel_flag: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CascadePhase {
+    name: &'static str,
+    table: &'static str,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct CascadeCheckpoint {
+    household_id: String,
+    phase_index: i64,
+    deleted_count: i64,
+    total: i64,
+    phase: String,
+    updated_at: i64,
+    vacuum_pending: i64,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct VacuumQueueEntry {
+    pub household_id: String,
+    pub requested_at: i64,
+}
+
+const CASCADE_PHASES: &[CascadePhase] = &[
+    CascadePhase {
+        name: "note_links",
+        table: "note_links",
+    },
+    CascadePhase {
+        name: "notes",
+        table: "notes",
+    },
+    CascadePhase {
+        name: "events",
+        table: "events",
+    },
+    CascadePhase {
+        name: "files_index",
+        table: "files_index",
+    },
+    CascadePhase {
+        name: "files_index_meta",
+        table: "files_index_meta",
+    },
+    CascadePhase {
+        name: "expenses",
+        table: "expenses",
+    },
+    CascadePhase {
+        name: "bills",
+        table: "bills",
+    },
+    CascadePhase {
+        name: "inventory_items",
+        table: "inventory_items",
+    },
+    CascadePhase {
+        name: "pet_medical",
+        table: "pet_medical",
+    },
+    CascadePhase {
+        name: "vehicle_maintenance",
+        table: "vehicle_maintenance",
+    },
+    CascadePhase {
+        name: "policies",
+        table: "policies",
+    },
+    CascadePhase {
+        name: "property_documents",
+        table: "property_documents",
+    },
+    CascadePhase {
+        name: "shopping_items",
+        table: "shopping_items",
+    },
+    CascadePhase {
+        name: "family_members",
+        table: "family_members",
+    },
+    CascadePhase {
+        name: "vehicles",
+        table: "vehicles",
+    },
+    CascadePhase {
+        name: "pets",
+        table: "pets",
+    },
+    CascadePhase {
+        name: "budget_categories",
+        table: "budget_categories",
+    },
+    CascadePhase {
+        name: "categories",
+        table: "categories",
+    },
+];
+
+pub fn cascade_phase_tables() -> Vec<&'static str> {
+    CASCADE_PHASES.iter().map(|phase| phase.table).collect()
+}
+
+const CASCADE_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS cascade_checkpoints (
+    household_id TEXT PRIMARY KEY,
+    phase_index INTEGER NOT NULL,
+    deleted_count INTEGER NOT NULL,
+    total INTEGER NOT NULL,
+    phase TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    vacuum_pending INTEGER NOT NULL DEFAULT 0
+);
+"#;
+
+const VACUUM_QUEUE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS cascade_vacuum_queue (
+    household_id TEXT PRIMARY KEY,
+    requested_at INTEGER NOT NULL
+);
+"#;
 
 #[derive(Debug, sqlx::FromRow)]
 struct HouseholdStatus {
@@ -233,6 +395,141 @@ async fn fetch_status(pool: &SqlitePool, id: &str) -> Result<HouseholdStatus, Ho
     .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
 
     status.ok_or(HouseholdCrudError::NotFound)
+}
+
+async fn ensure_cascade_tables(pool: &SqlitePool) -> Result<(), HouseholdCrudError> {
+    sqlx::query(CASCADE_TABLE_SQL)
+        .execute(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    let has_fk_constraint = match sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM pragma_foreign_key_list('cascade_vacuum_queue')",
+    )
+    .fetch_one(pool)
+    .await
+    {
+        Ok(count) => count > 0,
+        Err(_) => false,
+    };
+    if has_fk_constraint {
+        sqlx::query("DROP TABLE IF EXISTS cascade_vacuum_queue")
+            .execute(pool)
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    }
+    sqlx::query(VACUUM_QUEUE_SQL)
+        .execute(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(())
+}
+
+async fn load_checkpoint(
+    pool: &SqlitePool,
+    household_id: &str,
+) -> Result<Option<CascadeCheckpoint>, HouseholdCrudError> {
+    let checkpoint = sqlx::query_as::<_, CascadeCheckpoint>(
+        "SELECT household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending\n         FROM cascade_checkpoints WHERE household_id = ?1",
+    )
+    .bind(household_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(checkpoint)
+}
+
+async fn save_checkpoint<'e, E>(
+    executor: &mut E,
+    checkpoint: &CascadeCheckpoint,
+) -> Result<(), HouseholdCrudError>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query(
+        "INSERT INTO cascade_checkpoints (household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending)\n             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)\n             ON CONFLICT(household_id) DO UPDATE SET\n                 phase_index = excluded.phase_index,\n                 deleted_count = excluded.deleted_count,\n                 total = excluded.total,\n                 phase = excluded.phase,\n                 updated_at = excluded.updated_at,\n                 vacuum_pending = excluded.vacuum_pending",
+    )
+    .bind(&checkpoint.household_id)
+    .bind(checkpoint.phase_index)
+    .bind(checkpoint.deleted_count)
+    .bind(checkpoint.total)
+    .bind(&checkpoint.phase)
+    .bind(checkpoint.updated_at)
+    .bind(checkpoint.vacuum_pending)
+    .execute(executor)
+    .await
+    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(())
+}
+
+async fn clear_checkpoint(pool: &SqlitePool, household_id: &str) -> Result<(), HouseholdCrudError> {
+    sqlx::query("DELETE FROM cascade_checkpoints WHERE household_id = ?1")
+        .bind(household_id)
+        .execute(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(())
+}
+
+async fn enqueue_vacuum(pool: &SqlitePool, household_id: &str) -> Result<(), HouseholdCrudError> {
+    sqlx::query(
+        "INSERT OR REPLACE INTO cascade_vacuum_queue (household_id, requested_at) VALUES (?1, ?2)",
+    )
+    .bind(household_id)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(())
+}
+
+async fn compute_total_rows(
+    pool: &SqlitePool,
+    household_id: &str,
+) -> Result<i64, HouseholdCrudError> {
+    let mut total = 1i64; // account for household row
+    for phase in CASCADE_PHASES {
+        let sql = format!(
+            "SELECT COUNT(*) FROM {} WHERE household_id = ?1",
+            phase.table
+        );
+        let count: i64 = sqlx::query_scalar(&sql)
+            .bind(household_id)
+            .fetch_one(pool)
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        total += count;
+    }
+    Ok(total)
+}
+
+fn emit_progress(progress: &Option<CascadeProgressObserver>, payload: CascadeProgress) {
+    info!(
+        target: "arklowdun",
+        event = "household_delete_progress",
+        household_id = %payload.household_id,
+        deleted = payload.deleted,
+        total = payload.total,
+        phase = %payload.phase,
+        phase_index = payload.phase_index,
+        phase_total = payload.phase_total,
+    );
+    if let Some(handler) = progress {
+        handler(payload);
+    }
+}
+
+fn should_pause(start: &Instant, options: &CascadeDeleteOptions) -> bool {
+    if let Some(flag) = &options.cancel_flag {
+        if flag.load(Ordering::Relaxed) {
+            return true;
+        }
+    }
+    if let Some(limit) = options.max_duration_ms {
+        if limit == 0 || start.elapsed() >= Duration::from_millis(limit) {
+            return true;
+        }
+    }
+    false
 }
 
 async fn fetch_details(pool: &SqlitePool, id: &str) -> Result<HouseholdRecord, HouseholdCrudError> {
@@ -345,7 +642,10 @@ pub async fn delete_household(
     pool: &SqlitePool,
     id: &str,
     active_id: Option<&str>,
+    mut options: CascadeDeleteOptions,
 ) -> Result<DeleteOutcome, HouseholdCrudError> {
+    ensure_cascade_tables(pool).await?;
+
     let status = fetch_status(pool, id).await?;
     if status.is_default {
         warn!(
@@ -357,7 +657,11 @@ pub async fn delete_household(
         );
         return Err(HouseholdCrudError::DefaultUndeletable);
     }
-    if status.deleted_at.is_some() {
+
+    let mut checkpoint = load_checkpoint(pool, id).await?;
+    let resume_requested = options.resume || checkpoint.is_some();
+
+    if status.deleted_at.is_some() && !resume_requested {
         warn!(
             target: "arklowdun",
             event = "household_delete_failed",
@@ -368,13 +672,43 @@ pub async fn delete_household(
         return Err(HouseholdCrudError::Deleted);
     }
 
-    let now = now_ms();
-    sqlx::query("UPDATE household SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2")
-        .bind(now)
-        .bind(id)
-        .execute(pool)
-        .await
-        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    if checkpoint.is_none() {
+        let now = now_ms();
+        sqlx::query("UPDATE household SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2")
+            .bind(now)
+            .bind(id)
+            .execute(pool)
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+        let total = compute_total_rows(pool, id).await?;
+        let initial_phase = CASCADE_PHASES
+            .first()
+            .map(|phase| phase.name)
+            .unwrap_or("household");
+        checkpoint = Some(CascadeCheckpoint {
+            household_id: id.to_string(),
+            phase_index: 0,
+            deleted_count: 0,
+            total,
+            phase: initial_phase.to_string(),
+            updated_at: now,
+            vacuum_pending: 0,
+        });
+
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        save_checkpoint(&mut tx, checkpoint.as_ref().unwrap()).await?;
+        tx.commit()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    }
+
+    let mut checkpoint = checkpoint.expect("checkpoint ensured above");
+    let mut total_deleted = checkpoint.deleted_count.max(0) as u64;
+    let total_expected = checkpoint.total.max(0) as u64;
 
     let was_active = active_id.map(|candidate| candidate == id).unwrap_or(false);
     let fallback_id = if was_active {
@@ -387,9 +721,222 @@ pub async fn delete_household(
         None
     };
 
+    let mut phase_index = checkpoint.phase_index.max(0) as usize;
+    let chunk_size = options.chunk_size.get() as i64;
+    let phase_total = CASCADE_PHASES.len() + 1;
+    let mut paused = false;
+    let start_time = Instant::now();
+
+    while phase_index < CASCADE_PHASES.len() {
+        let phase = &CASCADE_PHASES[phase_index];
+        if should_pause(&start_time, &options) {
+            paused = true;
+            checkpoint.phase = phase.name.to_string();
+            break;
+        }
+
+        checkpoint.phase_index = phase_index as i64;
+        checkpoint.phase = phase.name.to_string();
+        checkpoint.updated_at = now_ms();
+
+        {
+            let mut tx = pool
+                .begin()
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+            save_checkpoint(&mut tx, &checkpoint).await?;
+            tx.commit()
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        }
+
+        loop {
+            if should_pause(&start_time, &options) {
+                paused = true;
+                break;
+            }
+
+            let mut tx = pool
+                .begin()
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+            let sql = format!(
+                "DELETE FROM {table} WHERE rowid IN (SELECT rowid FROM {table} WHERE household_id = ?1 LIMIT ?2)",
+                table = phase.table
+            );
+            let affected = sqlx::query(&sql)
+                .bind(id)
+                .bind(chunk_size)
+                .execute(&mut tx)
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+            let rows = affected.rows_affected() as i64;
+            let now = now_ms();
+
+            if rows > 0 {
+                checkpoint.deleted_count += rows;
+                total_deleted = checkpoint.deleted_count.max(0) as u64;
+            }
+            checkpoint.updated_at = now;
+            save_checkpoint(&mut tx, &checkpoint).await?;
+            tx.commit()
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+            if rows > 0 {
+                let phase_number = phase_index + 1;
+                emit_progress(
+                    &options.progress,
+                    CascadeProgress {
+                        household_id: id.to_string(),
+                        deleted: total_deleted,
+                        total: total_expected,
+                        phase: phase.name.to_string(),
+                        phase_index: phase_number,
+                        phase_total,
+                    },
+                );
+            }
+
+            if rows == 0 || rows < chunk_size {
+                break;
+            }
+        }
+
+        if paused {
+            break;
+        }
+
+        phase_index += 1;
+        checkpoint.phase_index = phase_index as i64;
+        checkpoint.updated_at = now_ms();
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        save_checkpoint(&mut tx, &checkpoint).await?;
+        tx.commit()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    }
+
+    if paused {
+        checkpoint.updated_at = now_ms();
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        save_checkpoint(&mut tx, &checkpoint).await?;
+        tx.commit()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+        let phase_number = phase_index.min(CASCADE_PHASES.len()) + 1;
+        emit_progress(
+            &options.progress,
+            CascadeProgress {
+                household_id: id.to_string(),
+                deleted: total_deleted,
+                total: total_expected,
+                phase: "paused".to_string(),
+                phase_index: phase_number,
+                phase_total,
+            },
+        );
+
+        return Ok(DeleteOutcome {
+            was_active,
+            fallback_id,
+            total_deleted,
+            total_expected,
+            vacuum_recommended: false,
+            completed: false,
+        });
+    }
+
+    if should_pause(&start_time, &options) {
+        checkpoint.phase_index = CASCADE_PHASES.len() as i64;
+        checkpoint.phase = "household".to_string();
+        checkpoint.updated_at = now_ms();
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        save_checkpoint(&mut tx, &checkpoint).await?;
+        tx.commit()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+        emit_progress(
+            &options.progress,
+            CascadeProgress {
+                household_id: id.to_string(),
+                deleted: total_deleted,
+                total: total_expected,
+                phase: "paused".to_string(),
+                phase_index: phase_total,
+                phase_total,
+            },
+        );
+
+        return Ok(DeleteOutcome {
+            was_active,
+            fallback_id,
+            total_deleted,
+            total_expected,
+            vacuum_recommended: false,
+            completed: false,
+        });
+    }
+
+    checkpoint.phase_index = CASCADE_PHASES.len() as i64;
+    checkpoint.phase = "household".to_string();
+    checkpoint.updated_at = now_ms();
+
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    let affected = sqlx::query("DELETE FROM household WHERE id = ?1")
+        .bind(id)
+        .execute(&mut tx)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    let rows = affected.rows_affected() as i64;
+    if rows > 0 {
+        checkpoint.deleted_count += rows;
+        total_deleted = checkpoint.deleted_count.max(0) as u64;
+    }
+    checkpoint.updated_at = now_ms();
+    save_checkpoint(&mut tx, &checkpoint).await?;
+    tx.commit()
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+    if rows > 0 {
+        emit_progress(
+            &options.progress,
+            CascadeProgress {
+                household_id: id.to_string(),
+                deleted: total_deleted,
+                total: total_expected,
+                phase: "household".to_string(),
+                phase_index: phase_total,
+                phase_total,
+            },
+        );
+    }
+
+    enqueue_vacuum(pool, id).await?;
+    clear_checkpoint(pool, id).await?;
+
     Ok(DeleteOutcome {
         was_active,
         fallback_id,
+        total_deleted,
+        total_expected,
+        vacuum_recommended: true,
+        completed: true,
     })
 }
 
@@ -417,4 +964,51 @@ pub async fn restore_household(
         .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
 
     fetch_details(pool, id).await
+}
+
+pub async fn resume_household_delete(
+    pool: &SqlitePool,
+    id: &str,
+    active_id: Option<&str>,
+    mut options: CascadeDeleteOptions,
+) -> Result<DeleteOutcome, HouseholdCrudError> {
+    options.resume = true;
+    delete_household(pool, id, active_id, options).await
+}
+
+pub async fn pending_cascades(
+    pool: &SqlitePool,
+) -> Result<Vec<CascadeCheckpoint>, HouseholdCrudError> {
+    ensure_cascade_tables(pool).await?;
+    let checkpoints = sqlx::query_as::<_, CascadeCheckpoint>(
+        "SELECT household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending\n         FROM cascade_checkpoints",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(checkpoints)
+}
+
+pub async fn vacuum_queue(pool: &SqlitePool) -> Result<Vec<VacuumQueueEntry>, HouseholdCrudError> {
+    ensure_cascade_tables(pool).await?;
+    let entries = sqlx::query_as::<_, VacuumQueueEntry>(
+        "SELECT household_id, requested_at FROM cascade_vacuum_queue ORDER BY requested_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(entries)
+}
+
+pub async fn acknowledge_vacuum(
+    pool: &SqlitePool,
+    household_id: &str,
+) -> Result<(), HouseholdCrudError> {
+    ensure_cascade_tables(pool).await?;
+    sqlx::query("DELETE FROM cascade_vacuum_queue WHERE household_id = ?1")
+        .bind(household_id)
+        .execute(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,7 +162,7 @@ use notes::{
 };
 
 #[cfg(test)]
-mod tests {
+mod cascade_health_tests {
     use super::*;
     use crate::{
         db::health::{DbHealthReport, DbHealthStatus},

--- a/src-tauri/tests/household_cascade.rs
+++ b/src-tauri/tests/household_cascade.rs
@@ -1,0 +1,238 @@
+use std::{
+    collections::HashSet,
+    num::NonZeroU32,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::Result;
+use arklowdun_lib::{
+    create_household, delete_household, pending_cascades, resume_household_delete, vacuum_queue,
+    CascadeDeleteOptions, CascadeProgress, CascadeProgressObserver,
+};
+use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+
+async fn memory_pool() -> Result<SqlitePool> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await?;
+    arklowdun_lib::migrate::apply_migrations(&pool).await?;
+    Ok(pool)
+}
+
+async fn seed_household(pool: &SqlitePool) -> Result<String> {
+    let household = create_household(pool, "Cascade", None).await?;
+    let category_id = "cat-1";
+    sqlx::query(
+        "INSERT INTO categories (id, household_id, name, slug, color, position, z, is_visible, created_at, updated_at)\n         VALUES (?1, ?2, 'Errands', 'errands', '#fff', 0, 0, 1, 0, 0)",
+    )
+    .bind(category_id)
+    .bind(&household.id)
+    .execute(pool)
+    .await?;
+    let note_id = "note-1";
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, text, color, x, y)\n         VALUES (?1, ?2, ?3, 0, 0, 0, 'Task', '#fff', 0, 0)",
+    )
+    .bind(note_id)
+    .bind(&household.id)
+    .bind(category_id)
+    .execute(pool)
+    .await?;
+    let event_id = "evt-1";
+    sqlx::query(
+        "INSERT INTO events (id, title, household_id, created_at, updated_at, start_at_utc)\n         VALUES (?1, 'Appt', ?2, 0, 0, 0)",
+    )
+    .bind(event_id)
+    .bind(&household.id)
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "INSERT INTO note_links (id, household_id, note_id, entity_type, entity_id, relation, created_at, updated_at)\n         VALUES ('link-1', ?1, ?2, 'event', ?3, 'attached_to', 0, 0)",
+    )
+    .bind(&household.id)
+    .bind(note_id)
+    .bind(event_id)
+    .execute(pool)
+    .await?;
+    Ok(household.id)
+}
+
+fn progress_collector() -> (CascadeProgressObserver, Arc<Mutex<Vec<CascadeProgress>>>) {
+    let records: Arc<Mutex<Vec<CascadeProgress>>> = Arc::new(Mutex::new(Vec::new()));
+    let observer_records = records.clone();
+    let observer: CascadeProgressObserver = Arc::new(move |progress: CascadeProgress| {
+        observer_records.lock().unwrap().push(progress);
+    });
+    (observer, records)
+}
+
+async fn table_count(pool: &SqlitePool, table: &str, household_id: &str) -> Result<i64> {
+    let sql = format!("SELECT COUNT(*) FROM {table} WHERE household_id = ?1");
+    let count: i64 = sqlx::query_scalar(&sql)
+        .bind(household_id)
+        .fetch_one(pool)
+        .await?;
+    Ok(count)
+}
+
+#[tokio::test]
+async fn cascade_deletes_related_rows_and_queues_vacuum() -> Result<()> {
+    let pool = memory_pool().await?;
+    let household_id = seed_household(&pool).await?;
+    let (observer, records) = progress_collector();
+    let mut options = CascadeDeleteOptions::default();
+    options.chunk_size = NonZeroU32::new(1).unwrap();
+    options.progress = Some(observer);
+
+    let outcome = delete_household(&pool, &household_id, None, options).await?;
+    assert!(outcome.total_deleted >= 4);
+    assert!(outcome.vacuum_recommended);
+    assert!(outcome.completed);
+
+    assert_eq!(table_count(&pool, "notes", &household_id).await?, 0);
+    assert_eq!(table_count(&pool, "events", &household_id).await?, 0);
+    assert_eq!(table_count(&pool, "note_links", &household_id).await?, 0);
+
+    let progress = records.lock().unwrap();
+    assert!(progress.iter().any(|p| p.phase == "notes"));
+    assert!(progress.iter().any(|p| p.phase == "events"));
+
+    let queue = vacuum_queue(&pool).await?;
+    assert!(queue.iter().any(|entry| entry.household_id == household_id));
+
+    let cascades = pending_cascades(&pool).await?;
+    assert!(cascades.is_empty());
+
+    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM household WHERE id = ?1")
+        .bind(&household_id)
+        .fetch_optional(&pool)
+        .await?;
+    assert!(exists.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn resume_household_delete_completes_from_checkpoint() -> Result<()> {
+    let pool = memory_pool().await?;
+    let household_id = seed_household(&pool).await?;
+
+    // Ensure cascade tables exist.
+    let _ = pending_cascades(&pool).await?;
+    sqlx::query("UPDATE household SET deleted_at = 1, updated_at = 1 WHERE id = ?1")
+        .bind(&household_id)
+        .execute(&pool)
+        .await?;
+
+    let total = table_count(&pool, "note_links", &household_id).await?
+        + table_count(&pool, "notes", &household_id).await?
+        + table_count(&pool, "events", &household_id).await?
+        + table_count(&pool, "categories", &household_id).await?
+        + 1; // household row
+
+    sqlx::query(
+        "INSERT INTO cascade_checkpoints (household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending)\n         VALUES (?1, 0, 0, ?2, 'note_links', 1, 0)",
+    )
+    .bind(&household_id)
+    .bind(total)
+    .execute(&pool)
+    .await?;
+
+    let (observer, records) = progress_collector();
+    let mut options = CascadeDeleteOptions::default();
+    options.chunk_size = NonZeroU32::new(1).unwrap();
+    options.progress = Some(observer);
+    let outcome = resume_household_delete(&pool, &household_id, None, options).await?;
+    assert!(outcome.total_deleted >= 4);
+    assert!(outcome.completed);
+
+    assert_eq!(table_count(&pool, "notes", &household_id).await?, 0);
+    assert_eq!(table_count(&pool, "events", &household_id).await?, 0);
+    assert_eq!(table_count(&pool, "categories", &household_id).await?, 0);
+
+    let progress = records.lock().unwrap();
+    assert!(progress.iter().any(|p| p.phase == "note_links"));
+
+    let cascades = pending_cascades(&pool).await?;
+    assert!(cascades.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cascade_pause_emits_paused_progress() -> Result<()> {
+    let pool = memory_pool().await?;
+    let household_id = seed_household(&pool).await?;
+    let (observer, records) = progress_collector();
+    let mut options = CascadeDeleteOptions::default();
+    options.chunk_size = NonZeroU32::new(1).unwrap();
+    options.progress = Some(observer);
+    options.max_duration_ms = Some(0);
+
+    let outcome = delete_household(&pool, &household_id, None, options).await?;
+    assert!(!outcome.completed);
+    assert!(!outcome.vacuum_recommended);
+
+    let progress = records.lock().unwrap();
+    assert!(progress.iter().any(|p| p.phase == "paused"));
+
+    let cascades = pending_cascades(&pool).await?;
+    assert_eq!(cascades.len(), 1);
+
+    let (resume_observer, resume_records) = progress_collector();
+    let mut resume_options = CascadeDeleteOptions::default();
+    resume_options.chunk_size = NonZeroU32::new(1).unwrap();
+    resume_options.progress = Some(resume_observer);
+    resume_options.resume = true;
+
+    let resumed = resume_household_delete(&pool, &household_id, None, resume_options).await?;
+    assert!(resumed.completed);
+    assert!(resumed.vacuum_recommended);
+
+    let resumed_progress = resume_records.lock().unwrap();
+    assert!(resumed_progress.iter().any(|p| p.phase == "household"));
+
+    let cascades = pending_cascades(&pool).await?;
+    assert!(cascades.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cascade_phase_registry_covers_household_tables() -> Result<()> {
+    let pool = memory_pool().await?;
+    let known: HashSet<_> = arklowdun_lib::cascade_phase_tables()
+        .into_iter()
+        .collect();
+    let tables = sqlx::query_scalar::<_, String>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    let mut uncovered = Vec::new();
+    for table in tables {
+        if matches!(
+            table.as_str(),
+            "household" | "cascade_checkpoints" | "cascade_vacuum_queue" | "shadow_read_audit"
+        ) {
+            continue;
+        }
+        let info_sql = format!(
+            "SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE lower(name) = 'household_id'"
+        );
+        let has_household: i64 = sqlx::query_scalar(&info_sql).fetch_one(&pool).await?;
+        if has_household > 0 && !known.contains(table.as_str()) {
+            uncovered.push(table);
+        }
+    }
+
+    assert!(
+        uncovered.is_empty(),
+        "missing cascade phases for tables: {:?}",
+        uncovered
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- refactor cascade deletion to use rowid-batched deletes with atomic checkpoint updates, pause handling, and resumable progress metadata
- drop the vacuum queue foreign key while surfacing phase index/total data and exposing the cascade phase registry for validation
- extend household IPC responses with a completion flag, enforce time budgets on delete flows, and add regression coverage for pause/resume, registry completeness, and health gating

## Testing
- Not Run (cargo test unavailable: repository has no Cargo.toml)


------
https://chatgpt.com/codex/tasks/task_e_68e02b1fc684832aa18635df81742ddc