### PR TITLE
Add household scope regression tests and tighten CLI guard

### DIFF
--- a/docs/support-playbook.md
+++ b/docs/support-playbook.md
@@ -1,0 +1,50 @@
+# Support Playbook
+
+## Household inventory snapshot
+
+Use the household inventory snapshot to confirm that data isolation rules are
+holding and to verify row counts before and after repair work.
+
+### IPC / App layer
+
+Developers and support engineers can call the `diagnostics_household_stats`
+command through the IPC bridge. The TypeScript helper returns normalised
+records:
+
+```ts
+import { fetchHouseholdStats } from "api/diagnostics";
+
+const stats = await fetchHouseholdStats();
+```
+
+Each entry includes the household identifier, display name, whether it is the
+current default, and a map of entity counts across notes, files, events, and
+other supported domains.
+
+### CLI
+
+To inspect the same data from the command line, run the dedicated Tauri CLI
+command:
+
+```bash
+npm run --silent tauri -- diagnostics household-stats
+```
+
+Pass `--json` to emit a machine-readable document:
+
+```bash
+npm run --silent tauri -- diagnostics household-stats -- --json
+```
+
+The CLI validates database health before executing and prints a table that
+highlights per-household totals.
+
+### Helper scripts
+
+For quick access, use the bundled wrapper scripts:
+
+- **macOS/Linux:** `scripts/guards/household_stats.sh` (pass `--json` for JSON)
+- **Windows:** `scripts/guards/household_stats.ps1 -Json`
+
+Both scripts call the CLI command above, ensure the output is non-empty, and
+bubble up the exit status if the inspection fails.

--- a/scripts/guards/household_stats.ps1
+++ b/scripts/guards/household_stats.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($Help.IsPresent) {
+    Write-Output @'
+Usage: scripts/guards/household_stats.ps1 [--Json]
+
+Options:
+  --Json   Emit JSON instead of the formatted table.
+  --Help   Show this help message.
+'@
+    return
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    Write-Error 'npm is required to run the Tauri CLI.'
+    exit 2
+}
+
+$repoRoot = (& git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+$args = @('run', '--silent', 'tauri', '--', 'diagnostics', 'household-stats')
+if ($Json.IsPresent) {
+    $args += '--json'
+}
+
+$process = Start-Process -FilePath 'npm' -ArgumentList $args -NoNewWindow -RedirectStandardOutput Pipe -RedirectStandardError Pipe -PassThru
+$output = $process.StandardOutput.ReadToEnd()
+$stderr = $process.StandardError.ReadToEnd()
+$process.WaitForExit()
+
+if ($process.ExitCode -ne 0) {
+    if (-not [string]::IsNullOrWhiteSpace($stderr)) {
+        Write-Error ($stderr.Trim())
+    }
+    exit $process.ExitCode
+}
+
+if ([string]::IsNullOrWhiteSpace($output)) {
+    Write-Error 'No household stats were returned.'
+    exit 1
+}
+
+$output.TrimEnd() | Write-Output

--- a/scripts/guards/household_stats.sh
+++ b/scripts/guards/household_stats.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_usage() {
+  cat <<'USAGE'
+Usage: scripts/guards/household_stats.sh [--json]
+
+Options:
+  --json    Emit JSON instead of the formatted table.
+  --help    Show this help message.
+USAGE
+}
+
+want_json=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      want_json=1
+      shift
+      ;;
+    --help|-h)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to run the Tauri CLI." >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+args=(tauri -- diagnostics household-stats)
+if [[ $want_json -eq 1 ]]; then
+  args+=(--json)
+fi
+
+if ! output=$(npm run --silent "${args[@]}"); then
+  echo "Failed to execute household stats command." >&2
+  exit 1
+fi
+
+if [[ -z "${output//[[:space:]]/}" ]]; then
+  echo "No household stats were returned." >&2
+  exit 1
+fi
+
+printf '%s\n' "$output"

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::{collections::BTreeMap, env, fs, path::PathBuf};
 
@@ -28,7 +28,7 @@ pub struct AboutInfo {
     pub commit_hash: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HouseholdStatsEntry {
     pub id: String,

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
-use std::{env, fs, path::PathBuf};
+use sqlx::SqlitePool;
+use std::{collections::BTreeMap, env, fs, path::PathBuf};
 
 use crate::{git_commit_hash, resolve_logs_dir, AppError, AppResult, LOG_FILE_NAME};
 use tauri::Manager;
@@ -25,6 +26,57 @@ pub struct Summary {
 pub struct AboutInfo {
     pub app_version: String,
     pub commit_hash: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HouseholdStatsEntry {
+    pub id: String,
+    pub name: String,
+    pub is_default: bool,
+    pub counts: BTreeMap<String, u64>,
+}
+
+struct CountSpec {
+    table: &'static str,
+    alias: &'static str,
+    filter_deleted: bool,
+}
+
+macro_rules! household_count_specs {
+    ($($table:literal => $alias:literal => $filter_deleted:expr),+ $(,)?) => {
+        const COUNT_SPECS: &[CountSpec] = &[
+            $(CountSpec {
+                table: $table,
+                alias: $alias,
+                filter_deleted: $filter_deleted,
+            }),+
+        ];
+
+        pub const HOUSEHOLD_STATS_ALIASES: &[&str] = &[
+            $($alias),+
+        ];
+    };
+}
+
+household_count_specs! {
+    "notes" => "notes" => true,
+    "events" => "events" => true,
+    "files_index" => "files" => false,
+    "bills" => "bills" => true,
+    "policies" => "policies" => true,
+    "property_documents" => "propertyDocuments" => true,
+    "inventory_items" => "inventoryItems" => true,
+    "vehicles" => "vehicles" => true,
+    "vehicle_maintenance" => "vehicleMaintenance" => true,
+    "pets" => "pets" => true,
+    "pet_medical" => "petMedical" => true,
+    "family_members" => "familyMembers" => true,
+    "categories" => "categories" => true,
+    "budget_categories" => "budgetCategories" => true,
+    "expenses" => "expenses" => true,
+    "shopping_items" => "shoppingItems" => true,
+    "note_links" => "noteLinks" => false,
 }
 
 #[allow(clippy::result_large_err)]
@@ -98,6 +150,79 @@ pub fn about_info<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> AboutInfo {
         app_version: app.package_info().version.to_string(),
         commit_hash: git_commit_hash().to_string(),
     }
+}
+
+#[derive(sqlx::FromRow)]
+struct HouseholdRow {
+    id: String,
+    name: String,
+    is_default: i64,
+}
+
+#[allow(clippy::result_large_err)]
+pub async fn household_stats(pool: &SqlitePool) -> AppResult<Vec<HouseholdStatsEntry>> {
+    let households = sqlx::query_as::<_, HouseholdRow>(
+        "SELECT id, name, is_default FROM household ORDER BY name COLLATE NOCASE, id",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(AppError::from)?;
+
+    let mut stats: Vec<HouseholdStatsEntry> = households
+        .into_iter()
+        .map(|row| {
+            let mut counts = BTreeMap::new();
+            for spec in COUNT_SPECS {
+                counts.insert(spec.alias.to_string(), 0);
+            }
+            HouseholdStatsEntry {
+                id: row.id,
+                name: row.name,
+                is_default: row.is_default != 0,
+                counts,
+            }
+        })
+        .collect();
+
+    if stats.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut index_by_id = std::collections::HashMap::new();
+    for (idx, entry) in stats.iter().enumerate() {
+        index_by_id.insert(entry.id.clone(), idx);
+    }
+
+    for spec in COUNT_SPECS {
+        let sql = if spec.filter_deleted {
+            format!(
+                "SELECT household_id, COUNT(*) as count FROM {} WHERE deleted_at IS NULL GROUP BY household_id",
+                spec.table
+            )
+        } else {
+            format!(
+                "SELECT household_id, COUNT(*) as count FROM {} GROUP BY household_id",
+                spec.table
+            )
+        };
+
+        let rows = sqlx::query_as::<_, (String, i64)>(&sql)
+            .fetch_all(pool)
+            .await
+            .map_err(AppError::from)?;
+
+        for (household_id, count) in rows {
+            if let Some(index) = index_by_id.get(&household_id) {
+                if let Some(entry) = stats.get_mut(*index) {
+                    entry
+                        .counts
+                        .insert(spec.alias.to_string(), count.max(0) as u64);
+                }
+            }
+        }
+    }
+
+    Ok(stats)
 }
 
 #[allow(clippy::result_large_err)]

--- a/src-tauri/src/household.rs
+++ b/src-tauri/src/household.rs
@@ -4,7 +4,10 @@ use thiserror::Error;
 use tracing::{info, warn};
 
 use std::num::NonZeroU32;
-use std::sync::{atomic::{AtomicBool, Ordering}, Arc};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::{Duration, Instant};
 
 use crate::id::new_uuid_v7;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,7 +110,7 @@ mod attachments;
 mod categories;
 pub mod commands;
 pub mod db;
-mod diagnostics;
+pub mod diagnostics;
 pub mod error;
 pub mod events_tz_backfill;
 pub mod exdate;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1325,6 +1325,7 @@ async fn household_update(
     let _permit = guard::ensure_db_writable(&state)?;
     let pool = state.pool_clone();
     let id = args.id;
+    let id_for_log = id.clone();
     let name = args.name;
     let color = args.color;
     let result = dispatch_async_app_result(move || {
@@ -1360,7 +1361,7 @@ async fn household_update(
             tracing::warn!(
                 target: "arklowdun",
                 event = "household_update",
-                household_id = %id,
+                household_id = %id_for_log,
                 result = "error",
                 error_code = %err.code()
             );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,9 +121,8 @@ pub use household::{
     acknowledge_vacuum, assert_household_active, cascade_phase_tables, create_household,
     default_household_id, delete_household, ensure_household_invariants, get_household,
     list_households, pending_cascades, restore_household, resume_household_delete,
-    update_household, vacuum_queue, CascadeDeleteOptions, CascadeProgress,
-    CascadeProgressObserver, DeleteOutcome, HouseholdCrudError, HouseholdGuardError,
-    HouseholdRecord, HouseholdUpdateInput,
+    update_household, vacuum_queue, CascadeDeleteOptions, CascadeProgress, CascadeProgressObserver,
+    DeleteOutcome, HouseholdCrudError, HouseholdGuardError, HouseholdRecord, HouseholdUpdateInput,
 };
 mod id;
 pub mod import;
@@ -1291,17 +1290,31 @@ async fn household_create(
                 .map_err(map_household_crud_error)
         }
     })
-    .await?;
+    .await;
 
-    tracing::info!(
-        target: "arklowdun",
-        event = "household_create",
-        id = %result.id,
-        name = %result.name,
-        color = result.color.as_deref().unwrap_or("")
-    );
-
-    Ok(result)
+    match result {
+        Ok(record) => {
+            tracing::info!(
+                target: "arklowdun",
+                event = "household_create",
+                household_id = %record.id,
+                result = "ok",
+                name = %record.name,
+                color = record.color.as_deref().unwrap_or("")
+            );
+            Ok(record)
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "arklowdun",
+                event = "household_create",
+                household_id = "",
+                result = "error",
+                error_code = %err.code()
+            );
+            Err(err)
+        }
+    }
 }
 
 #[tauri::command]
@@ -1329,17 +1342,31 @@ async fn household_update(
             .map_err(map_household_crud_error)
         }
     })
-    .await?;
+    .await;
 
-    tracing::info!(
-        target: "arklowdun",
-        event = "household_update",
-        id = %result.id,
-        name = %result.name,
-        color = result.color.as_deref().unwrap_or("")
-    );
-
-    Ok(result)
+    match result {
+        Ok(record) => {
+            tracing::info!(
+                target: "arklowdun",
+                event = "household_update",
+                household_id = %record.id,
+                result = "ok",
+                name = %record.name,
+                color = record.color.as_deref().unwrap_or("")
+            );
+            Ok(record)
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "arklowdun",
+                event = "household_update",
+                household_id = %id,
+                result = "error",
+                error_code = %err.code()
+            );
+            Err(err)
+        }
+    }
 }
 
 #[tauri::command]
@@ -1366,13 +1393,16 @@ async fn household_delete(
                     crate::household::HouseholdCrudError::Deleted => "already_deleted",
                     crate::household::HouseholdCrudError::Unexpected(_) => "unexpected",
                 };
+                let app_error = map_household_crud_error(err);
                 tracing::warn!(
                     target: "arklowdun",
-                    event = "household_delete_failed",
-                    id = %id,
-                    reason
+                    event = "household_delete",
+                    household_id = %id,
+                    result = "error",
+                    reason,
+                    error_code = %app_error.code()
                 );
-                return Err(map_household_crud_error(err));
+                return Err(app_error);
             }
         };
 
@@ -1386,13 +1416,16 @@ async fn household_delete(
                 tracing::info!(
                     target: "arklowdun",
                     event = "household_active_switched",
-                    reason = "delete_active_fallback",
-                    id = %fallback
+                    household_id = %fallback,
+                    result = "ok",
+                    reason = "delete_active_fallback"
                 );
                 if let Err(err) = app.emit("household:changed", json!({ "id": fallback.clone() })) {
                     tracing::warn!(
                         target: "arklowdun",
                         event = "household_event_emit_failed",
+                        household_id = %fallback,
+                        result = "error",
                         error = %err
                     );
                 }
@@ -1402,7 +1435,8 @@ async fn household_delete(
                     target: "arklowdun",
                     event = "household_active_switch_failed",
                     reason = "delete_active_fallback",
-                    id = %fallback,
+                    household_id = %fallback,
+                    result = "error",
                     error = ?err
                 );
             }
@@ -1413,7 +1447,8 @@ async fn household_delete(
         tracing::info!(
             target: "arklowdun",
             event = "household_delete",
-            id = %record.id,
+            household_id = %record.id,
+            result = "ok",
             name = %record.name,
             color = record.color.as_deref().unwrap_or(""),
             was_active = outcome.was_active,
@@ -1460,7 +1495,8 @@ async fn household_resume_delete(
                 tracing::warn!(
                     target: "arklowdun",
                     event = "household_resume_failed",
-                    id = %id,
+                    household_id = %id,
+                    result = "error",
                     reason
                 );
                 return Err(map_household_crud_error(err));
@@ -1477,13 +1513,16 @@ async fn household_resume_delete(
                 tracing::info!(
                     target: "arklowdun",
                     event = "household_active_switched",
-                    reason = "resume_delete_active_fallback",
-                    id = %fallback
+                    household_id = %fallback,
+                    result = "ok",
+                    reason = "resume_delete_active_fallback"
                 );
                 if let Err(err) = app.emit("household:changed", json!({ "id": fallback.clone() })) {
                     tracing::warn!(
                         target: "arklowdun",
                         event = "household_event_emit_failed",
+                        household_id = %fallback,
+                        result = "error",
                         error = %err
                     );
                 }
@@ -1493,7 +1532,8 @@ async fn household_resume_delete(
                     target: "arklowdun",
                     event = "household_active_switch_failed",
                     reason = "resume_delete_active_fallback",
-                    id = %fallback,
+                    household_id = %fallback,
+                    result = "error",
                     error = ?err
                 );
             }
@@ -1504,7 +1544,8 @@ async fn household_resume_delete(
         tracing::info!(
             target: "arklowdun",
             event = "household_delete_resume",
-            id = %record.id,
+            household_id = %record.id,
+            result = "ok",
             name = %record.name,
             color = record.color.as_deref().unwrap_or(""),
             was_active = outcome.was_active,
@@ -1537,7 +1578,8 @@ async fn household_repair(
         tracing::warn!(
             target: "arklowdun",
             event = "household_repair_fk_failed",
-            id = %id,
+            household_id = %id,
+            result = "error",
             offenders = fk_rows.len()
         );
         return Err(AppError::new(
@@ -1568,7 +1610,8 @@ async fn household_repair(
                 tracing::warn!(
                     target: "arklowdun",
                     event = "household_repair_failed",
-                    id = %id,
+                    household_id = %id,
+                    result = "error",
                     reason
                 );
                 return Err(map_household_crud_error(err));
@@ -1585,13 +1628,16 @@ async fn household_repair(
                 tracing::info!(
                     target: "arklowdun",
                     event = "household_active_switched",
-                    reason = "repair_delete_active_fallback",
-                    id = %fallback
+                    household_id = %fallback,
+                    result = "ok",
+                    reason = "repair_delete_active_fallback"
                 );
                 if let Err(err) = app.emit("household:changed", json!({ "id": fallback.clone() })) {
                     tracing::warn!(
                         target: "arklowdun",
                         event = "household_event_emit_failed",
+                        household_id = %fallback,
+                        result = "error",
                         error = %err
                     );
                 }
@@ -1601,7 +1647,8 @@ async fn household_repair(
                     target: "arklowdun",
                     event = "household_active_switch_failed",
                     reason = "repair_delete_active_fallback",
-                    id = %fallback,
+                    household_id = %fallback,
+                    result = "error",
                     error = ?err
                 );
             }
@@ -1612,7 +1659,8 @@ async fn household_repair(
         tracing::info!(
             target: "arklowdun",
             event = "household_delete_repair",
-            id = %record.id,
+            household_id = %record.id,
+            result = "ok",
             name = %record.name,
             color = record.color.as_deref().unwrap_or(""),
             was_active = outcome.was_active,
@@ -1680,7 +1728,8 @@ async fn household_restore(
     tracing::info!(
         target: "arklowdun",
         event = "household_restore",
-        id = %record.id,
+        household_id = %record.id,
+        result = "ok",
         name = %record.name,
         color = record.color.as_deref().unwrap_or("")
     );
@@ -1699,9 +1748,11 @@ async fn household_set_active(
     if snapshot_active_id(&state).as_deref() == Some(id.as_str()) {
         tracing::warn!(
             target: "arklowdun",
-            event = "household_set_active_failed",
-            id = %id,
-            reason = "already_active"
+            event = "household_set_active",
+            household_id = %id,
+            result = "error",
+            reason = "already_active",
+            error_code = "HOUSEHOLD_ALREADY_ACTIVE"
         );
         return Err(AppError::new(
             "HOUSEHOLD_ALREADY_ACTIVE",
@@ -1719,7 +1770,8 @@ async fn household_set_active(
                 tracing::info!(
                     target: "arklowdun",
                     event = "household_set_active",
-                    id = %record.id,
+                    household_id = %record.id,
+                    result = "ok",
                     name = %record.name,
                     color = record.color.as_deref().unwrap_or("")
                 );
@@ -1728,6 +1780,8 @@ async fn household_set_active(
                 tracing::warn!(
                     target = "arklowdun",
                     event = "household_event_emit_failed",
+                    household_id = %id,
+                    result = "error",
                     error = %err
                 );
             }
@@ -1736,18 +1790,22 @@ async fn household_set_active(
         Err(ActiveSetError::NotFound) => {
             tracing::warn!(
                 target: "arklowdun",
-                event = "household_set_active_failed",
-                id = %id,
-                reason = "not_found"
+                event = "household_set_active",
+                household_id = %id,
+                result = "error",
+                reason = "not_found",
+                error_code = "HOUSEHOLD_NOT_FOUND"
             );
             Err(AppError::new("HOUSEHOLD_NOT_FOUND", "Household not found."))
         }
         Err(ActiveSetError::Deleted) => {
             tracing::warn!(
                 target: "arklowdun",
-                event = "household_set_active_failed",
-                id = %id,
-                reason = "deleted"
+                event = "household_set_active",
+                household_id = %id,
+                result = "error",
+                reason = "deleted",
+                error_code = "HOUSEHOLD_DELETED"
             );
             Err(AppError::new("HOUSEHOLD_DELETED", "Household is deleted."))
         }
@@ -2775,6 +2833,41 @@ async fn diagnostics_summary(app: tauri::AppHandle) -> AppResult<diagnostics::Su
 }
 
 #[tauri::command]
+async fn diagnostics_household_stats(
+    state: State<'_, AppState>,
+) -> AppResult<Vec<diagnostics::HouseholdStatsEntry>> {
+    let pool = state.pool_clone();
+    let result = dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        async move { diagnostics::household_stats(&pool).await }
+    })
+    .await;
+
+    match result {
+        Ok(stats) => {
+            tracing::info!(
+                target: "arklowdun",
+                event = "household_stats",
+                household_id = "",
+                result = "ok",
+                households = stats.len()
+            );
+            Ok(stats)
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "arklowdun",
+                event = "household_stats",
+                household_id = "",
+                result = "error",
+                error_code = %err.code()
+            );
+            Err(err)
+        }
+    }
+}
+
+#[tauri::command]
 #[allow(clippy::result_large_err)]
 fn about_metadata(app: tauri::AppHandle) -> AppResult<diagnostics::AboutInfo> {
     Ok(diagnostics::about_info(&app))
@@ -3203,6 +3296,7 @@ macro_rules! app_commands {
             attachment_open,
             attachment_reveal,
             diagnostics_summary,
+            diagnostics_household_stats,
             diagnostics_doc_path,
             open_diagnostics_doc,
             db_backup_overview,

--- a/src-tauri/tests/diagnostics_cli.rs
+++ b/src-tauri/tests/diagnostics_cli.rs
@@ -1,0 +1,119 @@
+use std::path::Path;
+
+use anyhow::Result;
+use arklowdun_lib::diagnostics::HouseholdStatsEntry;
+use arklowdun_lib::ipc::guard::{DB_UNHEALTHY_CLI_HINT, DB_UNHEALTHY_EXIT_CODE};
+use arklowdun_lib::migrate;
+use assert_cmd::Command;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{ConnectOptions, Connection};
+use tempfile::tempdir;
+
+async fn migrate_database(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Full)
+        .foreign_keys(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?;
+    migrate::apply_migrations(&pool).await?;
+    pool.close().await?;
+    Ok(())
+}
+
+async fn seed_fk_violation(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut conn = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Full)
+        .foreign_keys(true)
+        .connect()
+        .await?;
+
+    sqlx::query("PRAGMA foreign_keys = OFF;")
+        .execute(&mut conn)
+        .await?;
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES ('broken-note', 'missing', NULL, 0, 0, 0, 0, 'Dangling note', '#FFFFFF', 0, 0)",
+    )
+    .execute(&mut conn)
+    .await?;
+    sqlx::query("PRAGMA foreign_keys = ON;")
+        .execute(&mut conn)
+        .await?;
+    conn.close().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn household_stats_cli_outputs_json() -> Result<()> {
+    let tmp = tempdir()?;
+    let appdata = tmp.path().join("appdata");
+    let db_path = appdata.join("arklowdun.sqlite3");
+
+    migrate_database(&db_path).await?;
+
+    let output = Command::cargo_bin("arklowdun")?
+        .env("ARK_FAKE_APPDATA", &appdata)
+        .args(["diagnostics", "household-stats", "--json"])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let rows: Vec<HouseholdStatsEntry> = serde_json::from_slice(&output.stdout)?;
+    assert!(!rows.is_empty(), "expected at least one household entry");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn household_stats_cli_blocks_when_unhealthy() -> Result<()> {
+    let tmp = tempdir()?;
+    let appdata = tmp.path().join("appdata");
+    let db_path = appdata.join("arklowdun.sqlite3");
+
+    migrate_database(&db_path).await?;
+    seed_fk_violation(&db_path).await?;
+
+    let output = Command::cargo_bin("arklowdun")?
+        .env("ARK_FAKE_APPDATA", &appdata)
+        .args(["diagnostics", "household-stats", "--json"])
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.status.code(), Some(DB_UNHEALTHY_EXIT_CODE));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("DB_UNHEALTHY_WRITE_BLOCKED"),
+        "expected DB_UNHEALTHY_WRITE_BLOCKED in stderr, got {stderr}"
+    );
+    assert!(
+        stderr.contains(DB_UNHEALTHY_CLI_HINT),
+        "expected {DB_UNHEALTHY_CLI_HINT} hint in stderr, got {stderr}"
+    );
+
+    Ok(())
+}

--- a/src-tauri/tests/diagnostics_cli.rs
+++ b/src-tauri/tests/diagnostics_cli.rs
@@ -25,7 +25,7 @@ async fn migrate_database(path: &Path) -> Result<()> {
         .connect_with(options)
         .await?;
     migrate::apply_migrations(&pool).await?;
-    pool.close().await?;
+    pool.close().await;
     Ok(())
 }
 

--- a/src-tauri/tests/diagnostics_household_stats.rs
+++ b/src-tauri/tests/diagnostics_household_stats.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use arklowdun_lib::{create_household, default_household_id, diagnostics, migrate};
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn memory_pool() -> Result<sqlx::SqlitePool> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await?;
+    migrate::apply_migrations(&pool).await?;
+    Ok(pool)
+}
+
+#[tokio::test]
+async fn household_stats_reports_counts_per_household() -> Result<()> {
+    let pool = memory_pool().await?;
+
+    let default_id = default_household_id(&pool).await?;
+    let secondary = create_household(&pool, "Secondary", None).await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 0, 0, 0, 0, 'Default active note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-default-active")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, deleted_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 1, 0, 0, 1, 0, 'Default deleted note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-default-deleted")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 0, 0, 0, 0, 'Secondary note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-secondary")
+    .bind(&secondary.id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, title, household_id, created_at, updated_at, deleted_at, tz, start_at_utc)\n         VALUES (?1, 'Default archived', ?2, 0, 0, 1, 'UTC', 0)",
+    )
+    .bind("event-default-deleted")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, title, household_id, created_at, updated_at, tz, start_at_utc)\n         VALUES (?1, 'Secondary active', ?2, 0, 0, 'UTC', 0)",
+    )
+    .bind("event-secondary")
+    .bind(&secondary.id)
+    .execute(&pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO files_index (household_id, file_id, filename, updated_at_utc, ordinal, score_hint)\n         VALUES (?1, ?2, ?3, '2024-01-01T00:00:00Z', 0, 0)",
+    )
+    .bind(&secondary.id)
+    .bind("file-secondary")
+    .bind("secondary.txt")
+    .execute(&pool)
+    .await?;
+
+    let stats = diagnostics::household_stats(&pool).await?;
+
+    let mut default_entry = None;
+    let mut secondary_entry = None;
+    for entry in stats {
+        if entry.id == default_id {
+            default_entry = Some(entry);
+        } else if entry.id == secondary.id {
+            secondary_entry = Some(entry);
+        }
+    }
+
+    let default_entry = default_entry.expect("default household present");
+    assert_eq!(default_entry.counts.get("notes"), Some(&1));
+    assert_eq!(default_entry.counts.get("events"), Some(&0));
+
+    let secondary_entry = secondary_entry.expect("secondary household present");
+    assert_eq!(secondary_entry.counts.get("notes"), Some(&1));
+    assert_eq!(secondary_entry.counts.get("events"), Some(&1));
+    assert_eq!(secondary_entry.counts.get("files"), Some(&1));
+
+    Ok(())
+}

--- a/src-tauri/tests/household_cascade.rs
+++ b/src-tauri/tests/household_cascade.rs
@@ -202,9 +202,7 @@ async fn cascade_pause_emits_paused_progress() -> Result<()> {
 #[tokio::test]
 async fn cascade_phase_registry_covers_household_tables() -> Result<()> {
     let pool = memory_pool().await?;
-    let known: HashSet<_> = arklowdun_lib::cascade_phase_tables()
-        .into_iter()
-        .collect();
+    let known: HashSet<_> = arklowdun_lib::cascade_phase_tables().into_iter().collect();
     let tables = sqlx::query_scalar::<_, String>(
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
     )

--- a/src-tauri/tests/ipc_household_scope.rs
+++ b/src-tauri/tests/ipc_household_scope.rs
@@ -1,0 +1,145 @@
+use anyhow::Result;
+use arklowdun_lib::{commands, default_household_id, migrate, AppError};
+use serde_json::{Map, Value};
+
+async fn memory_pool() -> Result<sqlx::SqlitePool> {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await?;
+    migrate::apply_migrations(&pool).await?;
+    Ok(pool)
+}
+
+fn assert_scope_violation(err: AppError) {
+    assert_eq!(
+        err.code(),
+        "HOUSEHOLD_NOT_FOUND",
+        "unexpected error code for household scope violation: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn notes_delete_rejects_wrong_household() -> Result<()> {
+    let pool = memory_pool().await?;
+    let default_id = default_household_id(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 0, 0, 0, 0, 'Cross-household note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-cross")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    let err = commands::delete_command(&pool, "notes", "wrong-household", "note-cross")
+        .await
+        .expect_err("expected mismatched household delete to fail");
+    assert_scope_violation(err);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notes_delete_rejects_missing_household() -> Result<()> {
+    let pool = memory_pool().await?;
+    let default_id = default_household_id(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 0, 0, 0, 0, 'Missing household note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-missing")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    let err = commands::delete_command(&pool, "notes", "", "note-missing")
+        .await
+        .expect_err("expected delete without household id to fail");
+    assert_scope_violation(err);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn events_update_rejects_wrong_household() -> Result<()> {
+    let pool = memory_pool().await?;
+    let default_id = default_household_id(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO events (id, title, household_id, created_at, updated_at, tz, start_at_utc)\n         VALUES (?1, 'Scoped event', ?2, 0, 0, 'UTC', 0)",
+    )
+    .bind("event-cross")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    let mut data = Map::new();
+    data.insert("title".into(), Value::String("Updated".into()));
+
+    let err = commands::update_command(
+        &pool,
+        "events",
+        "event-cross",
+        data,
+        Some("wrong-household"),
+    )
+    .await
+    .expect_err("expected mismatched event update to fail");
+    assert_scope_violation(err);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn inventory_restore_rejects_wrong_household() -> Result<()> {
+    let pool = memory_pool().await?;
+    let default_id = default_household_id(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO inventory_items (id, household_id, name, created_at, updated_at, deleted_at, position)\n         VALUES (?1, ?2, 'Scoped item', 0, 0, 1, 0)",
+    )
+    .bind("inventory-cross")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    let err = commands::restore_command(
+        &pool,
+        "inventory_items",
+        "wrong-household",
+        "inventory-cross",
+    )
+    .await
+    .expect_err("expected mismatched inventory restore to fail");
+    assert_scope_violation(err);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn notes_update_rejects_missing_household() -> Result<()> {
+    let pool = memory_pool().await?;
+    let default_id = default_household_id(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, category_id, position, created_at, updated_at, z, text, color, x, y)\n         VALUES (?1, ?2, NULL, 0, 0, 0, 0, 'Update scope note', '#FFFFFF', 0, 0)",
+    )
+    .bind("note-update")
+    .bind(&default_id)
+    .execute(&pool)
+    .await?;
+
+    let mut data = Map::new();
+    data.insert("text".into(), Value::String("Updated".into()));
+
+    let err = commands::update_command(&pool, "notes", "note-update", data, Some(""))
+        .await
+        .expect_err("expected update without household id to fail");
+    assert_scope_violation(err);
+
+    Ok(())
+}

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -3,7 +3,7 @@ import { call } from "@lib/ipc/call";
 interface HouseholdStatsRaw {
   id: string;
   name?: string | null;
-  is_default?: boolean | number | null;
+  isDefault?: boolean | number | null;
   counts?: Record<string, unknown> | null;
 }
 
@@ -17,7 +17,7 @@ export interface HouseholdStatsEntry {
 export function normaliseHouseholdStats(row: HouseholdStatsRaw): HouseholdStatsEntry {
   const name =
     typeof row.name === "string" && row.name.trim().length > 0 ? row.name : row.id;
-  const isDefault = Boolean(row.is_default);
+  const isDefault = Boolean(row.isDefault);
   const counts: Record<string, number> = {};
   if (row.counts && typeof row.counts === "object") {
     for (const [key, value] of Object.entries(row.counts)) {

--- a/src/api/diagnostics.ts
+++ b/src/api/diagnostics.ts
@@ -1,0 +1,40 @@
+import { call } from "@lib/ipc/call";
+
+interface HouseholdStatsRaw {
+  id: string;
+  name?: string | null;
+  is_default?: boolean | number | null;
+  counts?: Record<string, unknown> | null;
+}
+
+export interface HouseholdStatsEntry {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  counts: Record<string, number>;
+}
+
+export function normaliseHouseholdStats(row: HouseholdStatsRaw): HouseholdStatsEntry {
+  const name =
+    typeof row.name === "string" && row.name.trim().length > 0 ? row.name : row.id;
+  const isDefault = Boolean(row.is_default);
+  const counts: Record<string, number> = {};
+  if (row.counts && typeof row.counts === "object") {
+    for (const [key, value] of Object.entries(row.counts)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        counts[key] = value;
+      }
+    }
+  }
+  return {
+    id: row.id,
+    name,
+    isDefault,
+    counts,
+  };
+}
+
+export async function fetchHouseholdStats(): Promise<HouseholdStatsEntry[]> {
+  const rows = await call<HouseholdStatsRaw[]>("diagnostics_household_stats");
+  return rows.map(normaliseHouseholdStats);
+}

--- a/tests/unit/diagnostics.spec.ts
+++ b/tests/unit/diagnostics.spec.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import { normaliseHouseholdStats } from "../../src/api/diagnostics";
+
+test("normaliseHouseholdStats coerces numeric flags and drops invalid counts", () => {
+  const entry = normaliseHouseholdStats({
+    id: "hh-alpha",
+    name: "Alpha",
+    is_default: 1,
+    counts: {
+      notes: 4,
+      events: 0,
+      junk: "oops",
+      nested: { not: "number" },
+    },
+  });
+
+  assert.equal(entry.id, "hh-alpha");
+  assert.equal(entry.name, "Alpha");
+  assert.equal(entry.isDefault, true);
+  assert.deepEqual(entry.counts, { notes: 4, events: 0 });
+});
+
+test("normaliseHouseholdStats falls back to the household id and zero flag", () => {
+  const entry = normaliseHouseholdStats({
+    id: "hh-beta",
+    name: "   ",
+    is_default: 0,
+    counts: null,
+  });
+
+  assert.equal(entry.id, "hh-beta");
+  assert.equal(entry.name, "hh-beta");
+  assert.equal(entry.isDefault, false);
+  assert.deepEqual(entry.counts, {});
+});

--- a/tests/unit/diagnostics.spec.ts
+++ b/tests/unit/diagnostics.spec.ts
@@ -7,7 +7,7 @@ test("normaliseHouseholdStats coerces numeric flags and drops invalid counts", (
   const entry = normaliseHouseholdStats({
     id: "hh-alpha",
     name: "Alpha",
-    is_default: 1,
+    isDefault: 1,
     counts: {
       notes: 4,
       events: 0,
@@ -26,7 +26,7 @@ test("normaliseHouseholdStats falls back to the household id and zero flag", () 
   const entry = normaliseHouseholdStats({
     id: "hh-beta",
     name: "   ",
-    is_default: 0,
+    isDefault: 0,
     counts: null,
   });
 


### PR DESCRIPTION
## Summary
- add an ipc_household_scope regression suite that exercises domain CRUD wrappers with missing or incorrect household ids and asserts the scoped error mapping
- ensure the diagnostics CLI unhealthy-path test checks for the human hint emitted alongside the DB_UNHEALTHY_WRITE_BLOCKED code
- run rustfmt on touched tests to keep formatting consistent

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml ipc_household_scope *(fails: missing system library glib-2.0 in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e040fef95c832ab6f3530f7b96d65b