### PR TITLE
chore: make household workflows manual-only

### DIFF
--- a/.github/workflows/nightly-household-stress.yml
+++ b/.github/workflows/nightly-household-stress.yml
@@ -1,0 +1,61 @@
+name: nightly-household-stress
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: 'Approx rows per secondary household'
+        required: false
+        default: '10000'
+      households:
+        description: 'Number of secondary households to seed'
+        required: false
+        default: '2'
+
+concurrency:
+  group: nightly-household-stress
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cascade_stress:
+    name: cascade-stress
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install build tools for native Node deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Seed dataset and run cascade stress
+        run: |
+          set -euo pipefail
+          DB_PATH="$RUNNER_TEMP/com.paula.arklowdun-dev/nightly.sqlite3"
+          mkdir -p "$(dirname "$DB_PATH")"
+          cargo run --manifest-path src-tauri/Cargo.toml --bin migrate -- --db "$DB_PATH" up
+          VITE_ENV=development node --loader ts-node/esm scripts/dev/seed.ts --db "$DB_PATH" --households "${{ github.event.inputs.households || 2 }}" --rows "${{ github.event.inputs.rows || 10000 }}" --reset
+          node scripts/dev/household_stats.mjs --db "$DB_PATH" --json > nightly-household-stats-before.json
+          cargo test --locked --manifest-path src-tauri/Cargo.toml --test household_cascade -- --nocapture > nightly-cascade.log
+          node scripts/dev/household_stats.mjs --db "$DB_PATH" --json > nightly-household-stats-after.json
+      - name: Upload nightly household stress logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-household-stress-${{ github.run_id }}
+          path: |
+            nightly-cascade.log
+            nightly-household-stats-before.json
+            nightly-household-stats-after.json
+          retention-days: 7

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,42 @@
+name: smoke
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  household_backend:
+    name: household-backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+      - name: Run household integration tests
+        run: bash scripts/ci/smoke.sh --household-tests --skip-nightly --no-ui
+
+  ui_households:
+    name: ui-households
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Run households Playwright spec
+        run: bash scripts/ci/smoke.sh --ui-households --skip-nightly
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-households-${{ runner.os }}
+          path: |
+            test-results/ui
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Override the diagnostics size cap with `ARK_MAX_FILE_MB=10` (default 10).
 - The full diagnostics guide (UI summary, CLI collectors, redaction policy, and sample bundles) lives in
   [docs/diagnostics.md](docs/diagnostics.md).
 
+## Diagnostics and Support
+
+- See the [Household database remediation playbook](docs/support/household-db-remediation.md) for the on-call checklist when a cascade pauses or health checks block writes.
+- Run the helper script to inspect per-household counts and health:
+  ```bash
+  scripts/dev/household_stats.sh
+  ```
+  PowerShell users can call `scripts/dev/household_stats.ps1` with the same semantics. Both wrappers exit non-zero when a household reports an unhealthy state.
+
 ## Licensing
 
 Arklowdun is distributed under the [Arklowdun – Proprietary License](LICENSE.txt). Third-party components

--- a/docs/integrity-rules.md
+++ b/docs/integrity-rules.md
@@ -2,6 +2,51 @@
 
 This document captures conventions for enforcing data integrity in our SQLite schema. Apply these constraints whenever tables or columns are introduced in a migration.
 
+## Household Integrity
+
+Household data is protected by a combination of SQL triggers, SQLite foreign keys, and runtime orchestration in the cascade/repair helpers. Keep the following guarantees in mind when touching the household domain or any table that participates in cascading deletion.
+
+### Default household record
+
+- A permanent household row with the string identifier `"default"` is created during boot and flagged with `is_default = 1`. Exactly **one** default row must exist at all times; migrations that backfill legacy data repair or create the default as needed.
+- The triggers defined in `migrations/0004_households_invariants.sql` and the consolidated copy in `schema.sql` abort both hard deletes and soft deletes of the default row (`default_household_undeletable`). IPC commands map these failures to the `DEFAULT_UNDELETABLE` error code so the renderer can keep the Delete control disabled and explain why the action is blocked.
+
+### Cascade deletion pipeline
+
+- `household_delete` and `household_resume_delete` tear down a household in phases. Each phase removes a table from `CASCADE_PHASES`, ensuring that note links, notes, events, files metadata, financial records, and remaining domain tables are emptied before the household row itself is removed.
+- Progress is reported through the `household_delete_progress` IPC event. Each payload includes the phase name, deleted/total counters, and a status flag of `running`, `paused`, or `completed`. UI progress bars translate this into the cascade HUD while backend logs capture the same events for support review.
+- When a cascade pauses (timeout, app exit, crash) the checkpoint tables (`cascade_checkpoints`, `cascade_vacuum_queue`) persist the phase and counts. A later resume continues from the saved phase and emits progress again until completion.
+
+### Database health and write suspension
+
+- The cascade subsystem feeds into the DB health cache. Any unfinished cascade surfaces in health reports as `DB_UNHEALTHY_WRITE_BLOCKED` and the IPC guard rejects new write commands until a repair clears the checkpoint list. The UI presents a red banner and disables destructive actions while this state is active.
+- Health checks also propagate foreign-key and WAL corruption failures detected by `db::health::run_health_checks`. These likewise raise `DB_UNHEALTHY_WRITE_BLOCKED` and require operator intervention before writes can continue.
+
+### Repair and re-check
+
+- The `household_repair` command is exposed through Settings → “Run Repair / Re-check” and the diagnostics CLI. It runs `PRAGMA foreign_key_check`, refreshes the cascade health cache, and resumes any pending cascade for the targeted household with a two-second slice budget. Repair succeeds when the cascade completes, the checkpoint row disappears, and the health cache returns to OK. Expect small households to finish in under a second and heavily populated ones to require several passes of the two-second window.
+- Successful repairs emit `household_delete_progress` updates and a final `household_delete_resume` log entry that records the total rows deleted, whether an active household fallback occurred, and if a manual VACUUM is recommended.
+
+### Manual VACUUM guidance
+
+- When a cascade finishes with `vacuum_recommended = true`, the UI enables a “Reclaim space” button that calls `household_vacuum_execute`. Trigger this once the cascade and any repair passes are done; the handler removes the row from `cascade_vacuum_queue`, executes `VACUUM`, and clears the health banner. Avoid running VACUUM while a cascade is paused or mid-flight—it blocks write traffic and can extend the unhealthy window.
+
+### Error codes
+
+| Error code | Meaning |
+| --- | --- |
+| `DEFAULT_UNDELETABLE` | Attempted hard/soft delete of the `"default"` household. |
+| `HOUSEHOLD_NOT_FOUND` | Target household id does not exist or has already been purged. |
+| `HOUSEHOLD_DELETED` | Target household is soft-deleted and must be restored before updates. |
+| `DB_UNHEALTHY_WRITE_BLOCKED` | Database health checks detected a cascade in progress or corruption; write commands are suspended until repair succeeds. |
+
+### Developer map
+
+- SQL triggers: `migrations/0004_households_invariants.sql`, consolidated into `schema.sql` for install-time verification.
+- IPC commands: `household_delete`, `household_resume_delete`, `household_repair`, and `household_vacuum_execute` in `src-tauri/src/lib.rs`.
+- Diagnostics: cascade checkpoint helpers and progress observers in `src-tauri/src/household.rs` plus health-cache synchronisation in `src-tauri/src/lib.rs`.
+- Logs: look for `household_delete_progress`, `household_delete_resume`, `household_repair_failed`, and the DB health summaries emitted by `log_db_health` when unhealthy states are detected.
+
 ## UNIQUE
 
 Use `UNIQUE` constraints (or unique indexes) to prevent duplicate natural keys. Favor partial unique indexes that ignore soft-deleted rows.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,13 @@
 # Release
 
+## Household Management and Database Health
+
+- Cascading deletes now emit progress and can resume after interruption.
+- The default household cannot be removed.
+- A new Repair / Re-check option restores integrity if corruption occurs.
+- Diagnostics now show per-household entity counts.
+- Large deletions may lock writes temporarily; a “Reclaim space” button can perform manual VACUUM.
+
 ## Pending migrations check
 
 The release process verifies that the target database has applied all migrations found in `migrations/`.

--- a/docs/settings-ui.md
+++ b/docs/settings-ui.md
@@ -43,6 +43,13 @@ immediate feedback while mirroring the behaviour of the backend invariants.
   - `INVALID_COLOR` → "Please use a hex colour like #2563EB."
 - The default household always renders with a disabled "Delete" control and a
   tooltip explaining the guard so users understand why the action is blocked.
+- When cascade health gates activate, the banner surfaces progress copy and the
+  new "Run Repair / Re-check" button. Progress mirrors
+  `household_delete_progress` events so the HUD moves in lock-step with the
+  backend queue.
+  ![Default household delete disabled](ui/households/default-delete-disabled.svg)
+  ![Cascade progress indicator](ui/households/cascade-progress.svg)
+  ![Repair button in Settings](ui/households/repair-button.svg)
 - Success and error paths surface toast notifications so users receive feedback
   without leaving the page.
 - Colour selections update the chip immediately and persist through store

--- a/docs/support-playbook.md
+++ b/docs/support-playbook.md
@@ -43,8 +43,10 @@ highlights per-household totals.
 
 For quick access, use the bundled wrapper scripts:
 
-- **macOS/Linux:** `scripts/guards/household_stats.sh` (pass `--json` for JSON)
-- **Windows:** `scripts/guards/household_stats.ps1 -Json`
+- **macOS/Linux:** `scripts/dev/household_stats.sh` (pass `--json` for JSON)
+- **Windows:** `scripts/dev/household_stats.ps1 -Json`
+- **Support smoke:** `scripts/dev/household_stats.sh` mirrors the CLI, annotates
+  cascade/vacuum status, and exits non-zero when a household is unhealthy.
 
 Both scripts call the CLI command above, ensure the output is non-empty, and
 bubble up the exit status if the inspection fails.

--- a/docs/support/household-db-remediation.md
+++ b/docs/support/household-db-remediation.md
@@ -1,0 +1,90 @@
+# Household database remediation
+
+Household cascades, database health checks, and repair commands share the same
+plumbing. Use this playbook when a support ticket reports blocked writes or a
+red banner in Settings.
+
+## 1. Identify the problem
+
+- **UI symptoms:** Settings → Households shows a red "Database health" banner
+  and the Delete action for the default household stays disabled. The banner
+  links to repair controls and should match the screenshot below.
+  ![Default household delete disabled](../ui/households/default-delete-disabled.svg)
+- **CLI symptoms:** Commands fail with `DB_UNHEALTHY_WRITE_BLOCKED` or the
+  diagnostics summary reports `status: error`.
+- **Logs:** Search the desktop logs for `household_delete_progress` and
+  `cascade_state` entries to confirm the cascade paused mid-flight.
+
+## 2. Inspect state
+
+1. Run the bundled helper script to capture per-household counts and health
+   information:
+
+   ```bash
+   scripts/dev/household_stats.sh
+   ```
+
+   Example output:
+
+   ```
+   Household ID   Name             Default  notes  events  files  bills  policies  inventoryItems  cascade  vacuum  health
+   default        Default Home     yes          4       2      1      0         0               0        0       0  healthy
+   hhd-24722      Detached Annex   no           96      78     12      5         3               9      742       1  cascade_pending
+   ```
+
+   The script exits non-zero if any household health column is not `healthy`.
+   On Windows call `scripts/dev/household_stats.ps1` instead. Both wrappers call
+   the `diagnostics household-stats` CLI endpoint and annotate the results with
+   cascade/vacuum state.
+2. If shell access is unavailable, open the desktop Diagnostics → Households
+   view and capture the same table as a screenshot for the ticket.
+
+## 3. Repair
+
+- Prefer the in-app button: Settings → Households → "Run Repair / Re-check".
+  ![Repair button in Settings](../ui/households/repair-button.svg)
+  The UI streams cascade progress while the repair loop runs and retries every
+  two seconds until the checkpoint clears.
+- CLI alternative:
+
+  ```bash
+  cargo run --manifest-path src-tauri/Cargo.toml --bin arklowdun -- diagnostics household-stats --json
+  ```
+
+  (Use the scripts above to wrap the command on customer machines.)
+- Watch the cascade HUD. A paused or resumed run shows a yellow progress state
+  before returning to green.
+  ![Cascade progress indicator](../ui/households/cascade-progress.svg)
+
+## 4. Verify
+
+- Re-run `scripts/dev/household_stats.sh`. All households should report `health`
+  as `healthy` and the `cascade` column should read `0`.
+- Refresh Settings. The banner should disappear and the "Reclaim space" button
+  should only appear when `vacuum` reports a pending entry.
+- Confirm the application log includes `household_delete_resume` with
+  `result="ok"` for the repaired household.
+
+### Post-repair checklist
+
+- [ ] Default household still exists (`id = "default"`, `is_default = 1`).
+- [ ] No cascade checkpoint rows remain in `diagnostics_household_stats` output.
+- [ ] Optional: trigger the "Reclaim space" button if `vacuum` reported `1`.
+
+## 5. Escalate
+
+If the health state remains `error` after repair:
+
+1. Capture a fresh backup so engineers can reproduce locally:
+
+   ```bash
+   cargo run --manifest-path src-tauri/Cargo.toml --bin arklowdun -- db backup --json
+   ```
+
+   Note the emitted archive path.
+2. Collect the log bundle referenced in Diagnostics → Summary. Attach both to
+   the ticket.
+3. Share the outputs above plus any user actions that triggered the cascade.
+
+For background on cascade order, health gates, and repair internals see
+[`docs/integrity-rules.md`](../integrity-rules.md#household-integrity).

--- a/docs/ui/households/cascade-progress.svg
+++ b/docs/ui/households/cascade-progress.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="240" viewBox="0 0 640 240" role="img" aria-labelledby="title desc">
+  <title id="title">Cascade progress indicator</title>
+  <desc id="desc">A cascade deletion HUD showing phases and a paused/retry state.</desc>
+  <rect x="0" y="0" width="640" height="240" fill="#ffffff" stroke="#d1d8e2" rx="12" />
+  <text x="40" y="54" font-family="Inter,Arial,sans-serif" font-size="20" fill="#1f2933">Cascade delete · Household hhd-24722</text>
+  <text x="40" y="84" font-family="Inter,Arial,sans-serif" font-size="14" fill="#55606f">Streaming `household_delete_progress` events…</text>
+  <rect x="40" y="104" width="560" height="28" fill="#eef2f8" stroke="#cbd4e1" rx="14" />
+  <rect x="40" y="104" width="392" height="28" fill="#2563eb" rx="14" />
+  <rect x="432" y="104" width="100" height="28" fill="#fcd34d" rx="14" />
+  <rect x="540" y="104" width="60" height="28" fill="#cbd4e1" rx="14" />
+  <text x="80" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#f8fafc">notes</text>
+  <text x="168" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#f8fafc">events</text>
+  <text x="264" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#f8fafc">files</text>
+  <text x="358" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#f8fafc">bills</text>
+  <text x="446" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#1f2933">paused</text>
+  <text x="552" y="124" font-family="Inter,Arial,sans-serif" font-size="13" fill="#1f2933">pending</text>
+  <circle cx="80" cy="168" r="9" fill="#22c55e" />
+  <text x="96" y="172" font-family="Inter,Arial,sans-serif" font-size="14" fill="#1f2933">Deleted 742 / 980 rows</text>
+  <circle cx="80" cy="200" r="9" fill="#facc15" />
+  <text x="96" y="204" font-family="Inter,Arial,sans-serif" font-size="14" fill="#1f2933">Paused at phase `vehicle_maintenance` · resuming…</text>
+</svg>

--- a/docs/ui/households/default-delete-disabled.svg
+++ b/docs/ui/households/default-delete-disabled.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="260" viewBox="0 0 640 260" role="img" aria-labelledby="title desc">
+  <title id="title">Default household card with disabled delete control</title>
+  <desc id="desc">The default household row shows a dimmed Delete button and a banner indicating the database health gate.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f7f9fc" />
+      <stop offset="100%" stop-color="#e5ecf6" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="640" height="260" fill="#fff" stroke="#d0d6e0" rx="12" />
+  <rect x="24" y="24" width="592" height="72" fill="#ffeceb" stroke="#f2b8b5" rx="8" />
+  <text x="44" y="66" font-family="Inter,Arial,sans-serif" font-size="20" fill="#b3261e">Database health: repair required</text>
+  <rect x="24" y="116" width="592" height="112" fill="url(#bg)" stroke="#c5ccda" rx="10" />
+  <text x="48" y="156" font-family="Inter,Arial,sans-serif" font-size="22" fill="#1f2933">Default Home</text>
+  <text x="48" y="184" font-family="Inter,Arial,sans-serif" font-size="14" fill="#51606f">Household ID · default</text>
+  <rect x="456" y="152" width="120" height="40" rx="20" fill="#e2e6ec" stroke="#c2c9d3" stroke-dasharray="4 4" />
+  <text x="475" y="177" font-family="Inter,Arial,sans-serif" font-size="16" fill="#8a94a5">Delete</text>
+  <line x1="456" y1="192" x2="576" y2="192" stroke="#b9c1ce" stroke-dasharray="6 6" />
+  <text x="48" y="212" font-family="Inter,Arial,sans-serif" font-size="13" fill="#5f6b7a">Default households cannot be removed. Switch to another household to delete it.</text>
+</svg>

--- a/docs/ui/households/repair-button.svg
+++ b/docs/ui/households/repair-button.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="220" viewBox="0 0 640 220" role="img" aria-labelledby="title desc">
+  <title id="title">Repair / Re-check button</title>
+  <desc id="desc">Settings panel showing the Run Repair / Re-check button beside the cascade status.</desc>
+  <rect x="0" y="0" width="640" height="220" fill="#ffffff" stroke="#d2d8e3" rx="12" />
+  <text x="36" y="56" font-family="Inter,Arial,sans-serif" font-size="22" fill="#1f2933">Household health</text>
+  <text x="36" y="86" font-family="Inter,Arial,sans-serif" font-size="14" fill="#5b6573">Automatic checks pause writes until cascades finish.</text>
+  <rect x="36" y="106" width="568" height="64" fill="#f9fafb" stroke="#d9dfe7" rx="10" />
+  <circle cx="68" cy="138" r="10" fill="#f97316" />
+  <text x="84" y="142" font-family="Inter,Arial,sans-serif" font-size="15" fill="#1f2933">Cascade paused · 742 rows remaining</text>
+  <rect x="380" y="122" width="204" height="38" rx="8" fill="#2563eb" />
+  <text x="396" y="146" font-family="Inter,Arial,sans-serif" font-size="16" fill="#f8fafc">Run Repair / Re-check</text>
+  <text x="36" y="176" font-family="Inter,Arial,sans-serif" font-size="13" fill="#5f6b7a">Repair resumes the cascade, refreshes DB health, and re-enables write operations.</text>
+</svg>

--- a/scripts/ci/smoke.sh
+++ b/scripts/ci/smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Consolidated smoke helpers for CI. See docs/support/household-db-remediation.md.
+set -euo pipefail
+
+run_household_tests() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  pushd "$repo_root/src-tauri" >/dev/null
+  cargo test --locked --package arklowdun --test household_* -- --nocapture
+  popd >/dev/null
+}
+
+run_ui_households() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel)"
+  pushd "$repo_root" >/dev/null
+  npm ci
+  npx playwright install --with-deps
+  mkdir -p test-results/ui
+  npx playwright test tests/ui/settings-households.spec.ts --reporter=list --output=test-results/ui
+  popd >/dev/null
+}
+
+show_usage() {
+  cat <<'USAGE'
+Usage: scripts/ci/smoke.sh [options]
+
+Options:
+  --household-tests  Run Rust integration tests for household cascades.
+  --ui-households    Run the Playwright households settings spec.
+  --no-ui            Skip UI tests even if selected by default.
+  --skip-nightly     Reserved for compatibility; no effect in this script.
+  --help             Show this help message.
+USAGE
+}
+
+do_household=0
+do_ui=0
+skip_ui=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --household-tests)
+      do_household=1
+      shift
+      ;;
+    --ui-households)
+      do_ui=1
+      shift
+      ;;
+    --no-ui)
+      skip_ui=1
+      shift
+      ;;
+    --skip-nightly)
+      shift
+      ;;
+    --help|-h)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ $do_household -eq 0 && $do_ui -eq 0 ]]; then
+  do_household=1
+  do_ui=1
+fi
+
+if [[ $skip_ui -eq 1 ]]; then
+  do_ui=0
+fi
+
+if [[ $do_household -eq 1 ]]; then
+  run_household_tests
+fi
+
+if [[ $do_ui -eq 1 ]]; then
+  run_ui_households
+fi

--- a/scripts/dev/household_stats.mjs
+++ b/scripts/dev/household_stats.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Household diagnostics formatter.
+ * The shell and PowerShell wrappers call this script directly.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import Database from "better-sqlite3";
+
+function usage() {
+  console.log(`Usage: node scripts/dev/household_stats.mjs [options]
+
+Options:
+  --db <path>   Override the SQLite database path.
+  --json        Emit JSON instead of the table view.
+  --help        Show this message.
+`);
+}
+
+function parseArgs(argv) {
+  const opts = { db: "", json: false, help: false };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--db":
+        if (i + 1 >= argv.length) {
+          throw new Error("--db requires a path argument");
+        }
+        opts.db = argv[++i];
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "--help":
+      case "-h":
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function ensureTool(name) {
+  const probe = spawnSync(name, ["--version"], { encoding: "utf8", stdio: "pipe" });
+  if (probe.error) {
+    throw new Error(`${name} is required to run this helper`);
+  }
+}
+
+function repoRoot() {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" });
+  if (result.status !== 0 || !result.stdout.trim()) {
+    throw new Error("Unable to determine repository root; ensure git is available.");
+  }
+  return result.stdout.trim();
+}
+
+function runCargoDiagnostics(root) {
+  const args = [
+    "run",
+    "--quiet",
+    "--manifest-path",
+    path.join(root, "src-tauri", "Cargo.toml"),
+    "--bin",
+    "arklowdun",
+    "--",
+    "diagnostics",
+    "household-stats",
+    "--json",
+  ];
+  const result = spawnSync("cargo", args, { cwd: root, encoding: "utf8" });
+  if (result.status !== 0) {
+    const stderr = result.stderr || result.stdout;
+    throw new Error(`Failed to execute household diagnostics command.\n${stderr}`);
+  }
+  const trimmed = result.stdout.trim();
+  if (!trimmed) {
+    throw new Error("Household diagnostics returned no data");
+  }
+  let rows;
+  try {
+    rows = JSON.parse(trimmed);
+  } catch (err) {
+    throw new Error(`Unable to parse diagnostics JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!Array.isArray(rows)) {
+    throw new Error("Unexpected diagnostics payload; expected an array");
+  }
+  return rows;
+}
+
+function defaultDbPath() {
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "com.paula.arklowdun", "arklowdun.sqlite3");
+  }
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    return path.join(appdata, "com.paula.arklowdun", "arklowdun.sqlite3");
+  }
+  return path.join(home, ".local", "share", "com.paula.arklowdun", "arklowdun.sqlite3");
+}
+
+function annotate(rows, dbPath) {
+  const aliasOrder = [
+    "notes",
+    "events",
+    "files",
+    "bills",
+    "policies",
+    "propertyDocuments",
+    "inventoryItems",
+    "vehicles",
+    "vehicleMaintenance",
+    "pets",
+    "petMedical",
+    "familyMembers",
+    "categories",
+    "budgetCategories",
+    "expenses",
+    "shoppingItems",
+    "noteLinks",
+  ];
+
+  const normalised = rows.map((row) => {
+    const counts = {};
+    if (row.counts && typeof row.counts === "object") {
+      for (const [key, value] of Object.entries(row.counts)) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          counts[key] = value;
+        }
+      }
+    }
+    const name = typeof row.name === "string" && row.name.trim().length > 0 ? row.name : row.id;
+    return {
+      id: String(row.id ?? ""),
+      name,
+      isDefault: Boolean(row.isDefault),
+      counts,
+    };
+  });
+
+  let cascadeMap = new Map();
+  let vacuumSet = new Set();
+  let deletedSet = new Set();
+
+  try {
+    if (fs.existsSync(dbPath)) {
+      const db = new Database(dbPath, { readonly: true });
+      const checkpoints = db.prepare(
+        "SELECT household_id, deleted_count, total, phase FROM cascade_checkpoints"
+      ).all();
+      cascadeMap = new Map(
+        checkpoints.map((row) => [
+          row.household_id,
+          {
+            deleted: Number(row.deleted_count ?? 0),
+            total: Number(row.total ?? 0),
+            phase: row.phase ?? "",
+          },
+        ]),
+      );
+      const vacuumRows = db.prepare(
+        "SELECT household_id FROM cascade_vacuum_queue"
+      ).all();
+      vacuumSet = new Set(vacuumRows.map((row) => row.household_id));
+      const deletedRows = db.prepare(
+        "SELECT id FROM household WHERE deleted_at IS NOT NULL"
+      ).all();
+      deletedSet = new Set(deletedRows.map((row) => row.id));
+      db.close();
+    }
+  } catch (err) {
+    console.error(`Warning: failed to inspect ${dbPath}:`, err instanceof Error ? err.message : err);
+  }
+
+  const augmented = normalised.map((row) => {
+    const cascade = cascadeMap.get(row.id);
+    const vacuumPending = vacuumSet.has(row.id) ? 1 : 0;
+    let health = "healthy";
+    if (cascade) {
+      health = "cascade_pending";
+    } else if (vacuumPending) {
+      health = "vacuum_pending";
+    }
+    if (deletedSet.has(row.id)) {
+      health = "deleted";
+    }
+    return {
+      ...row,
+      cascade: cascade ? `${cascade.deleted}/${cascade.total}` : "0",
+      vacuum: vacuumPending,
+      health,
+    };
+  });
+
+  return { aliasOrder, augmented };
+}
+
+function emitJson(rows) {
+  console.log(JSON.stringify(rows, null, 2));
+}
+
+function emitTable(data) {
+  const { aliasOrder, augmented } = data;
+  const numericColumns = aliasOrder.filter((key) => augmented.some((row) => Object.hasOwn(row.counts, key)));
+  const extraColumns = ["cascade", "vacuum", "health"];
+  const headerColumns = ["Household ID", "Name", "Default"];
+  const widths = new Map();
+
+  function updateWidth(key, value) {
+    const width = String(value).length;
+    widths.set(key, Math.max(widths.get(key) ?? key.length, width));
+  }
+
+  for (const key of headerColumns.concat(numericColumns, extraColumns)) {
+    widths.set(key, key.length);
+  }
+
+  for (const row of augmented) {
+    updateWidth("Household ID", row.id);
+    updateWidth("Name", row.name);
+    updateWidth("Default", row.isDefault ? "yes" : "no");
+    for (const key of numericColumns) {
+      updateWidth(key, row.counts[key] ?? 0);
+    }
+    updateWidth("cascade", row.cascade);
+    updateWidth("vacuum", row.vacuum);
+    updateWidth("health", row.health);
+  }
+
+  const pad = (key, value, alignRight = false) => {
+    const text = String(value);
+    const width = widths.get(key) ?? text.length;
+    return alignRight ? text.padStart(width, " ") : text.padEnd(width, " ");
+  };
+
+  let header = `${pad("Household ID", "Household ID")}  ${pad("Name", "Name")}  ${pad("Default", "Default")}`;
+  for (const key of numericColumns) {
+    header += `  ${pad(key, key, true)}`;
+  }
+  for (const key of extraColumns) {
+    header += `  ${pad(key, key)}`;
+  }
+  console.log(header);
+
+  for (const row of augmented) {
+    let line = `${pad("Household ID", row.id)}  ${pad("Name", row.name)}  ${pad("Default", row.isDefault ? "yes" : "no")}`;
+    for (const key of numericColumns) {
+      line += `  ${pad(key, row.counts[key] ?? 0, true)}`;
+    }
+    line += `  ${pad("cascade", row.cascade)}  ${pad("vacuum", row.vacuum)}  ${pad("health", row.health)}`;
+    console.log(line);
+  }
+}
+
+try {
+  const opts = parseArgs(process.argv);
+  if (opts.help) {
+    usage();
+    process.exit(0);
+  }
+  ensureTool("cargo");
+  ensureTool("git");
+  const root = repoRoot();
+  const rows = runCargoDiagnostics(root);
+  const dbPath = opts.db ? opts.db : defaultDbPath();
+  const data = annotate(rows, dbPath);
+  if (opts.json) {
+    emitJson(data.augmented);
+  } else {
+    emitTable(data);
+  }
+  const unhealthy = data.augmented.some((row) => row.health !== "healthy");
+  process.exit(unhealthy ? 1 : 0);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/scripts/dev/household_stats.ps1
+++ b/scripts/dev/household_stats.ps1
@@ -1,0 +1,22 @@
+#!/usr/bin/env pwsh
+# Helper for support engineers. See docs/support/household-db-remediation.md.
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$Args
+)
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+if (-not $repoRoot) {
+  Write-Error "Failed to resolve repository root. Ensure git is available."
+  exit 1
+}
+
+$nodeScript = Join-Path $repoRoot "scripts/dev/household_stats.mjs"
+if (-not (Test-Path $nodeScript)) {
+  Write-Error "Missing helper script: $nodeScript"
+  exit 1
+}
+
+$node = Get-Command node -ErrorAction Stop
+& $node.Path $nodeScript @Args
+exit $LASTEXITCODE

--- a/scripts/dev/household_stats.sh
+++ b/scripts/dev/household_stats.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Helper for support engineers. See docs/support/household-db-remediation.md.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+node_script="${repo_root}/scripts/dev/household_stats.mjs"
+
+if [[ ! -f "$node_script" ]]; then
+  echo "Missing helper script: $node_script" >&2
+  exit 1
+fi
+
+exec node "$node_script" "$@"


### PR DESCRIPTION
## Summary
- switch the smoke and nightly household workflows to manual dispatch only
- add runtime knobs, native build deps, and concurrency guards to the nightly stress run
- align integrity and support docs with the dev household diagnostics helpers

## Testing
- `npm_config_yes=true npx markdownlint-cli2 docs/integrity-rules.md docs/support-playbook.md` *(fails: pre-existing repository-wide style rules such as MD013)*

------
https://chatgpt.com/codex/tasks/task_e_68e258ffde24832a8eceeb205d0ee2d2