### PR TITLE
Centralize attachments root resolution via vault helpers

### DIFF
--- a/src-tauri/src/security/fs_policy.rs
+++ b/src-tauri/src/security/fs_policy.rs
@@ -62,15 +62,10 @@ pub fn base_for<R: Runtime>(
             .app_data_dir()
             .map_err(|_| FsPolicyError::Invalid)?
     };
-    let base = match root {
-        RootKey::AppData => base,
-        RootKey::Attachments => {
-            let mut p = base;
-            p.push("attachments");
-            p
-        }
-    };
-    Ok(base)
+    match root {
+        RootKey::AppData => Ok(base),
+        RootKey::Attachments => Ok(crate::vault::paths::attachments_root_for_appdata(&base)),
+    }
 }
 
 /// Canonicalize user/provided path against `root`, normalize separators,

--- a/src-tauri/src/vault/logging.rs
+++ b/src-tauri/src/vault/logging.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use crate::security::hash_path;
+
+pub fn hash_for_logging<P>(path: P) -> String
+where
+    P: AsRef<Path>,
+{
+    hash_path(path.as_ref())
+}
+
+#[macro_export]
+macro_rules! vault_log {
+    (
+        level: $level:ident,
+        event: $event:expr,
+        outcome: $outcome:expr,
+        household_id = $household:expr,
+        category = $category:expr,
+        path = $path:expr
+        $(, duration_ms = $duration:expr)?
+        $(, $field:ident = $value:expr)*
+        $(,)?
+    ) => {{
+        let hashed_path = $crate::vault::logging::hash_for_logging($path);
+        tracing::$level!(
+            target: "arklowdun",
+            event = $event,
+            outcome = $outcome,
+            household_id = $household,
+            category = $category,
+            path_hash = %hashed_path,
+            $(duration_ms = $duration,)?
+            $($field = $value,)*
+        );
+    }};
+}

--- a/src-tauri/src/vault/paths.rs
+++ b/src-tauri/src/vault/paths.rs
@@ -1,0 +1,14 @@
+use std::path::{Path, PathBuf};
+
+/// Derive the attachments root that corresponds to an application data base.
+pub fn attachments_root_for_appdata(base: &Path) -> PathBuf {
+    base.join("attachments")
+}
+
+/// Derive the attachments root adjacent to the SQLite database path.
+pub fn attachments_root_for_database(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .map(|parent| parent.join("attachments"))
+        .unwrap_or_else(|| PathBuf::from("attachments"))
+}

--- a/src/features/settings/api/vaultMigration.ts
+++ b/src/features/settings/api/vaultMigration.ts
@@ -27,3 +27,7 @@ export function fetchMigrationStatus(): Promise<MigrationProgress> {
 export function runMigration(mode: MigrationMode): Promise<MigrationProgress> {
   return call("attachments_migrate", { mode });
 }
+
+export function resumeMigration(): Promise<MigrationProgress> {
+  return call("attachments_resume_migration");
+}


### PR DESCRIPTION
## Summary
- add `vault::paths` helpers to derive attachments roots from database paths and app data bases
- replace manual attachments path joins in runtime setup, CLI defaults, and filesystem policy code with the shared helpers to keep joins inside the vault module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d328d094832ab7bbfc10ec96e7c0