### PR TITLE
Refine files index scheduling and search

### DIFF
--- a/migrations/0001_baseline.sql
+++ b/migrations/0001_baseline.sql
@@ -62,13 +62,21 @@ CREATE TABLE files_index (
   id INTEGER PRIMARY KEY,
   household_id TEXT NOT NULL,
   file_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'misc',
   filename TEXT NOT NULL,
   updated_at_utc TEXT NOT NULL,
   ordinal INTEGER NOT NULL,
   score_hint INTEGER NOT NULL DEFAULT 0,
+  size_bytes INTEGER,
+  mime TEXT,
+  modified_at_utc INTEGER,
+  sha256 TEXT,
   UNIQUE (household_id, file_id),
   FOREIGN KEY (household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+CREATE UNIQUE INDEX files_index_household_cat_filename
+  ON files_index(household_id, category, filename);
 
 CREATE TABLE files_index_meta (
   household_id TEXT PRIMARY KEY,

--- a/migrations/0024_files_index_metadata.down.sql
+++ b/migrations/0024_files_index_metadata.down.sql
@@ -1,0 +1,31 @@
+CREATE TABLE files_index_tmp AS
+  SELECT id,
+         household_id,
+         file_id,
+         filename,
+         updated_at_utc,
+         ordinal,
+         score_hint
+    FROM files_index;
+
+DROP TABLE files_index;
+
+CREATE TABLE files_index (
+  id INTEGER PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  file_id TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  updated_at_utc TEXT NOT NULL,
+  ordinal INTEGER NOT NULL,
+  score_hint INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (household_id, file_id),
+  FOREIGN KEY (household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO files_index (id, household_id, file_id, filename, updated_at_utc, ordinal, score_hint)
+  SELECT id, household_id, file_id, filename, updated_at_utc, ordinal, score_hint
+    FROM files_index_tmp;
+
+DROP TABLE files_index_tmp;
+
+DROP INDEX IF EXISTS files_index_household_cat_filename;

--- a/migrations/0024_files_index_metadata.up.sql
+++ b/migrations/0024_files_index_metadata.up.sql
@@ -1,0 +1,22 @@
+ALTER TABLE files_index
+  ADD COLUMN category TEXT NOT NULL DEFAULT 'misc';
+
+ALTER TABLE files_index
+  ADD COLUMN size_bytes INTEGER;
+
+ALTER TABLE files_index
+  ADD COLUMN mime TEXT;
+
+ALTER TABLE files_index
+  ADD COLUMN modified_at_utc BIGINT;
+
+ALTER TABLE files_index
+  ADD COLUMN sha256 TEXT NULL;
+
+UPDATE files_index
+   SET size_bytes = COALESCE(size_bytes, 0),
+       mime = NULL,
+       modified_at_utc = NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS files_index_household_cat_filename
+  ON files_index(household_id, category, filename);

--- a/schema.sql
+++ b/schema.sql
@@ -53,13 +53,21 @@ CREATE TABLE files_index (
   id INTEGER PRIMARY KEY,
   household_id TEXT NOT NULL,
   file_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'misc',
   filename TEXT NOT NULL,
   updated_at_utc TEXT NOT NULL,
   ordinal INTEGER NOT NULL,
   score_hint INTEGER NOT NULL DEFAULT 0,
+  size_bytes INTEGER,
+  mime TEXT,
+  modified_at_utc INTEGER,
+  sha256 TEXT,
   UNIQUE (household_id, file_id),
   FOREIGN KEY (household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+CREATE UNIQUE INDEX files_index_household_cat_filename
+  ON files_index(household_id, category, filename);
 CREATE TABLE files_index_meta (
   household_id TEXT PRIMARY KEY,
   last_built_at_utc TEXT NOT NULL,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -169,9 +169,11 @@ dependencies = [
  "futures",
  "iana-time-zone",
  "include_dir",
+ "infer 0.15.0",
  "jsonschema",
  "libc",
  "log",
+ "mime_guess",
  "once_cell",
  "paste",
  "proptest",
@@ -204,6 +206,7 @@ dependencies = [
  "ts-rs",
  "unicode-normalization",
  "uuid",
+ "walkdir",
  "windows-sys 0.52.0",
 ]
 
@@ -2468,6 +2471,15 @@ dependencies = [
 
 [[package]]
 name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
+name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
@@ -2882,6 +2894,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -5632,7 +5654,7 @@ dependencies = [
  "glob",
  "html5ever",
  "http 1.3.1",
- "infer",
+ "infer 0.19.0",
  "json-patch",
  "json5",
  "kuchikiki",
@@ -6258,6 +6280,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,9 @@ file-rotate = "0.7"
 rusqlite = { version = "0.32", features = ["backup"] }
 fs2 = "0.4"
 unicode-normalization = "0.1"
+walkdir = "2"
+mime_guess = "2"
+infer = "0.15"
 
 [dev-dependencies]
 libc = "0.2"

--- a/src-tauri/schema.sql
+++ b/src-tauri/schema.sql
@@ -55,13 +55,21 @@ CREATE TABLE files_index (
   id INTEGER PRIMARY KEY,
   household_id TEXT NOT NULL,
   file_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'misc',
   filename TEXT NOT NULL,
   updated_at_utc TEXT NOT NULL,
   ordinal INTEGER NOT NULL,
   score_hint INTEGER NOT NULL DEFAULT 0,
+  size_bytes INTEGER,
+  mime TEXT,
+  modified_at_utc INTEGER,
+  sha256 TEXT,
   UNIQUE (household_id, file_id),
   FOREIGN KEY (household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+CREATE UNIQUE INDEX files_index_household_cat_filename
+  ON files_index(household_id, category, filename);
 CREATE TABLE files_index_meta (
   household_id TEXT PRIMARY KEY,
   last_built_at_utc TEXT NOT NULL,

--- a/src-tauri/src/files_indexer.rs
+++ b/src-tauri/src/files_indexer.rs
@@ -1,0 +1,468 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{SecondsFormat, Utc};
+use infer::Infer;
+use mime_guess::MimeGuess;
+use sha2::{Digest, Sha256};
+use sqlx::{Row, SqlitePool};
+use tokio::sync::mpsc::Sender;
+use walkdir::WalkDir;
+
+use crate::attachment_category::AttachmentCategory;
+use crate::vault::Vault;
+use crate::{AppError, AppResult};
+
+const PROGRESS_BATCH: u64 = 25;
+const MAX_DEPTH: usize = 16;
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RebuildMode {
+    Full,
+    Incremental,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum IndexerState {
+    Idle,
+    Building,
+    Cancelling,
+    Error,
+}
+
+impl Default for IndexerState {
+    fn default() -> Self {
+        IndexerState::Idle
+    }
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IndexProgress {
+    pub scanned: u64,
+    pub updated: u64,
+    pub skipped: u64,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IndexSummary {
+    pub total: u64,
+    pub updated: u64,
+    pub duration_ms: u64,
+}
+
+struct ExistingRow {
+    file_id: String,
+    size_bytes: Option<i64>,
+    modified_at: Option<i64>,
+}
+
+pub struct FilesIndexer {
+    pool: SqlitePool,
+    vault: Arc<Vault>,
+    cancel_token: Arc<AtomicBool>,
+    state: Arc<Mutex<HashMap<String, IndexerState>>>,
+}
+
+impl FilesIndexer {
+    pub fn new(pool: SqlitePool, vault: Arc<Vault>) -> Self {
+        Self {
+            pool,
+            vault,
+            cancel_token: Arc::new(AtomicBool::new(false)),
+            state: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn rebuild(
+        &self,
+        household_id: &str,
+        mode: RebuildMode,
+        progress_tx: Sender<IndexProgress>,
+    ) -> AppResult<IndexSummary> {
+        self.cancel_token.store(false, Ordering::SeqCst);
+        self.set_state(household_id, IndexerState::Building);
+        let result = self
+            .rebuild_internal(household_id.to_string(), mode, progress_tx)
+            .await;
+        match result {
+            Ok(summary) => {
+                self.set_state(household_id, IndexerState::Idle);
+                Ok(summary)
+            }
+            Err(err) => {
+                self.set_state(household_id, IndexerState::Error);
+                Err(err)
+            }
+        }
+    }
+
+    fn set_state(&self, household_id: &str, state: IndexerState) {
+        let mut guard = self.state.lock().expect("indexer state lock");
+        if matches!(state, IndexerState::Idle) {
+            guard.remove(household_id);
+        } else {
+            guard.insert(household_id.to_string(), state);
+        }
+    }
+
+    pub fn current_state(&self, household_id: &str) -> IndexerState {
+        let guard = self.state.lock().expect("indexer state lock");
+        guard
+            .get(household_id)
+            .copied()
+            .unwrap_or(IndexerState::Idle)
+    }
+
+    async fn rebuild_internal(
+        &self,
+        household: String,
+        mode: RebuildMode,
+        progress_tx: Sender<IndexProgress>,
+    ) -> AppResult<IndexSummary> {
+        let start = std::time::Instant::now();
+        let mut tx = progress_tx;
+
+        let pool = self.pool.clone();
+        let vault = self.vault.clone();
+        let cancel = self.cancel_token.clone();
+
+        let mut conn = pool.acquire().await?;
+        let mut existing: HashMap<(String, String), ExistingRow> = HashMap::new();
+        let rows = sqlx::query(
+            "SELECT file_id, category, filename, size_bytes, modified_at_utc\n             FROM files_index WHERE household_id=?1",
+        )
+        .bind(&household)
+        .fetch_all(&mut conn)
+        .await?;
+        for row in rows {
+            let file_id: String = row.try_get("file_id")?;
+            let category: String = row.try_get("category")?;
+            let filename: String = row.try_get("filename")?;
+            let size_bytes: Option<i64> = row.try_get("size_bytes")?;
+            let modified_at: Option<i64> = row.try_get("modified_at_utc")?;
+            existing.insert(
+                (category, filename),
+                ExistingRow {
+                    file_id,
+                    size_bytes,
+                    modified_at,
+                },
+            );
+        }
+        drop(conn);
+
+        let mut scanned = 0_u64;
+        let mut updated = 0_u64;
+        let mut skipped = 0_u64;
+        let mut batch_progress = IndexProgress::default();
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        let mut ordinal: i64 = 0;
+        let mut max_modified: Option<i64> = None;
+
+        let base = vault.base().join(&household);
+        if !base.exists() {
+            tracing::warn!(
+                target: "arklowdun",
+                event = "files_index_rebuild_missing_household",
+                household_id = %household,
+                "Household attachments directory does not exist"
+            );
+        }
+
+        let infer_engine = Infer::new();
+
+        for category in AttachmentCategory::iter() {
+            if cancel.load(Ordering::SeqCst) {
+                break;
+            }
+            let category_slug = category.as_str().to_string();
+            let category_dir = base.join(category_slug.as_str());
+            if !category_dir.exists() {
+                continue;
+            }
+            for entry in WalkDir::new(&category_dir)
+                .follow_links(false)
+                .min_depth(1)
+                .max_depth(MAX_DEPTH)
+            {
+                if cancel.load(Ordering::SeqCst) {
+                    break;
+                }
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "arklowdun",
+                            event = "files_index_walk_error",
+                            household_id = %household,
+                            category = %category_slug,
+                            error = %err,
+                            "Skipping entry due to walkdir error"
+                        );
+                        continue;
+                    }
+                };
+                let file_type = entry.file_type();
+                if !file_type.is_file() {
+                    continue;
+                }
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.starts_with('.') {
+                        continue;
+                    }
+                }
+                let depth = entry.depth();
+                if depth > MAX_DEPTH {
+                    continue;
+                }
+
+                let path = entry.path().to_path_buf();
+                let filename = match relative_filename(&category_dir, &path) {
+                    Some(name) => name,
+                    None => continue,
+                };
+
+                scanned += 1;
+                batch_progress.scanned += 1;
+
+                let metadata = match std::fs::metadata(&path) {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "arklowdun",
+                            event = "files_index_metadata_error",
+                            household_id = %household,
+                            category = %category_slug,
+                            error = %err,
+                            path = %path.display(),
+                            "Failed to read metadata for attachment"
+                        );
+                        skipped += 1;
+                        batch_progress.skipped += 1;
+                        maybe_emit(&mut tx, &mut batch_progress).await?;
+                        continue;
+                    }
+                };
+
+                if metadata.is_dir() {
+                    continue;
+                }
+
+                let size = metadata.len() as i64;
+                let modified_at = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|mtime| to_epoch_seconds(mtime));
+
+                let key = (category_slug.clone(), filename.clone());
+                let unchanged = if let (RebuildMode::Incremental, Some(existing_row)) =
+                    (mode, existing.get(&key))
+                {
+                    existing_row.size_bytes == Some(size) && existing_row.modified_at == modified_at
+                } else {
+                    false
+                };
+
+                if unchanged {
+                    skipped += 1;
+                    batch_progress.skipped += 1;
+                    seen.insert(key.clone());
+                    maybe_emit(&mut tx, &mut batch_progress).await?;
+                    continue;
+                }
+
+                let file_id = if let Some(existing_row) = existing.get(&key) {
+                    existing_row.file_id.clone()
+                } else {
+                    derive_file_id(&key)
+                };
+
+                let mime = detect_mime(&infer_engine, &path);
+
+                let sha256: Option<String> = None;
+                let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+                let mut conn = pool.acquire().await?;
+                sqlx::query(
+                    "INSERT INTO files_index\n                     (household_id, file_id, category, filename, updated_at_utc, ordinal, score_hint, size_bytes, mime, modified_at_utc, sha256)\n                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8, ?9, ?10)\n                     ON CONFLICT(household_id, category, filename)\n                     DO UPDATE SET\n                       file_id=excluded.file_id,\n                       updated_at_utc=excluded.updated_at_utc,\n                       ordinal=excluded.ordinal,\n                       score_hint=excluded.score_hint,\n                       size_bytes=excluded.size_bytes,\n                       mime=excluded.mime,\n                       modified_at_utc=excluded.modified_at_utc,\n                       sha256=excluded.sha256"
+                )
+                .bind(&household)
+                .bind(&file_id)
+                .bind(&key.0)
+                .bind(&key.1)
+                .bind(&now)
+                .bind(ordinal)
+                .bind(size)
+                .bind(&mime)
+                .bind(modified_at)
+                .bind(&sha256)
+                .execute(&mut conn)
+                .await?;
+                drop(conn);
+
+                ordinal += 1;
+                updated += 1;
+                batch_progress.updated += 1;
+                seen.insert(key.clone());
+                if let Some(modified) = modified_at {
+                    max_modified =
+                        Some(max_modified.map_or(modified, |existing| existing.max(modified)));
+                }
+                maybe_emit(&mut tx, &mut batch_progress).await?;
+            }
+        }
+
+        // Delete orphans
+        let mut conn = pool.acquire().await?;
+        for ((category, filename), existing_row) in existing.into_iter() {
+            if cancel.load(Ordering::SeqCst) {
+                break;
+            }
+            if !seen.contains(&(category.clone(), filename.clone())) {
+                sqlx::query("DELETE FROM files_index WHERE household_id=?1 AND file_id=?2")
+                    .bind(&household)
+                    .bind(&existing_row.file_id)
+                    .execute(&mut conn)
+                    .await?;
+            }
+        }
+
+        let total = seen.len() as u64;
+        let duration_ms = start.elapsed().as_millis() as u64;
+        let max_updated_iso = max_modified
+            .and_then(|value| Some(iso_from_epoch(value)))
+            .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+        let last_built = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        sqlx::query(
+            "INSERT INTO files_index_meta (household_id, last_built_at_utc, source_row_count, source_max_updated_utc, version)\n             VALUES (?1, ?2, ?3, ?4, ?5)\n             ON CONFLICT(household_id) DO UPDATE SET\n               last_built_at_utc=excluded.last_built_at_utc,\n               source_row_count=excluded.source_row_count,\n               source_max_updated_utc=excluded.source_max_updated_utc,\n               version=excluded.version",
+        )
+        .bind(&household)
+        .bind(&last_built)
+        .bind(total as i64)
+        .bind(&max_updated_iso)
+        .bind(crate::FILES_INDEX_VERSION)
+        .execute(&mut conn)
+        .await?;
+        drop(conn);
+
+        if cancel.load(Ordering::SeqCst) {
+            tracing::info!(
+                target: "arklowdun",
+                event = "files_index_cancelled",
+                household_id = %household,
+                scanned,
+                updated,
+                skipped,
+                "Indexer cancelled"
+            );
+        } else {
+            tracing::info!(
+                target: "arklowdun",
+                event = "files_index_completed",
+                household_id = %household,
+                scanned,
+                updated,
+                skipped,
+                total,
+                duration_ms,
+                "Indexer completed"
+            );
+        }
+
+        let summary = IndexSummary {
+            total,
+            updated,
+            duration_ms,
+        };
+
+        let _ = tx
+            .send(IndexProgress {
+                scanned,
+                updated,
+                skipped,
+            })
+            .await;
+
+        Ok(summary)
+    }
+
+    pub async fn cancel(&self, household_id: &str) {
+        self.cancel_token.store(true, Ordering::SeqCst);
+        self.set_state(household_id, IndexerState::Cancelling);
+    }
+}
+
+fn relative_filename(base: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(base).ok()?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(os) => {
+                let part = os.to_string_lossy().into_owned();
+                if part.starts_with('.') {
+                    return None;
+                }
+                parts.push(part);
+            }
+            Component::CurDir => continue,
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
+fn to_epoch_seconds(time: SystemTime) -> Option<i64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|dur| dur.as_secs() as i64)
+}
+
+fn iso_from_epoch(epoch: i64) -> String {
+    let dt = UNIX_EPOCH + Duration::from_secs(epoch as u64);
+    let datetime: chrono::DateTime<Utc> = dt.into();
+    datetime.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn detect_mime(infer_engine: &Infer, path: &PathBuf) -> String {
+    if let Ok(Some(kind)) = infer_engine.get_from_path(path) {
+        return kind.mime_type().to_string();
+    }
+    MimeGuess::from_path(path)
+        .first()
+        .map(|m| m.essence_str().to_string())
+        .unwrap_or_else(|| "application/octet-stream".to_string())
+}
+
+fn derive_file_id(key: &(String, String)) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(key.0.as_bytes());
+    hasher.update(b"/");
+    hasher.update(key.1.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+async fn maybe_emit(tx: &mut Sender<IndexProgress>, batch: &mut IndexProgress) -> AppResult<()> {
+    if batch.scanned + batch.updated + batch.skipped >= PROGRESS_BATCH {
+        let snapshot = batch.clone();
+        tx.send(snapshot).await.map_err(|err| {
+            AppError::new(
+                "INDEX_PROGRESS_CHANNEL_CLOSED",
+                "Progress receiver dropped.",
+            )
+            .with_context("error", err.to_string())
+        })?;
+        *batch = IndexProgress::default();
+    }
+    Ok(())
+}

--- a/src-tauri/src/ipc/guard.rs
+++ b/src-tauri/src/ipc/guard.rs
@@ -104,6 +104,7 @@ mod tests {
     use super::*;
     use crate::db::health::DbHealthReport;
     use crate::events_tz_backfill::BackfillCoordinator;
+    use crate::files_indexer::FilesIndexer;
     use crate::household_active::StoreHandle;
     use crate::vault::Vault;
     use crate::vault_migration::VaultMigrationManager;
@@ -127,6 +128,7 @@ mod tests {
             .expect("temp attachments dir")
             .keep();
         fs::create_dir_all(&attachments).expect("create attachments root");
+        let vault = Arc::new(Vault::new(attachments.clone()));
         AppState {
             pool: Arc::new(RwLock::new(pool)),
             active_household_id: Arc::new(Mutex::new(String::new())),
@@ -134,11 +136,12 @@ mod tests {
             backfill: Arc::new(Mutex::new(BackfillCoordinator::new())),
             db_health: Arc::new(Mutex::new(report)),
             db_path: Arc::new(PathBuf::from("test.sqlite3")),
-            vault: Arc::new(Vault::new(attachments.clone())),
+            vault: vault.clone(),
             vault_migration: Arc::new(
                 VaultMigrationManager::new(&attachments).expect("create vault migration manager"),
             ),
             maintenance: Arc::new(AtomicBool::new(false)),
+            files_indexer: Arc::new(FilesIndexer::new(pool.clone(), vault)),
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 use anyhow::{Context, Result as AnyResult};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use once_cell::sync::OnceCell;
 use paste::paste;
 use semver::Version;
@@ -16,6 +17,10 @@ use std::{
 };
 use tauri::{Emitter, Manager, State};
 use thiserror::Error;
+use tokio::{
+    sync::mpsc,
+    time::{sleep, Duration as TokioDuration},
+};
 use tracing_appender::non_blocking::NonBlockingBuilder;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{
@@ -35,13 +40,14 @@ use crate::{
         health::{DbHealthCheck, DbHealthReport, DbHealthStatus, STORAGE_SANITY_HEAL_NOTE},
         repair::{self, DbRepairEvent, DbRepairSummary},
     },
+    files_indexer::{IndexProgress, IndexerState, RebuildMode},
     household_active::ActiveSetError,
     ipc::guard,
     state::AppState,
     vault_migration::ATTACHMENT_TABLES,
 };
 
-const FILES_INDEX_VERSION: i64 = 1;
+pub(crate) const FILES_INDEX_VERSION: i64 = 2;
 
 const DEFAULT_LOG_MAX_SIZE_BYTES: u64 = 5_000_000;
 const DEFAULT_LOG_MAX_FILES: usize = 5;
@@ -120,6 +126,7 @@ pub mod error;
 pub mod events_tz_backfill;
 pub mod exdate;
 pub mod export;
+pub mod files_indexer;
 mod household; // declare module; avoid `use` to prevent name collision
 pub mod household_active;
 pub use household::{
@@ -205,6 +212,7 @@ mod cascade_health_tests {
         };
 
         let attachments = PathBuf::from("test.attachments");
+        let vault = Arc::new(crate::vault::Vault::new(attachments.clone()));
         let state = AppState {
             pool: Arc::new(RwLock::new(pool.clone())),
             active_household_id: Arc::new(Mutex::new(String::new())),
@@ -212,11 +220,12 @@ mod cascade_health_tests {
             backfill: Arc::new(Mutex::new(BackfillCoordinator::new())),
             db_health: Arc::new(Mutex::new(report)),
             db_path: Arc::new(PathBuf::from("test.sqlite")),
-            vault: Arc::new(crate::vault::Vault::new(attachments.clone())),
+            vault: vault.clone(),
             vault_migration: Arc::new(
                 crate::vault_migration::VaultMigrationManager::new(&attachments).unwrap(),
             ),
             maintenance: Arc::new(AtomicBool::new(false)),
+            files_indexer: Arc::new(crate::files_indexer::FilesIndexer::new(pool.clone(), vault)),
         };
 
         let household = crate::household::create_household(&pool, "Health", None).await?;
@@ -1885,6 +1894,10 @@ async fn household_set_active<R: tauri::Runtime>(
                     error = %err
                 );
             }
+            let indexer = state.files_indexer();
+            if indexer.current_state(&id) == IndexerState::Idle {
+                spawn_background_index_rebuild(&app, indexer, id.clone(), RebuildMode::Incremental);
+            }
             Ok(())
         }
         Err(ActiveSetError::NotFound) => {
@@ -2220,6 +2233,18 @@ pub struct SearchErrorPayload {
     pub details: serde_json::Value,
 }
 
+#[derive(Serialize, Deserialize)]
+struct FilesIndexStatus {
+    pub last_built_at: Option<String>,
+    pub row_count: i64,
+    pub state: IndexerState,
+}
+
+#[derive(Serialize, Deserialize)]
+struct FilesIndexCancelResponse {
+    cancelled: bool,
+}
+
 async fn table_exists(pool: &sqlx::SqlitePool, name: &str) -> bool {
     sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(1) FROM sqlite_master WHERE type='table' AND name=?1",
@@ -2283,6 +2308,25 @@ async fn files_index_ready(pool: &sqlx::SqlitePool, household_id: &str) -> bool 
     meta.0 == count && meta.1 == max_updated
 }
 
+fn emit_index_state_event<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    household_id: &str,
+    state: IndexerState,
+) {
+    let payload = json!({
+        "household_id": household_id,
+        "state": state,
+    });
+    if let Err(err) = app.emit("files_index_state", payload) {
+        tracing::warn!(
+            target: "arklowdun",
+            event = "files_index_state_emit_failed",
+            error = %err,
+            household_id = %household_id,
+        );
+    }
+}
+
 #[tauri::command]
 async fn db_table_exists(state: State<'_, AppState>, name: String) -> AppResult<bool> {
     let pool = state.pool_clone();
@@ -2303,6 +2347,169 @@ async fn db_files_index_ready(state: State<'_, AppState>, household_id: String) 
         move || async move { Ok(files_index_ready(&pool, &household_id).await) },
     )
     .await
+}
+
+#[tauri::command]
+async fn files_index_status(
+    state: State<'_, AppState>,
+    household_id: String,
+) -> AppResult<FilesIndexStatus> {
+    let pool = state.pool_clone();
+    let indexer = state.files_indexer();
+    let state_snapshot = indexer.current_state(&household_id);
+    let hh = household_id.clone();
+
+    let (last_built_at, row_count) = dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household = hh.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut last_built = None;
+            let mut row_count = 0_i64;
+
+            if let Some(row) = sqlx::query(
+                "SELECT last_built_at_utc, source_row_count FROM files_index_meta WHERE household_id=?1",
+            )
+            .bind(&household)
+            .fetch_optional(&mut conn)
+            .await?
+            {
+                last_built = row.try_get::<String, _>("last_built_at_utc").ok();
+                row_count = row.try_get::<i64, _>("source_row_count").unwrap_or(0);
+            }
+
+            if row_count == 0 {
+                row_count = sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*) FROM files_index WHERE household_id=?1",
+                )
+                .bind(&household)
+                .fetch_one(&mut conn)
+                .await
+                .unwrap_or(0);
+            }
+
+            Ok((last_built, row_count))
+        }
+    })
+    .await?;
+
+    Ok(FilesIndexStatus {
+        last_built_at,
+        row_count,
+        state: state_snapshot,
+    })
+}
+
+async fn run_index_rebuild<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    indexer: Arc<crate::files_indexer::FilesIndexer>,
+    household_id: String,
+    mode: RebuildMode,
+) -> AppResult<crate::files_indexer::IndexSummary> {
+    let (tx, mut rx) = mpsc::channel::<IndexProgress>(32);
+    let progress_household = household_id.clone();
+    let app_for_progress = app.clone();
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(progress) = rx.recv().await {
+            let payload = json!({
+                "household_id": progress_household,
+                "scanned": progress.scanned,
+                "updated": progress.updated,
+                "skipped": progress.skipped,
+            });
+            if let Err(err) = app_for_progress.emit("files_index_progress", payload) {
+                tracing::warn!(
+                    target: "arklowdun",
+                    event = "files_index_progress_emit_failed",
+                    error = %err,
+                );
+                break;
+            }
+        }
+    });
+
+    emit_index_state_event(&app, &household_id, IndexerState::Building);
+    tracing::info!(
+        target: "arklowdun",
+        event = "files_index_started",
+        hh = %household_id,
+        mode = ?mode,
+    );
+
+    let summary = match indexer.rebuild(&household_id, mode, tx).await {
+        Ok(summary) => {
+            tracing::info!(
+                target: "arklowdun",
+                event = "files_index_completed",
+                hh = %household_id,
+                total = summary.total,
+                updated = summary.updated,
+                duration_ms = summary.duration_ms,
+            );
+            summary
+        }
+        Err(err) => {
+            tracing::error!(
+                target: "arklowdun",
+                event = "files_index_failed",
+                household_id = %household_id,
+                error = %err,
+            );
+            emit_index_state_event(&app, &household_id, IndexerState::Error);
+            return Err(err);
+        }
+    };
+
+    emit_index_state_event(&app, &household_id, indexer.current_state(&household_id));
+    Ok(summary)
+}
+
+fn spawn_background_index_rebuild<R: tauri::Runtime + 'static>(
+    app: &tauri::AppHandle<R>,
+    indexer: Arc<crate::files_indexer::FilesIndexer>,
+    household_id: String,
+    mode: RebuildMode,
+) {
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(err) = run_index_rebuild(app_clone, indexer, household_id.clone(), mode).await {
+            tracing::error!(
+                target: "arklowdun",
+                event = "files_index_background_failed",
+                household_id = %household_id,
+                error = %err,
+            );
+        }
+    });
+}
+
+#[tauri::command]
+async fn files_index_cancel<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: State<'_, AppState>,
+    household_id: String,
+) -> AppResult<FilesIndexCancelResponse> {
+    let indexer = state.files_indexer();
+    indexer.cancel(&household_id).await;
+    emit_index_state_event(&app, &household_id, IndexerState::Cancelling);
+    tracing::info!(
+        target: "arklowdun",
+        event = "files_index_cancelled",
+        household_id = %household_id,
+    );
+    Ok(FilesIndexCancelResponse { cancelled: true })
+}
+
+#[tauri::command]
+async fn files_index_rebuild<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    state: State<'_, AppState>,
+    household_id: String,
+    mode: RebuildMode,
+) -> AppResult<crate::files_indexer::IndexSummary> {
+    let indexer = state.files_indexer();
+    run_index_rebuild(app, indexer, household_id, mode).await
 }
 
 #[tauri::command]
@@ -2455,6 +2662,15 @@ fn like_escape(s: &str) -> String {
         .replace('_', "\\_")
 }
 
+struct SearchHit {
+    score: i64,
+    ts: i64,
+    ordinal: usize,
+    filename_key: Option<String>,
+    id_key: Option<String>,
+    result: SearchResult,
+}
+
 #[tauri::command]
 async fn search_entities(
     state: State<'_, AppState>,
@@ -2475,7 +2691,7 @@ async fn search_entities(
             if household_id.trim().is_empty() {
                 return Err(AppError::new("BAD_REQUEST", "household_id is required"));
             }
-            if !(1..=100).contains(&limit) || offset < 0 {
+            if !(1..=10_000).contains(&limit) || offset < 0 {
                 return Err(AppError::new("BAD_REQUEST", "invalid limit/offset")
                     .with_context("limit", limit.to_string())
                     .with_context("offset", offset.to_string()));
@@ -2489,10 +2705,9 @@ async fn search_entities(
             let esc = like_escape(&q);
             let prefix = format!("{esc}%");
             let sub = format!("%{esc}%");
-            let branch_limit = (limit + offset).min(200);
+            let branch_limit = limit.saturating_add(offset).min(10_000);
 
             let index_ready = files_index_ready(pool, &household_id).await;
-            let has_files_table = table_exists(pool, "files").await;
 
             let has_events = table_exists(pool, "events").await;
             if !has_events {
@@ -2512,7 +2727,7 @@ async fn search_entities(
             }
 
             let short = q.len() < 2;
-            if short && !(index_ready || has_files_table) {
+            if short && !index_ready {
                 tracing::debug!(target: "arklowdun", q = %q, len = q.len(), "short_query_bypass");
                 return Ok(vec![]);
             }
@@ -2523,21 +2738,11 @@ async fn search_entities(
                     .with_context("branch", branch.to_string())
             };
 
-            let mut out: Vec<(i32, i64, usize, SearchResult)> = Vec::new();
+            let mut hits: Vec<SearchHit> = Vec::new();
             let mut ord: usize = 0;
 
-            if index_ready || has_files_table {
-                let (sql, branch_name) = if index_ready {
-                    (
-                        "SELECT file_id AS id, filename, strftime('%s', updated_at_utc) AS ts, ordinal AS ord FROM files_index\n     WHERE household_id=?1 AND filename LIKE ?2 ESCAPE '\\' COLLATE NOCASE LIMIT ?3 OFFSET ?4",
-                        "files_index",
-                    )
-                } else {
-                    (
-                        "SELECT id, filename, updated_at AS ts, rowid AS ord FROM files\n             WHERE household_id=?1 AND filename LIKE ?2 ESCAPE '\\' COLLATE NOCASE ORDER BY rowid ASC LIMIT ?3 OFFSET ?4",
-                        "files",
-                    )
-                };
+            if index_ready {
+                let sql = "SELECT file_id AS id, filename, strftime('%s', updated_at_utc) AS ts, ordinal AS ord, score_hint\n             FROM files_index\n             WHERE household_id=?1 AND filename LIKE ?2 ESCAPE '\\' COLLATE NOCASE\n             ORDER BY score_hint DESC, filename COLLATE NOCASE ASC, file_id ASC\n             LIMIT ?3 OFFSET ?4";
                 let start = std::time::Instant::now();
                 let rows = sqlx::query(sql)
                     .bind(&household_id)
@@ -2546,26 +2751,40 @@ async fn search_entities(
                     .bind(0)
                     .fetch_all(pool)
                     .await
-                    .map_err(|e| mapq(branch_name, e))?;
+                    .map_err(|e| mapq("files_index", e))?;
                 let elapsed = start.elapsed().as_millis() as i64;
-                tracing::debug!(target: "arklowdun", name = branch_name, rows = rows.len(), elapsed_ms = elapsed, "branch");
+                tracing::debug!(
+                    target: "arklowdun",
+                    name = "files_index",
+                    rows = rows.len(),
+                    elapsed_ms = elapsed,
+                    "branch"
+                );
                 for r in rows {
                     let filename: String = r.try_get("filename").unwrap_or_default();
                     let ts: i64 = r.try_get("ts").unwrap_or_default();
                     let ord_val: i64 = r.try_get("ord").unwrap_or_default();
-                    let score = if filename.eq_ignore_ascii_case(&q) { 2 } else { 1 };
+                    let score_hint: i64 = r.try_get("score_hint").unwrap_or(0);
                     let id: String = r.try_get("id").unwrap_or_default();
-                    out.push((
-                        score,
+                    hits.push(SearchHit {
+                        score: score_hint,
                         ts,
-                        ord_val as usize,
-                        SearchResult::File {
+                        ordinal: ord_val.max(0) as usize,
+                        filename_key: Some(filename.to_ascii_lowercase()),
+                        id_key: Some(id.clone()),
+                        result: SearchResult::File {
                             id,
                             filename,
                             updated_at: ts,
                         },
-                    ));
+                    });
                 }
+            } else {
+                tracing::debug!(
+                    target: "arklowdun",
+                    name = "files_index",
+                    "index_not_ready"
+                );
             }
 
             if !short {
@@ -2589,17 +2808,19 @@ async fn search_entities(
                         let tz: String = r.try_get("tz").unwrap_or_else(|_| "Europe/London".to_string());
                         let score = if title.eq_ignore_ascii_case(&q) { 2 } else { 1 };
                         let id: String = r.try_get("id").unwrap_or_default();
-                        out.push((
-                            score,
+                        hits.push(SearchHit {
+                            score: score as i64,
                             ts,
-                            ord,
-                            SearchResult::Event {
+                            ordinal: ord,
+                            filename_key: None,
+                            id_key: None,
+                            result: SearchResult::Event {
                                 id,
                                 title,
                                 start_at_utc: ts,
                                 tz,
                             },
-                        ));
+                        });
                         ord += 1;
                     }
                 }
@@ -2625,17 +2846,19 @@ async fn search_entities(
                         let score = if text.eq_ignore_ascii_case(&q) { 2 } else { 1 };
                         let snippet: String = text.chars().take(80).collect();
                         let id: String = r.try_get("id").unwrap_or_default();
-                        out.push((
-                            score,
+                        hits.push(SearchHit {
+                            score: score as i64,
                             ts,
-                            ord,
-                            SearchResult::Note {
+                            ordinal: ord,
+                            filename_key: None,
+                            id_key: None,
+                            result: SearchResult::Note {
                                 id,
                                 snippet,
                                 updated_at: ts,
                                 color,
                             },
-                        ));
+                        });
                         ord += 1;
                     }
                 }
@@ -2698,11 +2921,13 @@ async fn search_entities(
                             1
                         };
                         let id: String = r.try_get("id").unwrap_or_default();
-                        out.push((
-                            score,
+                        hits.push(SearchHit {
+                            score: score as i64,
                             ts,
-                            ord,
-                            SearchResult::Vehicle {
+                            ordinal: ord,
+                            filename_key: None,
+                            id_key: None,
+                            result: SearchResult::Vehicle {
                                 id,
                                 make,
                                 model,
@@ -2710,7 +2935,7 @@ async fn search_entities(
                                 updated_at: ts,
                                 nickname,
                             },
-                        ));
+                        });
                         ord += 1;
                     }
                 }
@@ -2759,32 +2984,48 @@ async fn search_entities(
                             1
                         };
                         let id: String = r.try_get("id").unwrap_or_default();
-                        out.push((
-                            score,
+                        hits.push(SearchHit {
+                            score: score as i64,
                             ts,
-                            ord,
-                            SearchResult::Pet {
+                            ordinal: ord,
+                            filename_key: None,
+                            id_key: None,
+                            result: SearchResult::Pet {
                                 id,
                                 name,
                                 species,
                                 updated_at: ts,
                             },
-                        ));
+                        });
                         ord += 1;
                     }
                 }
             }
 
-            out.sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)).then(a.2.cmp(&b.2)));
-            let total_before = out.len();
-            let out = out
+            hits.sort_by(|a, b| match (a.filename_key.as_ref(), b.filename_key.as_ref()) {
+                (Some(a_name), Some(b_name)) => {
+                    let aid = a.id_key.as_deref().unwrap_or("");
+                    let bid = b.id_key.as_deref().unwrap_or("");
+                    b.score
+                        .cmp(&a.score)
+                        .then_with(|| a_name.cmp(b_name))
+                        .then_with(|| aid.cmp(bid))
+                }
+                _ => b
+                    .score
+                    .cmp(&a.score)
+                    .then(b.ts.cmp(&a.ts))
+                    .then(a.ordinal.cmp(&b.ordinal)),
+            });
+            let total_before = hits.len();
+            let hits = hits
                 .into_iter()
                 .skip(offset as usize)
                 .take(limit as usize)
                 .collect::<Vec<_>>();
-            tracing::debug!(target: "arklowdun", total_before, returned = out.len(), "result_summary");
+            tracing::debug!(target: "arklowdun", total_before, returned = hits.len(), "result_summary");
 
-            Ok(out.into_iter().map(|(_, _, _, v)| v).collect())
+            Ok(hits.into_iter().map(|hit| hit.result).collect())
         }
     })
     .await
@@ -3347,12 +3588,25 @@ async fn attachments_migrate<R: tauri::Runtime>(
     let pool = state.pool_clone();
     let vault = state.vault();
     let manager = state.vault_migration();
-    dispatch_async_app_result(move || {
+    let result = dispatch_async_app_result(move || {
         let app = app.clone();
         let manager = manager.clone();
         async move { vault_migration::run_vault_migration(app, pool, vault, manager, mode).await }
     })
-    .await
+    .await;
+
+    if let Ok(progress) = &result {
+        if progress.completed {
+            if let Some(active) = snapshot_active_id(&state) {
+                let indexer = state.files_indexer();
+                if indexer.current_state(&active) == IndexerState::Idle {
+                    spawn_background_index_rebuild(&app, indexer, active, RebuildMode::Incremental);
+                }
+            }
+        }
+    }
+
+    result
 }
 
 #[tauri::command]
@@ -3369,12 +3623,25 @@ async fn attachments_resume_migration<R: tauri::Runtime>(
             "No vault migration checkpoint is available.",
         )
     })?;
-    dispatch_async_app_result(move || {
+    let result = dispatch_async_app_result(move || {
         let app = app.clone();
         let manager = manager.clone();
         async move { vault_migration::run_vault_migration(app, pool, vault, manager, mode).await }
     })
-    .await
+    .await;
+
+    if let Ok(progress) = &result {
+        if progress.completed {
+            if let Some(active) = snapshot_active_id(&state) {
+                let indexer = state.files_indexer();
+                if indexer.current_state(&active) == IndexerState::Idle {
+                    spawn_background_index_rebuild(&app, indexer, active, RebuildMode::Incremental);
+                }
+            }
+        }
+    }
+
+    result
 }
 
 #[tauri::command]
@@ -4000,6 +4267,10 @@ pub fn run() {
                 VaultMigrationManager::new(&attachments_root)
                     .map_err(|err| -> Box<dyn std::error::Error> { err.into() })?,
             );
+            let files_indexer = Arc::new(crate::files_indexer::FilesIndexer::new(
+                pool.clone(),
+                vault.clone(),
+            ));
 
             let sentinel_exists = vault_migration.last_apply_ok_path().exists();
             if sentinel_exists {
@@ -4054,6 +4325,80 @@ pub fn run() {
                 vault,
                 vault_migration,
                 maintenance: Arc::new(AtomicBool::new(false)),
+                files_indexer: files_indexer.clone(),
+            });
+
+            let idle_app = app.handle();
+            let idle_state = app.state::<crate::state::AppState>().clone();
+            let idle_indexer = files_indexer.clone();
+            tauri::async_runtime::spawn(async move {
+                let interval = TokioDuration::from_secs(15 * 60);
+                loop {
+                    sleep(interval).await;
+
+                    let Some(household_id) = snapshot_active_id(&idle_state) else {
+                        continue;
+                    };
+                    if idle_indexer.current_state(&household_id) != IndexerState::Idle {
+                        continue;
+                    }
+
+                    let pool = idle_state.pool_clone();
+                    if !table_exists(&pool, "files_index").await
+                        || !table_exists(&pool, "files_index_meta").await
+                    {
+                        continue;
+                    }
+                    let should_run = match sqlx::query(
+                        "SELECT last_built_at_utc, source_row_count FROM files_index_meta WHERE household_id=?1",
+                    )
+                    .bind(&household_id)
+                    .fetch_optional(&pool)
+                    .await
+                    {
+                        Ok(Some(row)) => {
+                            let row_count: i64 =
+                                row.try_get::<i64, _>("source_row_count").unwrap_or(0);
+                            let last_built = row.try_get::<String, _>("last_built_at_utc").ok();
+                            let is_empty = row_count == 0;
+                            let is_stale = last_built
+                                .as_deref()
+                                .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+                                .map(|dt| {
+                                    let built_utc = dt.with_timezone(&Utc);
+                                    Utc::now() - built_utc >= ChronoDuration::minutes(15)
+                                })
+                                .unwrap_or(true);
+                            is_empty || is_stale
+                        }
+                        Ok(None) => true,
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "arklowdun",
+                                event = "files_index_idle_status_failed",
+                                household_id = %household_id,
+                                error = %err,
+                            );
+                            true
+                        }
+                    };
+
+                    if !should_run {
+                        continue;
+                    }
+
+                    tracing::info!(
+                        target: "arklowdun",
+                        event = "files_index_idle_trigger",
+                        household_id = %household_id,
+                    );
+                    spawn_background_index_rebuild(
+                        &idle_app,
+                        idle_indexer.clone(),
+                        household_id,
+                        RebuildMode::Incremental,
+                    );
+                }
             });
             Ok(())
         })
@@ -4066,6 +4411,9 @@ pub fn run() {
             db_table_exists,
             db_has_files_index,
             db_files_index_ready,
+            files_index_status,
+            files_index_rebuild,
+            files_index_cancel,
             db_has_vehicle_columns,
             db_has_pet_columns,
             // Database health IPC commands consumed by the frontend shell.
@@ -4280,6 +4628,7 @@ mod db_health_command_tests {
 
         let attachments_root = crate::vault::paths::attachments_root_for_database(&db_path);
         std::fs::create_dir_all(&attachments_root).expect("create attachments dir");
+        let vault = Arc::new(Vault::new(attachments_root.clone()));
         let app_state = crate::state::AppState {
             pool: Arc::new(RwLock::new(pool.clone())),
             active_household_id: Arc::new(Mutex::new(String::from("test-household"))),
@@ -4289,11 +4638,12 @@ mod db_health_command_tests {
             )),
             db_health: Arc::new(Mutex::new(cached_report.clone())),
             db_path: Arc::new(db_path.clone()),
-            vault: Arc::new(Vault::new(attachments_root.clone())),
+            vault: vault.clone(),
             vault_migration: Arc::new(
                 crate::vault_migration::VaultMigrationManager::new(&attachments_root).unwrap(),
             ),
             maintenance: Arc::new(AtomicBool::new(false)),
+            files_indexer: Arc::new(crate::files_indexer::FilesIndexer::new(pool.clone(), vault)),
         };
 
         let app = mock_builder()
@@ -4738,6 +5088,10 @@ mod attachment_ipc_command_tests {
         let migration = Arc::new(
             VaultMigrationManager::new(attachments_root).expect("create vault migration manager"),
         );
+        let files_indexer = Arc::new(crate::files_indexer::FilesIndexer::new(
+            pool.clone(),
+            vault.clone(),
+        ));
         AppState {
             pool: Arc::new(RwLock::new(pool)),
             active_household_id: Arc::new(Mutex::new(active)),
@@ -4748,6 +5102,7 @@ mod attachment_ipc_command_tests {
             vault,
             vault_migration: migration,
             maintenance: Arc::new(AtomicBool::new(false)),
+            files_indexer,
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,9 +130,7 @@ fn main() {
 
     let cli = Cli::parse();
     if cli.resume_migration && cli.command.is_some() {
-        eprintln!(
-            "Error: --resume-migration cannot be used together with a subcommand."
-        );
+        eprintln!("Error: --resume-migration cannot be used together with a subcommand.");
         process::exit(2);
     }
     if cli.resume_migration {
@@ -196,7 +194,9 @@ fn handle_resume_migration() -> Result<i32> {
                         Some(mode) => mode,
                         None => {
                             pool.close().await;
-                            return Ok::<Option<(MigrationMode, MigrationProgress)>, anyhow::Error>(None);
+                            return Ok::<Option<(MigrationMode, MigrationProgress)>, anyhow::Error>(
+                                None,
+                            );
                         }
                     };
                     let progress = run_vault_migration_headless(

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use crate::{
     db::health::DbHealthReport, events_tz_backfill::BackfillCoordinator,
-    household_active::StoreHandle, vault::Vault, vault_migration::VaultMigrationManager, AppError,
-    AppResult,
+    files_indexer::FilesIndexer, household_active::StoreHandle, vault::Vault,
+    vault_migration::VaultMigrationManager, AppError, AppResult,
 };
 
 #[derive(Clone)]
@@ -20,6 +20,7 @@ pub struct AppState {
     pub vault: Arc<Vault>,
     pub vault_migration: Arc<VaultMigrationManager>,
     pub maintenance: Arc<AtomicBool>,
+    pub files_indexer: Arc<FilesIndexer>,
 }
 
 impl AppState {
@@ -46,6 +47,10 @@ impl AppState {
 
     pub fn vault_migration(&self) -> Arc<VaultMigrationManager> {
         self.vault_migration.clone()
+    }
+
+    pub fn files_indexer(&self) -> Arc<FilesIndexer> {
+        self.files_indexer.clone()
     }
 }
 
@@ -108,6 +113,7 @@ mod tests {
             vault: vault.clone(),
             vault_migration: Arc::new(VaultMigrationManager::new(tmp.path()).expect("manager")),
             maintenance: Arc::new(AtomicBool::new(false)),
+            files_indexer: Arc::new(FilesIndexer::new(pool.clone(), vault.clone())),
         };
 
         let first = state.vault();

--- a/src-tauri/tests/diagnostics_household_stats.rs
+++ b/src-tauri/tests/diagnostics_household_stats.rs
@@ -62,7 +62,7 @@ async fn household_stats_reports_counts_per_household() -> Result<()> {
     .await?;
 
     sqlx::query(
-        "INSERT INTO files_index (household_id, file_id, filename, updated_at_utc, ordinal, score_hint)\n         VALUES (?1, ?2, ?3, '2024-01-01T00:00:00Z', 0, 0)",
+        "INSERT INTO files_index (household_id, file_id, category, filename, updated_at_utc, ordinal, score_hint, size_bytes, mime, modified_at_utc, sha256)\n         VALUES (?1, ?2, 'misc', ?3, '2024-01-01T00:00:00Z', 0, 0, 0, 'application/octet-stream', NULL, NULL)",
     )
     .bind(&secondary.id)
     .bind("file-secondary")

--- a/src-tauri/tests/fixtures/sample.sql
+++ b/src-tauri/tests/fixtures/sample.sql
@@ -260,15 +260,23 @@ CREATE TABLE IF NOT EXISTS "files_index" (
   id INTEGER PRIMARY KEY,
   household_id TEXT NOT NULL,
   file_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'misc',
   filename TEXT NOT NULL,
   updated_at_utc TEXT NOT NULL,
   ordinal INTEGER NOT NULL,
   score_hint INTEGER NOT NULL DEFAULT 0,
+  size_bytes INTEGER,
+  mime TEXT,
+  modified_at_utc INTEGER,
+  sha256 TEXT,
   UNIQUE (household_id, file_id),
   FOREIGN KEY (household_id) REFERENCES household(id)
     ON DELETE CASCADE
     ON UPDATE CASCADE
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS files_index_household_cat_filename
+  ON files_index(household_id, category, filename);
 CREATE TABLE IF NOT EXISTS "files_index_meta" (
   household_id TEXT PRIMARY KEY,
   last_built_at_utc TEXT NOT NULL,

--- a/src-tauri/tests/note_links_integration.rs
+++ b/src-tauri/tests/note_links_integration.rs
@@ -101,17 +101,26 @@ async fn insert_file(
         "INSERT INTO files_index (
              household_id,
              file_id,
+             category,
              filename,
              updated_at_utc,
              ordinal,
-             score_hint
-         ) VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+             score_hint,
+             size_bytes,
+             mime,
+             modified_at_utc,
+             sha256
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8, ?9, NULL)",
     )
     .bind(household_id)
     .bind(&file_id)
+    .bind("misc")
     .bind(filename)
     .bind("2024-01-01T00:00:00Z")
     .bind(ordinal)
+    .bind(0_i64)
+    .bind("application/octet-stream")
+    .bind(None::<i64>)
     .execute(pool)
     .await
     .expect("insert file");

--- a/src/files/attachment-categories.ts
+++ b/src/files/attachment-categories.ts
@@ -20,6 +20,7 @@ type EnsureParity = BackendAttachmentCategory extends AttachmentCategory
     : never
   : never;
 const _ensureAttachmentCategoryParity: EnsureParity = true;
+void _ensureAttachmentCategoryParity;
 
 export function isAttachmentCategory(value: string): value is AttachmentCategory {
   return (ATTACHMENT_CATEGORIES as readonly string[]).includes(value);

--- a/src/lib/files/indexer.ts
+++ b/src/lib/files/indexer.ts
@@ -1,0 +1,82 @@
+import { getActiveHouseholdId } from "../../api/households";
+import { call } from "@lib/ipc/call";
+
+export type IndexMode = "full" | "incremental";
+export type IndexerState = "Idle" | "Building" | "Cancelling" | "Error";
+
+export interface IndexStatus {
+  lastBuiltAt: string | null;
+  rowCount: number;
+  state: IndexerState;
+}
+
+export interface IndexStatusResult {
+  householdId: string;
+  status: IndexStatus;
+}
+
+export interface IndexSummary {
+  total: number;
+  updated: number;
+  durationMs: number;
+}
+
+export interface FilesIndexProgressPayload {
+  household_id: string;
+  scanned: number;
+  updated: number;
+  skipped: number;
+}
+
+export interface FilesIndexStatePayload {
+  household_id: string;
+  state: IndexerState;
+}
+
+async function resolveHouseholdId(householdId?: string): Promise<string> {
+  if (householdId && householdId.trim().length > 0) {
+    return householdId;
+  }
+  return getActiveHouseholdId();
+}
+
+export async function rebuildIndex(
+  mode: IndexMode,
+  householdId?: string,
+): Promise<IndexSummary> {
+  const id = await resolveHouseholdId(householdId);
+  const summary = await call<{
+    total: number;
+    updated: number;
+    duration_ms: number;
+  }>("files_index_rebuild", { householdId: id, mode });
+  return {
+    total: Number(summary.total ?? 0),
+    updated: Number(summary.updated ?? 0),
+    durationMs: Number(summary.duration_ms ?? 0),
+  };
+}
+
+export async function getIndexStatus(
+  householdId?: string,
+): Promise<IndexStatusResult> {
+  const id = await resolveHouseholdId(householdId);
+  const raw = await call<{
+    last_built_at: string | null;
+    row_count: number;
+    state: IndexerState;
+  }>("files_index_status", { householdId: id });
+  return {
+    householdId: id,
+    status: {
+      lastBuiltAt: typeof raw.last_built_at === "string" ? raw.last_built_at : null,
+      rowCount: Number(raw.row_count ?? 0),
+      state: raw.state,
+    },
+  };
+}
+
+export async function cancelIndexRebuild(householdId?: string): Promise<void> {
+  const id = await resolveHouseholdId(householdId);
+  await call("files_index_cancel", { householdId: id });
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1606,6 +1606,86 @@ footer a.footer__settings {
   margin-bottom: var(--space-4);
 }
 
+.settings__section--storage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.storage__index {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+}
+
+.storage__index-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.storage__index-title {
+  margin: 0;
+  font-size: var(--font-size-md);
+}
+
+.storage__index-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  background-color: var(--color-border-soft);
+  color: var(--color-text-muted);
+}
+
+.storage__index-status[data-status="success"] {
+  background-color: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
+}
+
+.storage__index-status[data-status="pending"] {
+  background-color: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  color: var(--color-accent);
+}
+
+.storage__index-status[data-status="warning"] {
+  background-color: color-mix(in srgb, var(--color-warning, #d48806) 18%, transparent);
+  color: var(--color-warning, #d48806);
+}
+
+.storage__index-status[data-status="danger"] {
+  background-color: color-mix(in srgb, var(--color-danger, #dc2626) 18%, transparent);
+  color: var(--color-danger, #dc2626);
+}
+
+.storage__index-summary {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.storage__index-progress {
+  inline-size: 100%;
+}
+
+.storage__index-progress-note {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.storage__index-controls {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
 .ambient-settings {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a reusable files index rebuild runner and trigger background jobs from household activation, migrations, and idle timers
- schedule periodic incremental rebuilds for the active household when the index is stale or empty
- refactor entity search to rely solely on the files index and order file hits by score hint, filename, and id

## Testing
- `npm run typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: requires system glib-2.0 via pkg-config)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eccc30ac832abe4e68a2c0495554