### PR TITLE
Improve attachment maintenance flows

### DIFF
--- a/migrations/0025_file_ops.down.sql
+++ b/migrations/0025_file_ops.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS missing_attachments;

--- a/migrations/0025_file_ops.up.sql
+++ b/migrations/0025_file_ops.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS missing_attachments (
+  household_id TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  row_id INTEGER NOT NULL,
+  category TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  detected_at_utc INTEGER NOT NULL,
+  repaired_at_utc INTEGER,
+  action TEXT,
+  new_category TEXT,
+  new_relative_path TEXT,
+  PRIMARY KEY (table_name, row_id)
+);

--- a/src-tauri/src/file_ops.rs
+++ b/src-tauri/src/file_ops.rs
@@ -1,0 +1,891 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use chrono::Utc;
+use futures::TryStreamExt;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use sqlx::{Executor, Row, Sqlite, SqlitePool, Transaction};
+use tauri::Emitter;
+use tokio::fs::{self, File};
+use tokio::sync::mpsc;
+use tokio::task::yield_now;
+use tokio::time::{sleep, Duration};
+
+use crate::attachment_category::AttachmentCategory;
+use crate::files_indexer::{IndexProgress, IndexerState, RebuildMode};
+use crate::security::hash_path;
+use crate::vault::normalize_relative;
+use crate::vault::Vault;
+use crate::vault_migration::ATTACHMENT_TABLES;
+use crate::{AppError, AppResult};
+use uuid::Uuid;
+
+const EVENT_FILE_MOVE_PROGRESS: &str = "file_move_progress";
+const EVENT_ATTACHMENTS_REPAIR_PROGRESS: &str = "attachments_repair_progress";
+
+static REPAIR_CANCEL_FLAG: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConflictStrategy {
+    Rename,
+    Fail,
+}
+
+impl ConflictStrategy {
+    fn apply(&self, target: &Path) -> AppResult<(PathBuf, bool)> {
+        match self {
+            ConflictStrategy::Fail => {
+                if target.exists() {
+                    Err(AppError::new(
+                        "FILE_EXISTS",
+                        "Destination file already exists.",
+                    ))
+                } else {
+                    Ok((target.to_path_buf(), false))
+                }
+            }
+            ConflictStrategy::Rename => {
+                if !target.exists() {
+                    return Ok((target.to_path_buf(), false));
+                }
+                let resolved = resolve_conflict_name(target)?;
+                Ok((resolved, true))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FileMoveRequest {
+    pub household_id: String,
+    pub from_category: AttachmentCategory,
+    pub from_rel: String,
+    pub to_category: AttachmentCategory,
+    pub to_rel: String,
+    pub conflict: ConflictStrategy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileMoveResponse {
+    pub moved: u32,
+    pub renamed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepairActionKind {
+    Detach,
+    Mark,
+    Relink,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepairAction {
+    pub table_name: String,
+    pub row_id: i64,
+    pub action: RepairActionKind,
+    pub new_category: Option<AttachmentCategory>,
+    pub new_relative_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentsRepairMode {
+    Scan,
+    Apply,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AttachmentsRepairRequest {
+    pub household_id: String,
+    pub mode: AttachmentsRepairMode,
+    #[serde(default)]
+    pub actions: Vec<RepairAction>,
+    #[serde(default)]
+    pub cancel: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AttachmentsRepairResponse {
+    pub scanned: u64,
+    pub missing: u64,
+    pub repaired: u64,
+}
+
+pub async fn move_file<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    pool: SqlitePool,
+    vault: Arc<Vault>,
+    request: FileMoveRequest,
+) -> AppResult<FileMoveResponse> {
+    let from_hash = hash_path(Path::new(&request.from_rel));
+    let to_hash = hash_path(Path::new(&request.to_rel));
+    tracing::info!(
+        target = "arklowdun",
+        event = "file_move_started",
+        household_id = %request.household_id,
+        from_category = %request.from_category.as_str(),
+        from_relative_hash = %from_hash,
+        to_category = %request.to_category.as_str(),
+        to_relative_hash = %to_hash,
+        conflict = ?request.conflict,
+    );
+
+    let source_path = vault.resolve(
+        &request.household_id,
+        request.from_category,
+        &request.from_rel,
+    )?;
+
+    if !source_path.exists() {
+        return Err(AppError::new(
+            "FILE_MISSING",
+            "Source file could not be found in the vault.",
+        ));
+    }
+
+    let metadata = fs::metadata(&source_path)
+        .await
+        .map_err(|err| AppError::from(err).with_context("operation", "move_metadata"))?;
+    if metadata.is_dir() {
+        return Err(AppError::new(
+            "DIRECTORY_MOVE_UNSUPPORTED",
+            "Moving directories is not supported.",
+        ));
+    }
+
+    let normalized_from = normalize_relative(&request.from_rel).map_err(|err| {
+        AppError::from(err).with_context("operation", "normalize_source_relative")
+    })?;
+    let from_relative = normalized_from.to_string_lossy().replace('\\', "/");
+
+    let mut target_path =
+        vault.resolve(&request.household_id, request.to_category, &request.to_rel)?;
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|err| AppError::from(err).with_context("operation", "create_target_parent"))?;
+    }
+
+    let (final_path, renamed_due_to_conflict) = request.conflict.apply(&target_path)?;
+    target_path = final_path;
+
+    let staging_path = staging_path_for(&target_path);
+    emit_move_progress(&app, "moving", &request.to_rel, 0, 1);
+
+    let prepared_move = match stage_move(&source_path, &staging_path).await {
+        Ok(prepared) => prepared,
+        Err(err) => {
+            tracing::error!(
+                target = "arklowdun",
+                event = "file_move_stage_failed",
+                household_id = %request.household_id,
+                error = %err,
+            );
+            return Err(err);
+        }
+    };
+
+    let new_relative = vault
+        .relative_from_resolved(&target_path, &request.household_id, request.to_category)
+        .ok_or_else(|| {
+            AppError::new(
+                "RELATIVE_RESOLVE_FAILED",
+                "Unable to compute vault relative path for moved file.",
+            )
+        })?;
+
+    let normalized_new = normalize_relative(&new_relative).map_err(|err| {
+        AppError::from(err).with_context("operation", "normalize_target_relative")
+    })?;
+    let new_relative = normalized_new.to_string_lossy().replace('\\', "/");
+
+    let db_outcome = {
+        let pool = pool.clone();
+        async {
+            let mut tx = pool
+                .begin()
+                .await
+                .map_err(|err| AppError::from(err).with_context("operation", "file_move_begin_tx"))?;
+
+            let mut updated_rows = 0_u32;
+            for table in ATTACHMENT_TABLES {
+                let sql = if cfg!(target_os = "windows") {
+                    format!("UPDATE {table} SET category = ?1, relative_path = ?2 WHERE household_id = ?3 AND category = ?4 AND LOWER(relative_path) = LOWER(?5)")
+                } else {
+                    format!("UPDATE {table} SET category = ?1, relative_path = ?2 WHERE household_id = ?3 AND category = ?4 AND relative_path = ?5")
+                };
+                let result = sqlx::query(&sql)
+                    .bind(request.to_category.as_str())
+                    .bind(&new_relative)
+                    .bind(&request.household_id)
+                    .bind(request.from_category.as_str())
+                    .bind(&from_relative)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|err| {
+                        AppError::from(err)
+                            .with_context("operation", format!("file_move_update_{table}"))
+                    })?;
+                updated_rows += result.rows_affected() as u32;
+            }
+
+            let new_index_name = index_basename(&new_relative);
+            let from_index_name = index_basename(&from_relative);
+            let files_index_sql = if cfg!(target_os = "windows") {
+                "UPDATE files_index SET category = ?1, filename = ?2 WHERE household_id = ?3 AND category = ?4 AND LOWER(filename) = LOWER(?5)"
+            } else {
+                "UPDATE files_index SET category = ?1, filename = ?2 WHERE household_id = ?3 AND category = ?4 AND filename = ?5"
+            };
+            let files_index_result = sqlx::query(files_index_sql)
+                .bind(request.to_category.as_str())
+                .bind(&new_index_name)
+                .bind(&request.household_id)
+                .bind(request.from_category.as_str())
+                .bind(&from_index_name)
+                .execute(&mut *tx)
+                .await
+                .map_err(|err| {
+                    AppError::from(err).with_context("operation", "file_move_update_files_index")
+                })?;
+
+            updated_rows += files_index_result.rows_affected() as u32;
+
+            tx.commit()
+                .await
+                .map_err(|err| AppError::from(err).with_context("operation", "file_move_commit"))?;
+
+            Ok::<u32, AppError>(updated_rows)
+        }
+        .await
+    };
+
+    let updated_rows = match db_outcome {
+        Ok(rows) => rows,
+        Err(err) => {
+            if let Err(rollback_err) = prepared_move.rollback(&source_path).await {
+                tracing::error!(
+                    target = "arklowdun",
+                    event = "file_move_rollback_failed",
+                    household_id = %request.household_id,
+                    error = %rollback_err,
+                );
+            }
+            return Err(err);
+        }
+    };
+
+    prepared_move
+        .finalize(&source_path, &target_path)
+        .await
+        .map_err(|err| AppError::from(err).with_context("operation", "file_move_finalize"))?;
+
+    emit_move_progress(&app, "completed", &new_relative, 1, 1);
+
+    tracing::info!(
+        target = "arklowdun",
+        event = "file_move_completed",
+        household_id = %request.household_id,
+        from_category = %request.from_category.as_str(),
+        from_relative_hash = %from_hash,
+        to_category = %request.to_category.as_str(),
+        to_relative_hash = %hash_path(Path::new(&new_relative)),
+        rows_updated = updated_rows,
+        renamed = renamed_due_to_conflict,
+    );
+
+    schedule_index_rebuild(&app, &request.household_id);
+
+    Ok(FileMoveResponse {
+        moved: updated_rows,
+        renamed: renamed_due_to_conflict,
+    })
+}
+
+pub async fn attachments_repair<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    pool: SqlitePool,
+    vault: Arc<Vault>,
+    request: AttachmentsRepairRequest,
+) -> AppResult<AttachmentsRepairResponse> {
+    if request.cancel {
+        REPAIR_CANCEL_FLAG.store(true, Ordering::SeqCst);
+        tracing::info!(
+            target = "arklowdun",
+            event = "attachments_repair_cancel_requested",
+            household_id = %request.household_id,
+        );
+        return Ok(AttachmentsRepairResponse::default());
+    }
+
+    REPAIR_CANCEL_FLAG.store(false, Ordering::SeqCst);
+
+    tracing::info!(
+        target = "arklowdun",
+        event = "attachments_repair_started",
+        household_id = %request.household_id,
+        mode = ?request.mode,
+    );
+
+    let response = match request.mode {
+        AttachmentsRepairMode::Scan => {
+            run_repair_scan(&app, &pool, &vault, &request.household_id).await?
+        }
+        AttachmentsRepairMode::Apply => run_repair_apply(&app, &pool, &vault, &request).await?,
+    };
+
+    tracing::info!(
+        target = "arklowdun",
+        event = "attachments_repair_completed",
+        household_id = %request.household_id,
+        mode = ?request.mode,
+        scanned = response.scanned,
+        missing = response.missing,
+        repaired = response.repaired,
+    );
+
+    Ok(response)
+}
+
+async fn run_repair_scan<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    pool: &SqlitePool,
+    vault: &Arc<Vault>,
+    household_id: &str,
+) -> AppResult<AttachmentsRepairResponse> {
+    let mut scanned = 0_u64;
+    let mut missing = 0_u64;
+
+    let mut conn = pool.acquire().await.map_err(|err| {
+        AppError::from(err).with_context("operation", "attachments_repair_acquire")
+    })?;
+
+    'tables: for table in ATTACHMENT_TABLES {
+        let sql = format!(
+            "SELECT rowid AS row_id, category, relative_path FROM {table} WHERE household_id = ?1 AND deleted_at IS NULL AND relative_path IS NOT NULL",
+        );
+        let mut rows = sqlx::query(&sql).bind(household_id).fetch(&mut *conn);
+
+        while let Some(row) = rows.try_next().await.map_err(|err| {
+            AppError::from(err)
+                .with_context("operation", format!("attachments_repair_scan_{table}"))
+        })? {
+            if REPAIR_CANCEL_FLAG.load(Ordering::SeqCst) {
+                break 'tables;
+            }
+            scanned += 1;
+            let category: String = row.try_get("category").unwrap_or_default();
+            let relative_path: String = row.try_get("relative_path").unwrap_or_default();
+            if relative_path.trim().is_empty() {
+                continue;
+            }
+            let parsed_category =
+                AttachmentCategory::from_str(&category).unwrap_or(AttachmentCategory::Misc);
+            let resolved = match vault.resolve(household_id, parsed_category, &relative_path) {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+            if !resolved.exists() {
+                missing += 1;
+                record_missing(
+                    pool,
+                    household_id,
+                    table,
+                    row.try_get::<i64, _>("row_id").unwrap_or_default(),
+                    &category,
+                    &relative_path,
+                )
+                .await?;
+                emit_repair_progress(app, table, scanned, missing);
+            }
+
+            if scanned % 100 == 0 {
+                sleep(Duration::from_millis(10)).await;
+            } else {
+                yield_now().await;
+            }
+        }
+    }
+
+    if REPAIR_CANCEL_FLAG.load(Ordering::SeqCst) {
+        REPAIR_CANCEL_FLAG.store(false, Ordering::SeqCst);
+    }
+
+    Ok(AttachmentsRepairResponse {
+        scanned,
+        missing,
+        repaired: 0,
+    })
+}
+
+async fn run_repair_apply<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    pool: &SqlitePool,
+    vault: &Arc<Vault>,
+    request: &AttachmentsRepairRequest,
+) -> AppResult<AttachmentsRepairResponse> {
+    if request.actions.is_empty() {
+        return Err(AppError::new(
+            "REPAIR_ACTIONS_REQUIRED",
+            "No repair actions were provided.",
+        ));
+    }
+
+    let mut tx = pool.begin().await.map_err(|err| {
+        AppError::from(err).with_context("operation", "attachments_repair_apply_begin")
+    })?;
+
+    let mut repaired = 0_u64;
+    let mut processed = 0_u64;
+    let now = Utc::now().timestamp();
+
+    for action in &request.actions {
+        processed += 1;
+        if !ATTACHMENT_TABLES
+            .iter()
+            .any(|candidate| candidate == &action.table_name.as_str())
+        {
+            return Err(AppError::new(
+                "REPAIR_TABLE_UNSUPPORTED",
+                "Repair action references an unsupported attachment table.",
+            ));
+        }
+
+        match action.action {
+            RepairActionKind::Detach => {
+                let sql = format!(
+                    "UPDATE {table} SET category = NULL, relative_path = NULL WHERE household_id = ?1 AND rowid = ?2",
+                    table = action.table_name,
+                );
+                let result = sqlx::query(&sql)
+                    .bind(&request.household_id)
+                    .bind(action.row_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|err| {
+                        AppError::from(err).with_context(
+                            "operation",
+                            format!("attachments_repair_detach_{}", action.table_name),
+                        )
+                    })?;
+                if result.rows_affected() == 0 {
+                    return Err(AppError::new(
+                        "REPAIR_ROW_MISSING",
+                        "Attachment row could not be updated for detach action.",
+                    ));
+                }
+                repaired += result.rows_affected() as u64;
+                update_missing_manifest(
+                    &mut tx,
+                    &request.household_id,
+                    &action.table_name,
+                    action.row_id,
+                    "detach",
+                    None,
+                    None,
+                    now,
+                )
+                .await?;
+            }
+            RepairActionKind::Mark => {
+                update_missing_manifest(
+                    &mut tx,
+                    &request.household_id,
+                    &action.table_name,
+                    action.row_id,
+                    "mark",
+                    None,
+                    None,
+                    now,
+                )
+                .await?;
+                repaired += 1;
+            }
+            RepairActionKind::Relink => {
+                let new_category = action.new_category.ok_or_else(|| {
+                    AppError::new(
+                        "REPAIR_RELINK_CATEGORY_REQUIRED",
+                        "Relink action requires a new category.",
+                    )
+                })?;
+                let new_relative_raw = action.new_relative_path.clone().ok_or_else(|| {
+                    AppError::new(
+                        "REPAIR_RELINK_RELATIVE_REQUIRED",
+                        "Relink action requires a new relative path.",
+                    )
+                })?;
+                let normalized = normalize_relative(&new_relative_raw).map_err(|err| {
+                    AppError::from(err).with_context("operation", "normalize_repair_relink")
+                })?;
+                let new_relative = normalized.to_string_lossy().replace('\\', "/");
+                let resolved = vault.resolve(&request.household_id, new_category, &new_relative)?;
+                if !resolved.exists() {
+                    return Err(AppError::new(
+                        "REPAIR_RELINK_TARGET_MISSING",
+                        "Relink target file does not exist in the vault.",
+                    ));
+                }
+                let metadata = fs::metadata(&resolved).await.map_err(|err| {
+                    AppError::from(err).with_context("operation", "relink_metadata")
+                })?;
+                if metadata.is_dir() {
+                    return Err(AppError::new(
+                        "REPAIR_RELINK_TARGET_INVALID",
+                        "Relink target must be a file.",
+                    ));
+                }
+                let sql = format!(
+                    "UPDATE {table} SET category = ?1, relative_path = ?2 WHERE household_id = ?3 AND rowid = ?4",
+                    table = action.table_name,
+                );
+                let result = sqlx::query(&sql)
+                    .bind(new_category.as_str())
+                    .bind(&new_relative)
+                    .bind(&request.household_id)
+                    .bind(action.row_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|err| {
+                        AppError::from(err).with_context(
+                            "operation",
+                            format!("attachments_repair_relink_{}", action.table_name),
+                        )
+                    })?;
+                if result.rows_affected() == 0 {
+                    return Err(AppError::new(
+                        "REPAIR_ROW_MISSING",
+                        "Attachment row could not be updated for relink action.",
+                    ));
+                }
+                repaired += result.rows_affected() as u64;
+                update_missing_manifest(
+                    &mut tx,
+                    &request.household_id,
+                    &action.table_name,
+                    action.row_id,
+                    "relink",
+                    Some(new_category.as_str()),
+                    Some(&new_relative),
+                    now,
+                )
+                .await?;
+            }
+        }
+
+        if processed % 25 == 0 {
+            yield_now().await;
+        }
+    }
+
+    tx.commit().await.map_err(|err| {
+        AppError::from(err).with_context("operation", "attachments_repair_apply_commit")
+    })?;
+
+    let remaining_missing = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM missing_attachments WHERE household_id = ?1 AND repaired_at_utc IS NULL",
+    )
+    .bind(&request.household_id)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+
+    schedule_index_rebuild(app, &request.household_id);
+
+    Ok(AttachmentsRepairResponse {
+        scanned: processed,
+        missing: remaining_missing as u64,
+        repaired,
+    })
+}
+
+async fn update_missing_manifest(
+    tx: &mut Transaction<'_, Sqlite>,
+    household_id: &str,
+    table_name: &str,
+    row_id: i64,
+    action: &str,
+    new_category: Option<&str>,
+    new_relative_path: Option<&str>,
+    timestamp: i64,
+) -> AppResult<()> {
+    let result = sqlx::query(
+        "UPDATE missing_attachments SET action = ?1, new_category = ?2, new_relative_path = ?3, repaired_at_utc = ?4 WHERE household_id = ?5 AND table_name = ?6 AND row_id = ?7",
+    )
+    .bind(action)
+    .bind(new_category)
+    .bind(new_relative_path)
+    .bind(timestamp)
+    .bind(household_id)
+    .bind(table_name)
+    .bind(row_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|err| {
+        AppError::from(err).with_context("operation", "attachments_repair_update_manifest")
+    })?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::new(
+            "REPAIR_MANIFEST_MISSING",
+            "Missing attachment record was not found in manifest.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn staging_path_for(target: &Path) -> PathBuf {
+    let parent = target
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    parent.join(format!(".arkmove-{}", Uuid::new_v4()))
+}
+
+enum PreparedMove {
+    Rename { staging: PathBuf },
+    Copy { staging: PathBuf },
+}
+
+impl PreparedMove {
+    async fn rollback(&self, source: &Path) -> AppResult<()> {
+        match self {
+            PreparedMove::Rename { staging } => {
+                if staging.exists() {
+                    fs::rename(staging, source).await.map_err(|err| {
+                        AppError::from(err).with_context("operation", "file_move_rollback_rename")
+                    })?;
+                }
+            }
+            PreparedMove::Copy { staging } => {
+                if staging.exists() {
+                    fs::remove_file(staging).await.map_err(|err| {
+                        AppError::from(err).with_context("operation", "file_move_rollback_copy")
+                    })?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn finalize(self, source: &Path, target: &Path) -> std::io::Result<()> {
+        match self {
+            PreparedMove::Rename { staging } => fs::rename(&staging, target).await,
+            PreparedMove::Copy { staging } => {
+                fs::rename(&staging, target).await?;
+                fs::remove_file(source).await
+            }
+        }
+    }
+}
+
+async fn stage_move(source: &Path, staging: &Path) -> AppResult<PreparedMove> {
+    match fs::rename(source, staging).await {
+        Ok(_) => Ok(PreparedMove::Rename {
+            staging: staging.to_path_buf(),
+        }),
+        Err(err) if err.kind() == std::io::ErrorKind::CrossDeviceLink => {
+            fs::copy(source, staging).await.map_err(|copy_err| {
+                AppError::from(copy_err).with_context("operation", "copy_cross_volume")
+            })?;
+            verify_same_content(source, staging).await?;
+            let mut handle = File::open(staging).await.map_err(|io_err| {
+                AppError::from(io_err).with_context("operation", "open_stage_file")
+            })?;
+            handle.sync_all().await.map_err(|io_err| {
+                AppError::from(io_err).with_context("operation", "sync_stage_file")
+            })?;
+            Ok(PreparedMove::Copy {
+                staging: staging.to_path_buf(),
+            })
+        }
+        Err(err) => Err(AppError::from(err).with_context("operation", "rename_attachment")),
+    }
+}
+
+async fn verify_same_content(source: &Path, staged: &Path) -> AppResult<()> {
+    let source_meta = fs::metadata(source)
+        .await
+        .map_err(|err| AppError::from(err).with_context("operation", "metadata_source"))?;
+    let staged_meta = fs::metadata(staged)
+        .await
+        .map_err(|err| AppError::from(err).with_context("operation", "metadata_stage"))?;
+
+    if source_meta.len() != staged_meta.len() {
+        return Err(AppError::new(
+            "COPY_VERIFICATION_FAILED",
+            "Cross-volume copy verification failed due to size mismatch.",
+        ));
+    }
+
+    if let (Ok(src_mtime), Ok(dst_mtime)) = (source_meta.modified(), staged_meta.modified()) {
+        if src_mtime != dst_mtime {
+            return Err(AppError::new(
+                "COPY_VERIFICATION_FAILED",
+                "Cross-volume copy verification failed due to timestamp mismatch.",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn index_basename(relative: &str) -> String {
+    Path::new(relative)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| relative.to_string())
+}
+
+fn schedule_index_rebuild<R: tauri::Runtime>(app: &tauri::AppHandle<R>, household_id: &str) {
+    let state_guard = app.state::<crate::state::AppState>();
+    let indexer = state_guard.files_indexer();
+    if indexer.current_state(household_id) != IndexerState::Idle {
+        return;
+    }
+    let hh = household_id.to_string();
+    let app_handle = app.clone();
+    let indexer_clone = indexer.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let (tx, mut rx) = mpsc::channel::<IndexProgress>(16);
+        let progress_app = app_handle.clone();
+        let progress_household = hh.clone();
+        tauri::async_runtime::spawn(async move {
+            while let Some(progress) = rx.recv().await {
+                let payload = serde_json::json!({
+                    "household_id": progress_household,
+                    "scanned": progress.scanned,
+                    "updated": progress.updated,
+                    "skipped": progress.skipped,
+                });
+                if let Err(err) = progress_app.emit("files_index_progress", payload) {
+                    tracing::warn!(
+                        target = "arklowdun",
+                        event = "files_index_progress_emit_failed",
+                        error = %err,
+                    );
+                    break;
+                }
+            }
+        });
+
+        if let Err(err) = indexer_clone
+            .rebuild(&hh, RebuildMode::Incremental, tx)
+            .await
+        {
+            tracing::warn!(
+                target = "arklowdun",
+                event = "files_index_rebuild_failed",
+                household_id = %hh,
+                error = %err,
+            );
+        }
+    });
+}
+
+fn emit_move_progress<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    stage: &str,
+    file: &str,
+    done: u64,
+    total: u64,
+) {
+    let payload = serde_json::json!({
+        "stage": stage,
+        "file": file,
+        "done": done,
+        "total": total,
+    });
+    if let Err(err) = app.emit(EVENT_FILE_MOVE_PROGRESS, payload) {
+        tracing::warn!(
+            target = "arklowdun",
+            event = "file_move_emit_failed",
+            error = %err,
+        );
+    }
+}
+
+fn emit_repair_progress<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    table: &str,
+    scanned: u64,
+    missing: u64,
+) {
+    let payload = serde_json::json!({
+        "table": table,
+        "scanned": scanned,
+        "missing": missing,
+    });
+    if let Err(err) = app.emit(EVENT_ATTACHMENTS_REPAIR_PROGRESS, payload) {
+        tracing::warn!(
+            target = "arklowdun",
+            event = "attachments_repair_emit_failed",
+            error = %err,
+        );
+    }
+}
+
+fn resolve_conflict_name(target: &Path) -> AppResult<PathBuf> {
+    let parent = target.parent().map(Path::to_path_buf).unwrap_or_default();
+    let stem = target
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "file".to_string());
+    let extension = target.extension().and_then(OsStr::to_str);
+
+    for suffix in 1..=9999 {
+        let candidate = if let Some(ext) = extension {
+            parent.join(format!("{stem} ({suffix}).{ext}"))
+        } else {
+            parent.join(format!("{stem} ({suffix})"))
+        };
+        match std::fs::metadata(&candidate) {
+            Ok(_) => continue,
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(candidate);
+                }
+                return Err(AppError::from(err).with_context("operation", "resolve_conflict_name"));
+            }
+        }
+    }
+
+    Err(AppError::new(
+        "CONFLICT_RESOLUTION_FAILED",
+        "Unable to resolve a unique filename for the destination.",
+    ))
+}
+
+async fn record_missing(
+    pool: &SqlitePool,
+    household_id: &str,
+    table: &str,
+    row_id: i64,
+    category: &str,
+    relative_path: &str,
+) -> AppResult<()> {
+    let now = Utc::now().timestamp();
+    sqlx::query(
+        "INSERT OR REPLACE INTO missing_attachments (household_id, table_name, row_id, category, relative_path, detected_at_utc) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )
+    .bind(household_id)
+    .bind(table)
+    .bind(row_id)
+    .bind(category)
+    .bind(relative_path)
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(|err| AppError::from(err).with_context("operation", "attachments_repair_record_missing"))?;
+    Ok(())
+}

--- a/src/api/fileOps.ts
+++ b/src/api/fileOps.ts
@@ -1,0 +1,80 @@
+import type { AttachmentCategory } from "@bindings/AttachmentCategory";
+
+import { call } from "@lib/ipc/call";
+
+export type ConflictStrategy = "rename" | "fail";
+
+export interface MoveFileParams {
+  householdId: string;
+  fromCategory: AttachmentCategory;
+  fromRelativePath: string;
+  toCategory: AttachmentCategory;
+  toRelativePath: string;
+  conflict?: ConflictStrategy;
+}
+
+export interface MoveFileResult {
+  moved: number;
+  renamed: boolean;
+}
+
+export type AttachmentsRepairMode = "scan" | "apply";
+
+export interface AttachmentsRepairAction {
+  tableName: string;
+  rowId: number;
+  action: "detach" | "mark" | "relink";
+  newCategory?: AttachmentCategory;
+  newRelativePath?: string;
+}
+
+export interface AttachmentsRepairParams {
+  householdId: string;
+  mode: AttachmentsRepairMode;
+  actions?: AttachmentsRepairAction[];
+  cancel?: boolean;
+}
+
+export interface AttachmentsRepairResult {
+  scanned: number;
+  missing: number;
+  repaired: number;
+}
+
+export function moveFile(params: MoveFileParams): Promise<MoveFileResult> {
+  const payload = {
+    household_id: params.householdId,
+    from_category: params.fromCategory,
+    from_rel: params.fromRelativePath,
+    to_category: params.toCategory,
+    to_rel: params.toRelativePath,
+    conflict: params.conflict ?? "rename",
+  } as const;
+  return call("file_move", payload) as Promise<MoveFileResult>;
+}
+
+export function runAttachmentsRepair(
+  params: AttachmentsRepairParams,
+): Promise<AttachmentsRepairResult> {
+  const payload = {
+    household_id: params.householdId,
+    mode: params.mode,
+    cancel: params.cancel ?? false,
+    actions: params.actions?.map((action) => ({
+      table_name: action.tableName,
+      row_id: action.rowId,
+      action: action.action,
+      new_category: action.newCategory,
+      new_relative_path: action.newRelativePath,
+    })),
+  } as const;
+  return call("attachments_repair", payload) as Promise<AttachmentsRepairResult>;
+}
+
+export function cancelAttachmentsRepair(householdId: string): Promise<void> {
+  return call("attachments_repair", {
+    household_id: householdId,
+    mode: "scan",
+    cancel: true,
+  }) as Promise<void>;
+}

--- a/src/features/settings/components/StorageVaultView.ts
+++ b/src/features/settings/components/StorageVaultView.ts
@@ -1,6 +1,16 @@
 import { listen } from "@tauri-apps/api/event";
 
-import { call } from "@lib/ipc/call";
+import {
+  cancelAttachmentsRepair,
+  moveFile,
+  runAttachmentsRepair,
+} from "@api/fileOps";
+import type {
+  AttachmentsRepairAction,
+  AttachmentsRepairMode,
+  ConflictStrategy,
+} from "@api/fileOps";
+import type { AttachmentCategory } from "@bindings/AttachmentCategory";
 import {
   cancelIndexRebuild,
   getIndexStatus,
@@ -11,6 +21,7 @@ import {
 } from "@lib/files/indexer";
 
 import createButton from "@ui/Button";
+import createInput from "@ui/Input";
 import toast from "@ui/Toast";
 
 import {
@@ -20,6 +31,7 @@ import {
   type MigrationMode,
   type MigrationProgress,
 } from "../api/vaultMigration";
+import { openPath } from "../api/opener";
 
 export const vaultMigrationUiEnabled =
   (import.meta.env.VITE_VAULT_MIGRATION_UI ?? "true") !== "false";
@@ -42,11 +54,41 @@ const MODE_STATUS: Record<MigrationMode, string> = {
   apply: "Applying migration",
 };
 
+const ATTACHMENT_CATEGORIES: AttachmentCategory[] = [
+  "bills",
+  "policies",
+  "property_documents",
+  "inventory_items",
+  "pet_medical",
+  "vehicles",
+  "vehicle_maintenance",
+  "notes",
+  "misc",
+];
+
 function formatCounts(counts: MigrationProgress["counts"]): string {
   return `Processed ${counts.processed} · Copied ${counts.copied} · Conflicts ${counts.conflicts} · Skipped ${counts.skipped} · Unsupported ${counts.unsupported}`;
 }
 
 export function createStorageVaultView(): StorageVaultViewInstance {
+  const makeCategorySelect = (placeholder: string): HTMLSelectElement => {
+    const select = document.createElement("select");
+    select.className = "storage__maintenance-select";
+    const placeholderOption = document.createElement("option");
+    placeholderOption.value = "";
+    placeholderOption.textContent = placeholder;
+    placeholderOption.disabled = true;
+    placeholderOption.selected = true;
+    select.appendChild(placeholderOption);
+    for (const category of ATTACHMENT_CATEGORIES) {
+      const option = document.createElement("option");
+      option.value = category;
+      option.textContent = category.replace(/_/g, " ");
+      select.appendChild(option);
+    }
+    return select;
+  };
+
   const section = document.createElement("section");
   section.className = "card settings__section settings__section--storage";
   section.setAttribute("aria-labelledby", "settings-storage");
@@ -92,7 +134,7 @@ export function createStorageVaultView(): StorageVaultViewInstance {
   manifestLink.addEventListener("click", (event) => {
     event.preventDefault();
     if (!state.latest?.manifest_path) return;
-    void call("open_path", { path: state.latest.manifest_path }).catch((error: unknown) => {
+    void openPath(state.latest.manifest_path).catch((error: unknown) => {
       const message = (error as { message?: string })?.message ?? "Unable to open manifest.";
       toast.show({ kind: "error", message });
     });
@@ -177,6 +219,142 @@ export function createStorageVaultView(): StorageVaultViewInstance {
     indexControls,
   );
 
+  const maintenanceSection = document.createElement("div");
+  maintenanceSection.className = "storage__maintenance";
+
+  const maintenanceHeading = document.createElement("h4");
+  maintenanceHeading.className = "storage__maintenance-title";
+  maintenanceHeading.textContent = "Maintenance tools";
+
+  const householdField = document.createElement("div");
+  householdField.className = "storage__maintenance-field";
+  const householdLabel = document.createElement("label");
+  householdLabel.className = "storage__maintenance-label";
+  householdLabel.textContent = "Household ID";
+  const householdInput = createInput({
+    id: "storage-maintenance-household",
+    placeholder: "Household ID",
+    className: "storage__maintenance-input",
+  });
+  householdLabel.setAttribute("for", "storage-maintenance-household");
+  householdField.append(householdLabel, householdInput);
+
+  const moveGroup = document.createElement("div");
+  moveGroup.className = "storage__maintenance-group";
+  const moveTitle = document.createElement("h5");
+  moveTitle.className = "storage__maintenance-heading";
+  moveTitle.textContent = "Move or rename";
+  const moveFields = document.createElement("div");
+  moveFields.className = "storage__maintenance-row";
+  const fromCategorySelect = makeCategorySelect("From category");
+  const fromRelInput = createInput({
+    placeholder: "From relative path",
+    className: "storage__maintenance-input",
+  });
+  const toCategorySelect = makeCategorySelect("To category");
+  const toRelInput = createInput({
+    placeholder: "To relative path",
+    className: "storage__maintenance-input",
+  });
+  const conflictSelect = document.createElement("select");
+  conflictSelect.className = "storage__maintenance-select";
+  const renameOption = document.createElement("option");
+  renameOption.value = "rename";
+  renameOption.textContent = "Rename on conflict";
+  const failOption = document.createElement("option");
+  failOption.value = "fail";
+  failOption.textContent = "Fail on conflict";
+  conflictSelect.append(renameOption, failOption);
+  conflictSelect.value = "rename";
+  const moveActionButton = createButton({
+    label: "Move file",
+    variant: "primary",
+    size: "sm",
+    className: "storage__maintenance-action",
+  });
+  moveFields.append(
+    fromCategorySelect,
+    fromRelInput,
+    toCategorySelect,
+    toRelInput,
+    conflictSelect,
+    moveActionButton,
+  );
+  const moveStatus = document.createElement("p");
+  moveStatus.className = "storage__maintenance-status";
+  moveStatus.hidden = true;
+  moveGroup.append(moveTitle, moveFields, moveStatus);
+
+  const repairGroup = document.createElement("div");
+  repairGroup.className = "storage__maintenance-group";
+  const repairTitle = document.createElement("h5");
+  repairTitle.className = "storage__maintenance-heading";
+  repairTitle.textContent = "Scan & repair";
+  const repairControls = document.createElement("div");
+  repairControls.className = "storage__maintenance-row";
+  const repairScanButton = createButton({
+    label: "Scan for missing attachments",
+    variant: "ghost",
+    size: "sm",
+    className: "storage__maintenance-action",
+  });
+  const repairApplyButton = createButton({
+    label: "Apply recorded actions",
+    variant: "ghost",
+    size: "sm",
+    className: "storage__maintenance-action",
+  });
+  const repairLoadManifestButton = createButton({
+    label: "Load manifest",
+    variant: "ghost",
+    size: "sm",
+    className: "storage__maintenance-action",
+  });
+  const repairCancelButton = createButton({
+    label: "Cancel",
+    variant: "ghost",
+    size: "sm",
+    className: "storage__maintenance-action",
+    disabled: true,
+  });
+  const repairProgress = document.createElement("progress");
+  repairProgress.className = "storage__maintenance-progress";
+  repairProgress.max = 1;
+  repairProgress.value = 0;
+  repairProgress.hidden = true;
+  const repairStatus = document.createElement("p");
+  repairStatus.className = "storage__maintenance-status";
+  repairStatus.hidden = true;
+  const repairManifestInput = document.createElement("input");
+  repairManifestInput.type = "file";
+  repairManifestInput.accept = ".json";
+  repairManifestInput.hidden = true;
+  const repairManifestNote = document.createElement("p");
+  repairManifestNote.className = "storage__maintenance-note";
+  repairManifestNote.hidden = true;
+  repairControls.append(
+    repairScanButton,
+    repairApplyButton,
+    repairLoadManifestButton,
+    repairCancelButton,
+  );
+  repairApplyButton.update({ disabled: true });
+  repairGroup.append(
+    repairTitle,
+    repairControls,
+    repairProgress,
+    repairStatus,
+    repairManifestNote,
+    repairManifestInput,
+  );
+
+  maintenanceSection.append(
+    maintenanceHeading,
+    householdField,
+    moveGroup,
+    repairGroup,
+  );
+
   const state: {
     running: boolean;
     mode: MigrationMode | null;
@@ -186,6 +364,18 @@ export function createStorageVaultView(): StorageVaultViewInstance {
       householdId: string | null;
       status: FilesIndexStatus | null;
       progress: { scanned: number; updated: number; skipped: number };
+    };
+    maintenance: {
+      move: {
+        running: boolean;
+      };
+      repair: {
+        running: boolean;
+        scanned: number;
+        missing: number;
+        actions: AttachmentsRepairAction[];
+        manifestName: string | null;
+      };
     };
   } = {
     running: false,
@@ -197,7 +387,288 @@ export function createStorageVaultView(): StorageVaultViewInstance {
       status: null,
       progress: { scanned: 0, updated: 0, skipped: 0 },
     },
+    maintenance: {
+      move: {
+        running: false,
+      },
+      repair: {
+        running: false,
+        scanned: 0,
+        missing: 0,
+        actions: [],
+        manifestName: null,
+      },
+    },
   };
+
+  const updateRepairActionsSummary = (): void => {
+    const { actions, manifestName } = state.maintenance.repair;
+    if (actions.length > 0) {
+      const source = manifestName ? ` from ${manifestName}` : "";
+      repairManifestNote.hidden = false;
+      repairManifestNote.textContent = `Loaded ${actions.length} actions${source}.`;
+    } else {
+      repairManifestNote.hidden = true;
+      repairManifestNote.textContent = "";
+    }
+    if (!state.maintenance.repair.running) {
+      repairApplyButton.update({ disabled: actions.length === 0 });
+    }
+  };
+
+  const requireHouseholdId = (): string | null => {
+    const value = householdInput.value.trim();
+    if (!value) {
+      toast.show({ kind: "error", message: "Household ID is required." });
+      householdInput.focus();
+      return null;
+    }
+    return value;
+  };
+
+  const ensureCategory = (value: string, label: string): AttachmentCategory | null => {
+    if (!value) {
+      toast.show({
+        kind: "error",
+        message: `${label} is required.`,
+      });
+      return null;
+    }
+    return value as AttachmentCategory;
+  };
+
+  const updateMoveStatus = (message: string, isError = false): void => {
+    moveStatus.hidden = false;
+    moveStatus.textContent = message;
+    moveStatus.dataset.status = isError ? "error" : "info";
+  };
+
+  const updateRepairStatus = (message: string, isError = false): void => {
+    repairStatus.hidden = false;
+    repairStatus.textContent = message;
+    repairStatus.dataset.status = isError ? "error" : "info";
+  };
+
+  repairLoadManifestButton.addEventListener("click", () => {
+    repairManifestInput.value = "";
+    repairManifestInput.click();
+  });
+
+  repairManifestInput.addEventListener("change", async () => {
+    const file = repairManifestInput.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as unknown;
+      if (!Array.isArray(parsed)) {
+        throw new Error("Manifest must be an array of repair actions.");
+      }
+      const actions: AttachmentsRepairAction[] = parsed.map((entry) => {
+        if (typeof entry !== "object" || entry === null) {
+          throw new Error("Manifest entries must be objects.");
+        }
+        interface ManifestEntry {
+          table_name?: unknown;
+          tableName?: unknown;
+          row_id?: unknown;
+          rowId?: unknown;
+          action?: unknown;
+          action_type?: unknown;
+          type?: unknown;
+          new_category?: unknown;
+          newCategory?: unknown;
+          new_relative_path?: unknown;
+          newRelativePath?: unknown;
+        }
+        const candidate = entry as ManifestEntry;
+        const tableNameValue = candidate.table_name ?? candidate.tableName;
+        if (typeof tableNameValue !== "string" || tableNameValue.length === 0) {
+          throw new Error("Manifest entry missing table name.");
+        }
+        const rowIdValue = candidate.row_id ?? candidate.rowId;
+        const rowId = Number(rowIdValue);
+        if (!Number.isInteger(rowId)) {
+          throw new Error("Manifest entry row_id must be an integer.");
+        }
+        const actionValueRaw = candidate.action ?? candidate.action_type ?? candidate.type;
+        if (typeof actionValueRaw !== "string") {
+          throw new Error("Manifest entry has unsupported action type.");
+        }
+        const actionValue = actionValueRaw as AttachmentsRepairAction["action"];
+        if (!["detach", "mark", "relink"].includes(actionValue)) {
+          throw new Error("Manifest entry has unsupported action type.");
+        }
+        const categoryRaw = candidate.new_category ?? candidate.newCategory;
+        const relativeRaw = candidate.new_relative_path ?? candidate.newRelativePath;
+        const action: AttachmentsRepairAction = {
+          tableName: tableNameValue,
+          rowId,
+          action: actionValue,
+        };
+        if (typeof categoryRaw === "string" && categoryRaw.length > 0) {
+          action.newCategory = categoryRaw as AttachmentCategory;
+        }
+        if (typeof relativeRaw === "string" && relativeRaw.trim().length > 0) {
+          action.newRelativePath = relativeRaw;
+        }
+        return action;
+      });
+      state.maintenance.repair.actions = actions;
+      state.maintenance.repair.manifestName = file.name;
+      updateRepairActionsSummary();
+      toast.show({
+        kind: "success",
+        message: `Loaded ${actions.length} repair action${actions.length === 1 ? "" : "s"}.`,
+      });
+    } catch (error) {
+      state.maintenance.repair.actions = [];
+      state.maintenance.repair.manifestName = null;
+      updateRepairActionsSummary();
+      const message =
+        (error as { message?: string })?.message ?? "Unable to load repair manifest.";
+      toast.show({ kind: "error", message });
+    }
+  });
+
+  repairCancelButton.addEventListener("click", async () => {
+    if (!state.maintenance.repair.running) return;
+    const householdId = householdInput.value.trim();
+    if (!householdId) {
+      toast.show({ kind: "error", message: "Household ID is required." });
+      return;
+    }
+    repairCancelButton.update({ disabled: true });
+    try {
+      await cancelAttachmentsRepair(householdId);
+      updateRepairStatus("Cancellation requested. Finishing current batch…");
+    } catch (error) {
+      const message = (error as { message?: string })?.message ?? "Unable to cancel repair.";
+      toast.show({ kind: "error", message });
+      repairCancelButton.update({ disabled: false });
+    }
+  });
+
+  async function performMove(): Promise<void> {
+    if (state.maintenance.move.running) return;
+    const householdId = requireHouseholdId();
+    if (!householdId) return;
+
+    const fromCategory = ensureCategory(
+      fromCategorySelect.value,
+      "Source category",
+    );
+    const toCategory = ensureCategory(
+      toCategorySelect.value,
+      "Destination category",
+    );
+    const fromRelative = fromRelInput.value.trim();
+    const toRelative = toRelInput.value.trim();
+
+    if (!fromCategory || !toCategory) return;
+    if (!fromRelative || !toRelative) {
+      toast.show({
+        kind: "error",
+        message: "Relative paths are required.",
+      });
+      return;
+    }
+
+    state.maintenance.move.running = true;
+    moveActionButton.update({ disabled: true });
+    updateMoveStatus("Moving file…");
+    try {
+      const result = await moveFile({
+        householdId,
+        fromCategory,
+        fromRelativePath: fromRelative,
+        toCategory,
+        toRelativePath: toRelative,
+        conflict: conflictSelect.value as ConflictStrategy,
+      });
+      const renameNote = result.renamed ? " (renamed)" : "";
+      updateMoveStatus(
+        `Updated ${result.moved} references${renameNote}.`,
+        false,
+      );
+      toast.show({ kind: "success", message: "File move completed." });
+    } catch (error) {
+      const message = (error as { message?: string })?.message ?? "File move failed.";
+      updateMoveStatus(message, true);
+      toast.show({ kind: "error", message });
+    } finally {
+      state.maintenance.move.running = false;
+      moveActionButton.update({ disabled: false });
+    }
+  }
+
+  async function runRepair(
+    mode: AttachmentsRepairMode,
+    actions?: AttachmentsRepairAction[],
+  ): Promise<void> {
+    if (state.maintenance.repair.running) return;
+    const householdId = requireHouseholdId();
+    if (!householdId) return;
+
+    let payloadActions: AttachmentsRepairAction[] | undefined;
+    if (mode === "apply") {
+      const active = actions ?? state.maintenance.repair.actions;
+      if (!active.length) {
+        toast.show({
+          kind: "error",
+          message: "Load a repair manifest before applying actions.",
+        });
+        return;
+      }
+      payloadActions = active;
+    }
+
+    state.maintenance.repair.running = true;
+    repairScanButton.update({ disabled: true });
+    repairApplyButton.update({ disabled: true });
+    repairLoadManifestButton.update({ disabled: true });
+    repairCancelButton.update({ disabled: false });
+    repairProgress.hidden = false;
+    repairProgress.removeAttribute("value");
+    updateRepairStatus(
+      mode === "scan"
+        ? "Scanning attachments…"
+        : "Applying recorded actions…",
+    );
+    try {
+      const result = await runAttachmentsRepair({
+        householdId,
+        mode,
+        actions: payloadActions,
+      });
+      state.maintenance.repair.scanned = result.scanned;
+      state.maintenance.repair.missing = result.missing;
+      const parts = [`Scanned ${result.scanned}`, `Missing ${result.missing}`];
+      if (result.repaired) {
+        parts.push(`Repaired ${result.repaired}`);
+      }
+      updateRepairStatus(parts.join(" · "));
+      toast.show({ kind: "success", message: `Repair ${mode} completed.` });
+      if (mode === "apply") {
+        state.maintenance.repair.actions = [];
+        state.maintenance.repair.manifestName = null;
+      } else if (result.missing > 0) {
+        repairApplyButton.update({
+          disabled: state.maintenance.repair.actions.length === 0,
+        });
+      }
+    } catch (error) {
+      const message = (error as { message?: string })?.message ?? "Repair run failed.";
+      updateRepairStatus(message, true);
+      toast.show({ kind: "error", message });
+    } finally {
+      state.maintenance.repair.running = false;
+      repairScanButton.update({ disabled: false });
+      repairLoadManifestButton.update({ disabled: false });
+      repairCancelButton.update({ disabled: true });
+      updateRepairActionsSummary();
+      repairProgress.hidden = true;
+    }
+  }
 
   function updateUi(): void {
     const status = state.latest;
@@ -468,6 +939,21 @@ export function createStorageVaultView(): StorageVaultViewInstance {
     void resume();
   });
 
+  moveActionButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    void performMove();
+  });
+
+  repairScanButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    void runRepair("scan");
+  });
+
+  repairApplyButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    void runRepair("apply", state.maintenance.repair.actions);
+  });
+
   indexRebuildButton.addEventListener("click", (event) => {
     event.preventDefault();
     void startIndexRebuild();
@@ -502,6 +988,41 @@ export function createStorageVaultView(): StorageVaultViewInstance {
     state.mode = null;
     updateUi();
   }).then((unlisten) => {
+    state.unlisten.push(unlisten);
+  });
+
+  void listen<{ stage?: string; file?: string; done?: number; total?: number }>(
+    "file_move_progress",
+    (event) => {
+      const payload = event.payload;
+      if (!payload) return;
+      const file = payload.file ?? "";
+      if (payload.stage === "completed") {
+        updateMoveStatus(`Completed: ${file}`);
+      } else {
+        const done = Number(payload.done ?? 0);
+        const total = Number(payload.total ?? 0);
+        const progress = total > 0 ? `${done}/${total}` : `${done}`;
+        updateMoveStatus(`Moving ${file} (${progress})`);
+      }
+    },
+  ).then((unlisten) => {
+    state.unlisten.push(unlisten);
+  });
+
+  void listen<{ table?: string; scanned?: number; missing?: number }>(
+    "attachments_repair_progress",
+    (event) => {
+      const payload = event.payload;
+      if (!payload) return;
+      const table = payload.table ?? "";
+      const scanned = Number(payload.scanned ?? 0);
+      const missing = Number(payload.missing ?? 0);
+      updateRepairStatus(
+        `Scanning ${table || "attachments"}: ${scanned} scanned · ${missing} missing`,
+      );
+    },
+  ).then((unlisten) => {
     state.unlisten.push(unlisten);
   });
 
@@ -558,6 +1079,8 @@ export function createStorageVaultView(): StorageVaultViewInstance {
     state.unlisten.push(unlisten);
   });
 
+  updateRepairActionsSummary();
+
   section.append(
     statusWrapper,
     helper,
@@ -566,6 +1089,7 @@ export function createStorageVaultView(): StorageVaultViewInstance {
     progressNote,
     summary,
     indexSection,
+    maintenanceSection,
   );
 
   return {

--- a/src/lib/ipc/contracts/index.ts
+++ b/src/lib/ipc/contracts/index.ts
@@ -96,6 +96,50 @@ const filesIndexRebuildRequest = filesIndexRequestBase
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "household id required" });
   });
 
+const attachmentCategory = z.enum([
+  "bills",
+  "policies",
+  "property_documents",
+  "inventory_items",
+  "pet_medical",
+  "vehicles",
+  "vehicle_maintenance",
+  "notes",
+  "misc",
+]);
+
+const conflictStrategy = z.enum(["rename", "fail"]);
+const attachmentsRepairMode = z.enum(["scan", "apply"]);
+
+const fileMoveRequest = z
+  .object({
+    household_id: z.string(),
+    from_category: attachmentCategory,
+    from_rel: z.string().min(1),
+    to_category: attachmentCategory,
+    to_rel: z.string().min(1),
+    conflict: conflictStrategy.optional(),
+  })
+  .passthrough();
+
+const fileMoveResponse = z.object({
+  moved: z.number(),
+  renamed: z.boolean(),
+});
+
+const attachmentsRepairRequest = z
+  .object({
+    household_id: z.string(),
+    mode: attachmentsRepairMode,
+  })
+  .passthrough();
+
+const attachmentsRepairResponse = z.object({
+  scanned: z.number(),
+  missing: z.number(),
+  repaired: z.number(),
+});
+
 const householdDeleteResponse = z
   .object({ fallbackId: z.string().nullable().optional() })
   .passthrough();
@@ -272,6 +316,10 @@ export const contracts = {
   about_metadata: contract({ request: flexibleRequest, response: flexibleRequest }),
   attachment_open: contract({ request: flexibleRequest, response: z.null() }),
   attachment_reveal: contract({ request: flexibleRequest, response: z.null() }),
+  attachments_repair: contract({
+    request: attachmentsRepairRequest,
+    response: attachmentsRepairResponse,
+  }),
   bills_list: contract({ request: flexibleRequest, response: z.array(flexibleRequest) }),
   bills_get: contract({ request: flexibleRequest, response: flexibleRequest.nullable() }),
   bills_create: contract({ request: flexibleRequest, response: flexibleRequest }),
@@ -279,6 +327,10 @@ export const contracts = {
   bills_delete: contract({ request: flexibleRequest, response: flexibleRequest }),
   bills_restore: contract({ request: flexibleRequest, response: flexibleRequest }),
   bills_list_due_between: contract({ request: flexibleRequest, response: z.array(flexibleRequest) }),
+  file_move: contract({
+    request: fileMoveRequest,
+    response: fileMoveResponse,
+  }),
   db_backup_create: contract({ request: flexibleRequest, response: z.custom<BackupEntry>() }),
   db_backup_overview: contract({ request: flexibleRequest, response: z.custom<BackupOverview>() }),
   db_backup_reveal: contract({ request: flexibleRequest, response: z.void() }),


### PR DESCRIPTION
## Summary
- stage vault moves before database updates, verify cross-device copies, and invalidate the files index after coordinated rewrites
- extend attachments_repair with apply-mode manifest actions, cancellation, and missing-record bookkeeping
- expose repair action manifests through the IPC API and storage maintenance UI with JSON loading, action summaries, and cancel support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e41a874c44832a85dff5a87d24992e