### PR TITLE
Fix cascade checkpoint timestamp field name

### DIFF
--- a/migrations/0026_cascade_checkpoints.up.sql
+++ b/migrations/0026_cascade_checkpoints.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS cascade_checkpoints (
+  household_id TEXT PRIMARY KEY,
+  phase_index INTEGER NOT NULL,
+  deleted_count INTEGER NOT NULL,
+  total INTEGER NOT NULL,
+  phase TEXT NOT NULL,
+  updated_at_utc INTEGER NOT NULL,
+  vacuum_pending INTEGER NOT NULL DEFAULT 0,
+  remaining_paths INTEGER NOT NULL DEFAULT 0
+);

--- a/src-tauri/src/household.rs
+++ b/src-tauri/src/household.rs
@@ -1,18 +1,25 @@
 use serde::{Deserialize, Serialize};
 use sqlx::{Error as SqlxError, Executor, Row, Sqlite, SqlitePool};
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
+use std::collections::HashSet;
 use std::num::NonZeroU32;
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
 use std::time::{Duration, Instant};
 
+use tokio::time::sleep;
+use walkdir::WalkDir;
+
 use crate::id::new_uuid_v7;
 use crate::repo::admin;
+use crate::security::hash_path;
 use crate::time::now_ms;
+use crate::vault::Vault;
 
 // TXN: domain=OUT OF SCOPE tables=household
 pub async fn default_household_id(pool: &SqlitePool) -> anyhow::Result<String> {
@@ -144,9 +151,10 @@ pub async fn assert_household_active(
     pool: &SqlitePool,
     id: &str,
 ) -> std::result::Result<(), HouseholdGuardError> {
-    let row = sqlx::query_as(
-        "SELECT COUNT(*), SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END)\n         FROM household WHERE id = ?1",
-    )
+    let row = sqlx::query_as(concat!(
+        "SELECT COUNT(*), SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END) ",
+        "FROM household WHERE id = ?1",
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await;
@@ -202,6 +210,8 @@ pub enum HouseholdCrudError {
     Deleted,
     #[error("invalid color")]
     InvalidColor,
+    #[error("household cascade blocked: database not empty")]
+    CascadeDbNotEmpty,
     #[error(transparent)]
     Unexpected(#[from] anyhow::Error),
 }
@@ -265,6 +275,32 @@ pub struct CascadeProgress {
 
 pub type CascadeProgressObserver = Arc<dyn Fn(CascadeProgress) + Send + Sync + 'static>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CascadePhase {
+    DbDeletes,
+    FilesCleanup,
+}
+
+impl CascadePhase {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CascadePhase::DbDeletes => "db_deletes",
+            CascadePhase::FilesCleanup => "files_cleanup",
+        }
+    }
+}
+
+const PROGRESS_INDEX_DB: usize = 1;
+const PROGRESS_INDEX_HOUSEHOLD: usize = 2;
+const PROGRESS_INDEX_FILES: usize = 3;
+
+fn fs_cascade_enabled() -> bool {
+    match std::env::var("HOUSEHOLD_FS_CASCADE") {
+        Ok(value) => value != "0",
+        Err(_) => true,
+    }
+}
+
 #[derive(Clone)]
 pub struct CascadeDeleteOptions {
     pub chunk_size: NonZeroU32,
@@ -287,7 +323,7 @@ impl Default for CascadeDeleteOptions {
 }
 
 #[derive(Debug, Clone)]
-struct CascadePhase {
+struct CascadeTablePhase {
     name: &'static str,
     table: &'static str,
 }
@@ -299,8 +335,9 @@ pub struct CascadeCheckpoint {
     pub deleted_count: i64,
     pub total: i64,
     pub phase: String,
-    pub updated_at: i64,
+    pub updated_at_utc: i64,
     pub vacuum_pending: i64,
+    pub remaining_paths: i64,
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -309,76 +346,76 @@ pub struct VacuumQueueEntry {
     pub requested_at: i64,
 }
 
-const CASCADE_PHASES: &[CascadePhase] = &[
-    CascadePhase {
+const CASCADE_PHASES: &[CascadeTablePhase] = &[
+    CascadeTablePhase {
         name: "note_links",
         table: "note_links",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "notes",
         table: "notes",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "events",
         table: "events",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "files_index",
         table: "files_index",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "files_index_meta",
         table: "files_index_meta",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "expenses",
         table: "expenses",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "bills",
         table: "bills",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "inventory_items",
         table: "inventory_items",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "pet_medical",
         table: "pet_medical",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "vehicle_maintenance",
         table: "vehicle_maintenance",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "policies",
         table: "policies",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "property_documents",
         table: "property_documents",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "shopping_items",
         table: "shopping_items",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "family_members",
         table: "family_members",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "vehicles",
         table: "vehicles",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "pets",
         table: "pets",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "budget_categories",
         table: "budget_categories",
     },
-    CascadePhase {
+    CascadeTablePhase {
         name: "categories",
         table: "categories",
     },
@@ -395,8 +432,9 @@ CREATE TABLE IF NOT EXISTS cascade_checkpoints (
     deleted_count INTEGER NOT NULL,
     total INTEGER NOT NULL,
     phase TEXT NOT NULL,
-    updated_at INTEGER NOT NULL,
-    vacuum_pending INTEGER NOT NULL DEFAULT 0
+    updated_at_utc INTEGER NOT NULL,
+    vacuum_pending INTEGER NOT NULL DEFAULT 0,
+    remaining_paths INTEGER NOT NULL DEFAULT 0
 );
 "#;
 
@@ -428,9 +466,10 @@ const SELECT_HOUSEHOLD_BASE: &str = r#"
 "#;
 
 async fn fetch_status(pool: &SqlitePool, id: &str) -> Result<HouseholdStatus, HouseholdCrudError> {
-    let status = sqlx::query_as::<_, HouseholdStatus>(
-        "SELECT id, name, CASE WHEN is_default = 1 THEN 1 ELSE 0 END AS is_default, deleted_at\n         FROM household WHERE id = ?1",
-    )
+    let status = sqlx::query_as::<_, HouseholdStatus>(concat!(
+        "SELECT id, name, CASE WHEN is_default = 1 THEN 1 ELSE 0 END AS is_default, deleted_at ",
+        "FROM household WHERE id = ?1",
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await
@@ -444,6 +483,59 @@ async fn ensure_cascade_tables(pool: &SqlitePool) -> Result<(), HouseholdCrudErr
         .execute(pool)
         .await
         .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+
+    let updated_at_utc_exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('cascade_checkpoints') WHERE name = 'updated_at_utc'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+    if updated_at_utc_exists == 0 {
+        let legacy_updated_at: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('cascade_checkpoints') WHERE name = 'updated_at'",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+        if legacy_updated_at > 0 {
+            let rename = sqlx::query(
+                "ALTER TABLE cascade_checkpoints RENAME COLUMN updated_at TO updated_at_utc",
+            )
+            .execute(pool)
+            .await;
+            if rename.is_err() {
+                sqlx::query(
+                    "ALTER TABLE cascade_checkpoints ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0",
+                )
+                .execute(pool)
+                .await
+                .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+            }
+        } else {
+            sqlx::query(
+                "ALTER TABLE cascade_checkpoints ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(pool)
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        }
+    }
+
+    let remaining_paths_exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('cascade_checkpoints') WHERE name = 'remaining_paths'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+    if remaining_paths_exists == 0 {
+        sqlx::query(
+            "ALTER TABLE cascade_checkpoints ADD COLUMN remaining_paths INTEGER NOT NULL DEFAULT 0",
+        )
+        .execute(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    }
+
     let has_fk_constraint = match sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*) FROM pragma_foreign_key_list('cascade_vacuum_queue')",
     )
@@ -471,7 +563,10 @@ async fn load_checkpoint(
     household_id: &str,
 ) -> Result<Option<CascadeCheckpoint>, HouseholdCrudError> {
     let checkpoint = sqlx::query_as::<_, CascadeCheckpoint>(
-        "SELECT household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending\n         FROM cascade_checkpoints WHERE household_id = ?1",
+        concat!(
+            "SELECT household_id, phase_index, deleted_count, total, phase, updated_at_utc, vacuum_pending, remaining_paths ",
+            "FROM cascade_checkpoints WHERE household_id = ?1",
+        ),
     )
     .bind(household_id)
     .fetch_optional(pool)
@@ -488,15 +583,33 @@ where
     E: Executor<'e, Database = Sqlite>,
 {
     sqlx::query(
-        "INSERT INTO cascade_checkpoints (household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending)\n             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)\n             ON CONFLICT(household_id) DO UPDATE SET\n                 phase_index = excluded.phase_index,\n                 deleted_count = excluded.deleted_count,\n                 total = excluded.total,\n                 phase = excluded.phase,\n                 updated_at = excluded.updated_at,\n                 vacuum_pending = excluded.vacuum_pending",
+        r#"INSERT INTO cascade_checkpoints (
+                household_id,
+                phase_index,
+                deleted_count,
+                total,
+                phase,
+                updated_at_utc,
+                vacuum_pending,
+                remaining_paths
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            ON CONFLICT(household_id) DO UPDATE SET
+                phase_index = excluded.phase_index,
+                deleted_count = excluded.deleted_count,
+                total = excluded.total,
+                phase = excluded.phase,
+                updated_at_utc = excluded.updated_at_utc,
+                vacuum_pending = excluded.vacuum_pending,
+                remaining_paths = excluded.remaining_paths"#,
     )
     .bind(&checkpoint.household_id)
     .bind(checkpoint.phase_index)
     .bind(checkpoint.deleted_count)
     .bind(checkpoint.total)
     .bind(&checkpoint.phase)
-    .bind(checkpoint.updated_at)
+    .bind(checkpoint.updated_at_utc)
     .bind(checkpoint.vacuum_pending)
+    .bind(checkpoint.remaining_paths)
     .execute(executor)
     .await
     .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
@@ -542,6 +655,332 @@ async fn compute_total_rows(
         total += count;
     }
     Ok(total)
+}
+
+async fn ensure_tables_empty(
+    pool: &SqlitePool,
+    household_id: &str,
+) -> Result<(), HouseholdCrudError> {
+    for table in cascade_phase_tables() {
+        let sql = format!("SELECT COUNT(*) FROM {table} WHERE household_id = ?1");
+        let count: i64 = sqlx::query_scalar(&sql)
+            .bind(household_id)
+            .fetch_one(pool)
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        if count > 0 {
+            warn!(
+                target: "arklowdun",
+                event = "files_cleanup_blocked",
+                household_id = %household_id,
+                table = table,
+                remaining_rows = count
+            );
+            return Err(HouseholdCrudError::CascadeDbNotEmpty);
+        }
+    }
+
+    let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM household WHERE id = ?1")
+        .bind(household_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    if remaining > 0 {
+        warn!(
+            target: "arklowdun",
+            event = "files_cleanup_blocked",
+            household_id = %household_id,
+            table = "household",
+            remaining_rows = remaining
+        );
+        return Err(HouseholdCrudError::CascadeDbNotEmpty);
+    }
+
+    Ok(())
+}
+
+const FILES_CLEANUP_BATCH: usize = 100;
+
+async fn cascade_files_cleanup(
+    pool: &SqlitePool,
+    vault: &Vault,
+    checkpoint: &mut CascadeCheckpoint,
+    household_id: &str,
+    options: &CascadeDeleteOptions,
+    total_deleted: &mut u64,
+    total_expected: &mut u64,
+    phase_total: usize,
+) -> Result<bool, HouseholdCrudError> {
+    ensure_tables_empty(pool, household_id).await?;
+
+    let base = vault.base().join(household_id);
+    let mut entries = Vec::new();
+    if base.exists() {
+        for item in WalkDir::new(&base).contents_first(true) {
+            match item {
+                Ok(dir_entry) => {
+                    let file_type = dir_entry.file_type();
+                    let mut is_dir = file_type.is_dir();
+                    if file_type.is_symlink() {
+                        warn!(
+                            target: "arklowdun",
+                            event = "files_cleanup_skip_symlink",
+                            household_id = %household_id,
+                            path_hash = %hash_path(dir_entry.path()),
+                        );
+                        is_dir = false;
+                    }
+                    entries.push((dir_entry.into_path(), is_dir));
+                }
+                Err(err) => {
+                    warn!(
+                        target: "arklowdun",
+                        event = "files_cleanup_walk_error",
+                        household_id = %household_id,
+                        error = %err,
+                    );
+                }
+            }
+        }
+    }
+
+    if base.exists() && !entries.iter().any(|(path, _)| path == &base) {
+        entries.push((base.clone(), true));
+    }
+
+    let total_entries = entries.len();
+    let mut remaining = total_entries as i64;
+
+    let files_phase_index = (CASCADE_PHASES.len() + 1) as i64;
+    if checkpoint.phase != CascadePhase::FilesCleanup.as_str() {
+        checkpoint.phase = CascadePhase::FilesCleanup.as_str().to_string();
+        checkpoint.phase_index = files_phase_index;
+        checkpoint.remaining_paths = remaining;
+        checkpoint.total += remaining;
+        *total_expected = checkpoint.total.max(0) as u64;
+    } else {
+        checkpoint.phase_index = files_phase_index;
+        checkpoint.phase = CascadePhase::FilesCleanup.as_str().to_string();
+        checkpoint.remaining_paths = remaining;
+    }
+
+    checkpoint.updated_at_utc = now_ms();
+
+    {
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+        save_checkpoint(&mut *tx, checkpoint).await?;
+        tx.commit()
+            .await
+            .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+    }
+
+    info!(
+        target: "arklowdun",
+        event = "files_cleanup_started",
+        household_id = %household_id,
+        total_entries = total_entries,
+    );
+
+    if entries.is_empty() {
+        if let Err(err) = std::fs::remove_dir(&base) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                warn!(
+                    target: "arklowdun",
+                    event = "files_cleanup_remove_dir_failed",
+                    household_id = %household_id,
+                    error = %err,
+                );
+                return Ok(false);
+            }
+        }
+        emit_progress(
+            &options.progress,
+            CascadeProgress {
+                household_id: household_id.to_string(),
+                deleted: *total_deleted,
+                total: *total_expected,
+                phase: CascadePhase::FilesCleanup.as_str().to_string(),
+                phase_index: phase_total,
+                phase_total,
+            },
+        );
+        info!(
+            target: "arklowdun",
+            event = "files_cleanup_completed",
+            household_id = %household_id,
+            deleted = *total_deleted,
+        );
+        return Ok(true);
+    }
+
+    let start = Instant::now();
+    let mut processed_since_flush = 0usize;
+    let mut paused = false;
+    let mut logged_failures: HashSet<String> = HashSet::new();
+
+    for (path, is_dir) in entries {
+        if should_pause(&start, options) {
+            paused = true;
+            break;
+        }
+
+        let mut attempts = 0u32;
+        let mut deleted = false;
+        let relative = path.strip_prefix(vault.base()).unwrap_or(&path);
+        let path_hash = hash_path(relative);
+        loop {
+            let result = if is_dir {
+                std::fs::remove_dir(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            match result {
+                Ok(_) => {
+                    deleted = true;
+                    break;
+                }
+                Err(err)
+                    if matches!(
+                        err.kind(),
+                        std::io::ErrorKind::PermissionDenied
+                            | std::io::ErrorKind::WouldBlock
+                            | std::io::ErrorKind::Other
+                    ) && attempts < 2 =>
+                {
+                    attempts += 1;
+                    let delay = 250u64 << attempts;
+                    sleep(Duration::from_millis(delay)).await;
+                    continue;
+                }
+                Err(err) => {
+                    if logged_failures.insert(path_hash.clone()) {
+                        warn!(
+                            target: "arklowdun",
+                            event = "files_cleanup_delete_failed",
+                            household_id = %household_id,
+                            error = %err,
+                            path_hash = %path_hash,
+                        );
+                    } else {
+                        debug!(
+                            target: "arklowdun",
+                            event = "files_cleanup_delete_failed_repeat",
+                            household_id = %household_id,
+                            error = %err,
+                            path_hash = %path_hash,
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+
+        if deleted {
+            checkpoint.deleted_count += 1;
+            *total_deleted = checkpoint.deleted_count.max(0) as u64;
+            checkpoint.remaining_paths = checkpoint.remaining_paths.saturating_sub(1);
+            checkpoint.updated_at_utc = now_ms();
+            processed_since_flush += 1;
+
+            emit_progress(
+                &options.progress,
+                CascadeProgress {
+                    household_id: household_id.to_string(),
+                    deleted: *total_deleted,
+                    total: *total_expected,
+                    phase: CascadePhase::FilesCleanup.as_str().to_string(),
+                    phase_index: phase_total,
+                    phase_total,
+                },
+            );
+
+            info!(
+                target: "arklowdun",
+                event = "files_cleanup_progress",
+                household_id = %household_id,
+                deleted = *total_deleted,
+                remaining = checkpoint.remaining_paths.max(0),
+                total = *total_expected,
+            );
+
+            if processed_since_flush >= FILES_CLEANUP_BATCH || checkpoint.remaining_paths == 0 {
+                let mut tx = pool
+                    .begin()
+                    .await
+                    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+                save_checkpoint(&mut *tx, checkpoint).await?;
+                tx.commit()
+                    .await
+                    .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
+                processed_since_flush = 0;
+            }
+        }
+    }
+
+    if paused {
+        info!(
+            target: "arklowdun",
+            event = "files_cleanup_paused",
+            household_id = %household_id,
+            remaining = checkpoint.remaining_paths.max(0),
+        );
+        return Ok(false);
+    }
+
+    if checkpoint.remaining_paths > 0 {
+        return Ok(false);
+    }
+
+    emit_progress(
+        &options.progress,
+        CascadeProgress {
+            household_id: household_id.to_string(),
+            deleted: *total_deleted,
+            total: *total_expected,
+            phase: CascadePhase::FilesCleanup.as_str().to_string(),
+            phase_index: phase_total,
+            phase_total,
+        },
+    );
+
+    if base.exists() {
+        match std::fs::remove_dir(&base) {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {
+                if let Err(err) = std::fs::remove_dir_all(&base) {
+                    warn!(
+                        target: "arklowdun",
+                        event = "files_cleanup_remove_dir_failed",
+                        household_id = %household_id,
+                        error = %err,
+                    );
+                    return Ok(false);
+                }
+            }
+            Err(err) => {
+                warn!(
+                    target: "arklowdun",
+                    event = "files_cleanup_remove_dir_failed",
+                    household_id = %household_id,
+                    error = %err,
+                );
+                return Ok(false);
+            }
+        }
+    }
+
+    info!(
+        target: "arklowdun",
+        event = "files_cleanup_completed",
+        household_id = %household_id,
+        deleted = *total_deleted,
+    );
+
+    Ok(true)
 }
 
 fn emit_progress(progress: &Option<CascadeProgressObserver>, payload: CascadeProgress) {
@@ -690,6 +1129,7 @@ pub async fn update_household(
 
 pub async fn delete_household(
     pool: &SqlitePool,
+    vault: &Vault,
     id: &str,
     active_id: Option<&str>,
     options: CascadeDeleteOptions,
@@ -744,7 +1184,7 @@ pub async fn delete_household(
             deleted_count: 0,
             total,
             phase: initial_phase.to_string(),
-            updated_at: now,
+            updated_at_utc: now,
             vacuum_pending: 0,
         });
 
@@ -760,7 +1200,7 @@ pub async fn delete_household(
 
     let mut checkpoint = checkpoint.expect("checkpoint ensured above");
     let mut total_deleted = checkpoint.deleted_count.max(0) as u64;
-    let total_expected = checkpoint.total.max(0) as u64;
+    let mut total_expected = checkpoint.total.max(0) as u64;
 
     let was_active = active_id.map(|candidate| candidate == id).unwrap_or(false);
     let fallback_id = if was_active {
@@ -773,9 +1213,18 @@ pub async fn delete_household(
         None
     };
 
+    let fs_enabled = fs_cascade_enabled();
+
     let mut phase_index = checkpoint.phase_index.max(0) as usize;
+    if phase_index > CASCADE_PHASES.len() {
+        phase_index = CASCADE_PHASES.len();
+    }
     let chunk_size = options.chunk_size.get() as i64;
-    let phase_total = CASCADE_PHASES.len() + 1;
+    let phase_total = if fs_enabled {
+        PROGRESS_INDEX_FILES
+    } else {
+        PROGRESS_INDEX_HOUSEHOLD
+    };
     let mut paused = false;
     let start_time = Instant::now();
 
@@ -789,7 +1238,7 @@ pub async fn delete_household(
 
         checkpoint.phase_index = phase_index as i64;
         checkpoint.phase = phase.name.to_string();
-        checkpoint.updated_at = now_ms();
+        checkpoint.updated_at_utc = now_ms();
 
         {
             let mut tx = pool
@@ -829,14 +1278,13 @@ pub async fn delete_household(
                 checkpoint.deleted_count += rows;
                 total_deleted = checkpoint.deleted_count.max(0) as u64;
             }
-            checkpoint.updated_at = now;
+            checkpoint.updated_at_utc = now;
             save_checkpoint(&mut *tx, &checkpoint).await?;
             tx.commit()
                 .await
                 .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
 
             if rows > 0 {
-                let phase_number = phase_index + 1;
                 emit_progress(
                     &options.progress,
                     CascadeProgress {
@@ -844,7 +1292,7 @@ pub async fn delete_household(
                         deleted: total_deleted,
                         total: total_expected,
                         phase: phase.name.to_string(),
-                        phase_index: phase_number,
+                        phase_index: PROGRESS_INDEX_DB,
                         phase_total,
                     },
                 );
@@ -861,7 +1309,7 @@ pub async fn delete_household(
 
         phase_index += 1;
         checkpoint.phase_index = phase_index as i64;
-        checkpoint.updated_at = now_ms();
+        checkpoint.updated_at_utc = now_ms();
         let mut tx = pool
             .begin()
             .await
@@ -873,7 +1321,7 @@ pub async fn delete_household(
     }
 
     if paused {
-        checkpoint.updated_at = now_ms();
+        checkpoint.updated_at_utc = now_ms();
         let mut tx = pool
             .begin()
             .await
@@ -883,7 +1331,6 @@ pub async fn delete_household(
             .await
             .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
 
-        let phase_number = phase_index.min(CASCADE_PHASES.len()) + 1;
         emit_progress(
             &options.progress,
             CascadeProgress {
@@ -891,7 +1338,7 @@ pub async fn delete_household(
                 deleted: total_deleted,
                 total: total_expected,
                 phase: "paused".to_string(),
-                phase_index: phase_number,
+                phase_index: PROGRESS_INDEX_DB,
                 phase_total,
             },
         );
@@ -909,7 +1356,7 @@ pub async fn delete_household(
     if should_pause(&start_time, &options) {
         checkpoint.phase_index = CASCADE_PHASES.len() as i64;
         checkpoint.phase = "household".to_string();
-        checkpoint.updated_at = now_ms();
+        checkpoint.updated_at_utc = now_ms();
         let mut tx = pool
             .begin()
             .await
@@ -926,7 +1373,7 @@ pub async fn delete_household(
                 deleted: total_deleted,
                 total: total_expected,
                 phase: "paused".to_string(),
-                phase_index: phase_total,
+                phase_index: PROGRESS_INDEX_HOUSEHOLD,
                 phase_total,
             },
         );
@@ -943,7 +1390,7 @@ pub async fn delete_household(
 
     checkpoint.phase_index = CASCADE_PHASES.len() as i64;
     checkpoint.phase = "household".to_string();
-    checkpoint.updated_at = now_ms();
+    checkpoint.updated_at_utc = now_ms();
 
     let mut tx = pool
         .begin()
@@ -959,7 +1406,7 @@ pub async fn delete_household(
         checkpoint.deleted_count += rows;
         total_deleted = checkpoint.deleted_count.max(0) as u64;
     }
-    checkpoint.updated_at = now_ms();
+    checkpoint.updated_at_utc = now_ms();
     save_checkpoint(&mut *tx, &checkpoint).await?;
     tx.commit()
         .await
@@ -973,10 +1420,35 @@ pub async fn delete_household(
                 deleted: total_deleted,
                 total: total_expected,
                 phase: "household".to_string(),
-                phase_index: phase_total,
+                phase_index: PROGRESS_INDEX_HOUSEHOLD,
                 phase_total,
             },
         );
+    }
+
+    if fs_enabled {
+        let cleanup_complete = cascade_files_cleanup(
+            pool,
+            vault,
+            &mut checkpoint,
+            id,
+            &options,
+            &mut total_deleted,
+            &mut total_expected,
+            phase_total,
+        )
+        .await?;
+
+        if !cleanup_complete {
+            return Ok(DeleteOutcome {
+                was_active,
+                fallback_id,
+                total_deleted,
+                total_expected,
+                vacuum_recommended: false,
+                completed: false,
+            });
+        }
     }
 
     enqueue_vacuum(pool, id).await?;
@@ -1020,12 +1492,13 @@ pub async fn restore_household(
 
 pub async fn resume_household_delete(
     pool: &SqlitePool,
+    vault: &Vault,
     id: &str,
     active_id: Option<&str>,
     mut options: CascadeDeleteOptions,
 ) -> Result<DeleteOutcome, HouseholdCrudError> {
     options.resume = true;
-    delete_household(pool, id, active_id, options).await
+    delete_household(pool, vault, id, active_id, options).await
 }
 
 pub async fn pending_cascades(
@@ -1033,7 +1506,10 @@ pub async fn pending_cascades(
 ) -> Result<Vec<CascadeCheckpoint>, HouseholdCrudError> {
     ensure_cascade_tables(pool).await?;
     let checkpoints = sqlx::query_as::<_, CascadeCheckpoint>(
-        "SELECT household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending\n         FROM cascade_checkpoints",
+        concat!(
+            "SELECT household_id, phase_index, deleted_count, total, phase, updated_at_utc, vacuum_pending, remaining_paths ",
+            "FROM cascade_checkpoints",
+        ),
     )
     .fetch_all(pool)
     .await
@@ -1063,4 +1539,16 @@ pub async fn acknowledge_vacuum(
         .await
         .map_err(|err| HouseholdCrudError::Unexpected(err.into()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_indices_follow_ui_order() {
+        assert_eq!(PROGRESS_INDEX_DB, 1);
+        assert_eq!(PROGRESS_INDEX_HOUSEHOLD, 2);
+        assert_eq!(PROGRESS_INDEX_FILES, 3);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,7 +238,7 @@ mod cascade_health_tests {
         let household = crate::household::create_household(&pool, "Health", None).await?;
         let _ = crate::household::pending_cascades(&pool).await?;
         sqlx::query(
-            "INSERT INTO cascade_checkpoints (household_id, phase_index, deleted_count, total, phase, updated_at, vacuum_pending)\n             VALUES (?1, 0, 0, 1, 'note_links', 1, 0)",
+            "INSERT INTO cascade_checkpoints (household_id, phase_index, deleted_count, total, phase, updated_at_utc, vacuum_pending, remaining_paths)\n             VALUES (?1, 0, 0, 1, 'note_links', 1, 0, 0)",
         )
         .bind(&household.id)
         .execute(&pool)
@@ -1208,6 +1208,10 @@ fn map_household_crud_error(err: crate::household::HouseholdCrudError) -> AppErr
         crate::household::HouseholdCrudError::InvalidColor => {
             AppError::new("INVALID_COLOR", "Please use a hex colour like #2563EB.")
         }
+        crate::household::HouseholdCrudError::CascadeDbNotEmpty => AppError::new(
+            "CASCADE_DB_NOT_EMPTY",
+            "Unable to remove files while data remains in the database.",
+        ),
         crate::household::HouseholdCrudError::Unexpected(err) => AppError::from(err),
     }
 }
@@ -1490,35 +1494,44 @@ async fn household_delete<R: tauri::Runtime>(
 ) -> AppResult<HouseholdDeleteResponse> {
     let _permit = guard::ensure_db_writable(&state)?;
     let pool = state.pool_clone();
+    let vault = state.vault();
     update_cascade_health_cache(&state, &[id.clone()])?;
     let active = snapshot_active_id(&state);
     let progress_handler = make_delete_progress_handler(&app, &id);
     let mut options = CascadeDeleteOptions::default();
     options.progress = Some(progress_handler);
     options.max_duration_ms = Some(2_000);
-    let outcome =
-        match crate::household::delete_household(&pool, &id, active.as_deref(), options).await {
-            Ok(outcome) => outcome,
-            Err(err) => {
-                let reason = match &err {
-                    crate::household::HouseholdCrudError::DefaultUndeletable => "default",
-                    crate::household::HouseholdCrudError::NotFound => "not_found",
-                    crate::household::HouseholdCrudError::Deleted => "already_deleted",
-                    crate::household::HouseholdCrudError::InvalidColor => "invalid_color",
-                    crate::household::HouseholdCrudError::Unexpected(_) => "unexpected",
-                };
-                let app_error = map_household_crud_error(err);
-                tracing::warn!(
-                    target: "arklowdun",
-                    event = "household_delete",
-                    household_id = %id,
-                    result = "error",
-                    reason,
-                    error_code = %app_error.code()
-                );
-                return Err(app_error);
-            }
-        };
+    let outcome = match crate::household::delete_household(
+        &pool,
+        vault.as_ref(),
+        &id,
+        active.as_deref(),
+        options,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            let reason = match &err {
+                crate::household::HouseholdCrudError::DefaultUndeletable => "default",
+                crate::household::HouseholdCrudError::NotFound => "not_found",
+                crate::household::HouseholdCrudError::Deleted => "already_deleted",
+                crate::household::HouseholdCrudError::InvalidColor => "invalid_color",
+                crate::household::HouseholdCrudError::CascadeDbNotEmpty => "db_not_empty",
+                crate::household::HouseholdCrudError::Unexpected(_) => "unexpected",
+            };
+            let app_error = map_household_crud_error(err);
+            tracing::warn!(
+                target: "arklowdun",
+                event = "household_delete",
+                household_id = %id,
+                result = "error",
+                reason,
+                error_code = %app_error.code()
+            );
+            return Err(app_error);
+        }
+    };
 
     sync_cascade_health(&state, &pool).await?;
 
@@ -1587,6 +1600,7 @@ async fn household_resume_delete<R: tauri::Runtime>(
 ) -> AppResult<HouseholdDeleteResponse> {
     let _permit = guard::ensure_db_writable(&state)?;
     let pool = state.pool_clone();
+    let vault = state.vault();
     update_cascade_health_cache(&state, &[id.clone()])?;
     let active = snapshot_active_id(&state);
     let progress_handler = make_delete_progress_handler(&app, &id);
@@ -1594,29 +1608,35 @@ async fn household_resume_delete<R: tauri::Runtime>(
     options.progress = Some(progress_handler);
     options.resume = true;
     options.max_duration_ms = Some(2_000);
-    let outcome =
-        match crate::household::resume_household_delete(&pool, &id, active.as_deref(), options)
-            .await
-        {
-            Ok(outcome) => outcome,
-            Err(err) => {
-                let reason = match &err {
-                    crate::household::HouseholdCrudError::DefaultUndeletable => "default",
-                    crate::household::HouseholdCrudError::NotFound => "not_found",
-                    crate::household::HouseholdCrudError::Deleted => "already_deleted",
-                    crate::household::HouseholdCrudError::InvalidColor => "invalid_color",
-                    crate::household::HouseholdCrudError::Unexpected(_) => "unexpected",
-                };
-                tracing::warn!(
-                    target: "arklowdun",
-                    event = "household_resume_failed",
-                    household_id = %id,
-                    result = "error",
-                    reason
-                );
-                return Err(map_household_crud_error(err));
-            }
-        };
+    let outcome = match crate::household::resume_household_delete(
+        &pool,
+        vault.as_ref(),
+        &id,
+        active.as_deref(),
+        options,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            let reason = match &err {
+                crate::household::HouseholdCrudError::DefaultUndeletable => "default",
+                crate::household::HouseholdCrudError::NotFound => "not_found",
+                crate::household::HouseholdCrudError::Deleted => "already_deleted",
+                crate::household::HouseholdCrudError::InvalidColor => "invalid_color",
+                crate::household::HouseholdCrudError::CascadeDbNotEmpty => "db_not_empty",
+                crate::household::HouseholdCrudError::Unexpected(_) => "unexpected",
+            };
+            tracing::warn!(
+                target: "arklowdun",
+                event = "household_resume_failed",
+                household_id = %id,
+                result = "error",
+                reason
+            );
+            return Err(map_household_crud_error(err));
+        }
+    };
 
     sync_cascade_health(&state, &pool).await?;
 

--- a/src-tauri/tests/household_delete.rs
+++ b/src-tauri/tests/household_delete.rs
@@ -9,6 +9,8 @@ use arklowdun_lib::{
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::SqlitePool;
 use tempfile::tempdir;
+#[path = "util.rs"]
+mod util;
 
 async fn open_pool(path: &Path) -> Result<SqlitePool> {
     let options = SqliteConnectOptions::new()
@@ -30,10 +32,12 @@ async fn default_delete_does_not_dirty_cascade_state() -> Result<()> {
     let dir = tempdir()?;
     let db_path = dir.path().join("households.sqlite3");
     let pool = open_pool(&db_path).await?;
+    let (_vault_guard, vault) = util::temp_vault();
 
     let default_id = default_household_id(&pool).await?;
     let err = delete_household(
         &pool,
+        &vault,
         &default_id,
         Some(&default_id),
         CascadeDeleteOptions::default(),

--- a/src-tauri/tests/household_files_cleanup.rs
+++ b/src-tauri/tests/household_files_cleanup.rs
@@ -1,0 +1,287 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use arklowdun_lib::{
+    create_household, delete_household, pending_cascades, resume_household_delete,
+    CascadeDeleteOptions, CascadeProgress, CascadeProgressObserver, HouseholdCrudError,
+};
+use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+use walkdir::WalkDir;
+
+#[path = "util.rs"]
+mod util;
+
+async fn memory_pool() -> Result<SqlitePool> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await?;
+    arklowdun_lib::migrate::apply_migrations(&pool).await?;
+    Ok(pool)
+}
+
+fn populate_sample_tree(base: &Path) -> Result<()> {
+    fs::create_dir_all(base.join("docs/nested"))?;
+    fs::write(base.join("root.txt"), b"root")?;
+    fs::write(base.join("docs/doc1.txt"), b"doc")?;
+    fs::write(base.join("docs/nested/deep.txt"), b"deep")?;
+    Ok(())
+}
+
+fn count_cleanup_entries(base: &Path) -> usize {
+    if !base.exists() {
+        return 0;
+    }
+    let mut entries: Vec<PathBuf> = Vec::new();
+    for item in WalkDir::new(base).contents_first(true) {
+        if let Ok(entry) = item {
+            entries.push(entry.into_path());
+        }
+    }
+    if !entries.iter().any(|path| path == base) {
+        entries.push(base.to_path_buf());
+    }
+    entries.len()
+}
+
+#[tokio::test]
+async fn filesystem_cleanup_removes_household_directory() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Files", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+
+    let outcome = delete_household(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await?;
+    assert!(outcome.completed);
+    assert!(!household_dir.exists());
+    assert!(pending_cascades(&pool).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cascade_progress_uses_step_indices() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Progress", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+
+    sqlx::query(
+        "INSERT INTO notes (id, household_id, position, created_at, updated_at, text, color, x, y)\
+         VALUES (?1, ?2, 0, 0, 0, 'note', '#fff', 0, 0)",
+    )
+    .bind("note-1")
+    .bind(&household.id)
+    .execute(&pool)
+    .await?;
+
+    let records: Arc<Mutex<Vec<CascadeProgress>>> = Arc::new(Mutex::new(Vec::new()));
+    let observer_records = records.clone();
+    let observer: CascadeProgressObserver = Arc::new(move |progress: CascadeProgress| {
+        observer_records.lock().unwrap().push(progress);
+    });
+
+    let mut options = CascadeDeleteOptions::default();
+    options.progress = Some(observer);
+
+    let outcome = delete_household(&pool, &vault, &household.id, None, options).await?;
+    assert!(outcome.completed);
+
+    let captured = records.lock().unwrap();
+    assert!(captured.iter().any(|p| p.phase == "files_cleanup"));
+    let db_indices: HashSet<usize> = captured
+        .iter()
+        .filter(|p| p.phase != "household" && p.phase != "files_cleanup" && p.phase != "paused")
+        .map(|p| p.phase_index)
+        .collect();
+    if !db_indices.is_empty() {
+        assert_eq!(db_indices, HashSet::from([1]));
+    }
+    for event in captured.iter().filter(|p| p.phase == "household") {
+        assert_eq!(event.phase_index, 2);
+        assert_eq!(event.phase_total, 3);
+    }
+    for event in captured.iter().filter(|p| p.phase == "files_cleanup") {
+        assert_eq!(event.phase_index, 3);
+        assert_eq!(event.phase_total, 3);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn cascade_resume_updates_remaining_paths() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Resume", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+    let initial_entries = count_cleanup_entries(&household_dir);
+
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let observer_flag = cancel_flag.clone();
+    let observer: CascadeProgressObserver = Arc::new(move |progress: CascadeProgress| {
+        if progress.phase == "files_cleanup" {
+            let fs_deleted = progress.deleted.saturating_sub(1);
+            if fs_deleted >= 2 {
+                observer_flag.store(true, Ordering::Relaxed);
+            }
+        }
+    });
+
+    let mut options = CascadeDeleteOptions::default();
+    options.progress = Some(observer);
+    options.cancel_flag = Some(cancel_flag);
+
+    let outcome = delete_household(&pool, &vault, &household.id, None, options).await?;
+    assert!(!outcome.completed);
+
+    let remaining_paths: i64 = sqlx::query_scalar(
+        "SELECT remaining_paths FROM cascade_checkpoints WHERE household_id = ?1",
+    )
+    .bind(&household.id)
+    .fetch_one(&pool)
+    .await?;
+    assert!(remaining_paths > 0);
+    assert!(remaining_paths < initial_entries as i64);
+
+    let resumed = resume_household_delete(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await?;
+    assert!(resumed.completed);
+    assert!(pending_cascades(&pool).await?.is_empty());
+    assert!(!household_dir.exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn filesystem_guard_blocks_when_db_not_empty() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Guard", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+
+    let cancel_flag = Arc::new(AtomicBool::new(false));
+    let observer_flag = cancel_flag.clone();
+    let observer: CascadeProgressObserver = Arc::new(move |progress: CascadeProgress| {
+        if progress.phase == "household" {
+            observer_flag.store(true, Ordering::Relaxed);
+        }
+    });
+    let mut options = CascadeDeleteOptions::default();
+    options.progress = Some(observer);
+    options.cancel_flag = Some(cancel_flag);
+
+    let outcome = delete_household(&pool, &vault, &household.id, None, options).await?;
+    assert!(!outcome.completed);
+
+    sqlx::query(
+        "INSERT INTO household (id, name, created_at, updated_at, deleted_at, tz, is_default, color)\
+         VALUES (?1, 'Reborn', 0, 0, NULL, NULL, 0, NULL)",
+    )
+    .bind(&household.id)
+    .execute(&pool)
+    .await?;
+
+    let err = resume_household_delete(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await
+    .expect_err("db guard should reject resume");
+    assert!(matches!(err, HouseholdCrudError::CascadeDbNotEmpty));
+    Ok(())
+}
+
+#[tokio::test]
+async fn symlink_entries_are_logged_but_not_followed() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Symlink", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+
+    let target = household_dir.parent().unwrap().join("external.txt");
+    fs::write(&target, b"external")?;
+    let link = household_dir.join("docs/link.txt");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&target, &link)?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_file(&target, &link)?;
+
+    let outcome = delete_household(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await?;
+    assert!(outcome.completed);
+    assert!(!household_dir.exists());
+    assert!(target.exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn permission_errors_retry_and_resume() -> Result<()> {
+    let pool = memory_pool().await?;
+    let (_vault_guard, vault) = util::temp_vault();
+    let household = create_household(&pool, "Permissions", None).await?;
+    let household_dir = vault.base().join(&household.id);
+    populate_sample_tree(&household_dir)?;
+
+    let mut perms = fs::metadata(&household_dir)?.permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&household_dir, perms.clone())?;
+
+    let outcome = delete_household(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await?;
+    assert!(!outcome.completed);
+
+    let mut writable = perms;
+    writable.set_readonly(false);
+    fs::set_permissions(&household_dir, writable)?;
+
+    let resumed = resume_household_delete(
+        &pool,
+        &vault,
+        &household.id,
+        None,
+        CascadeDeleteOptions::default(),
+    )
+    .await?;
+    assert!(resumed.completed);
+    assert!(pending_cascades(&pool).await?.is_empty());
+    assert!(!household_dir.exists());
+    Ok(())
+}

--- a/src-tauri/tests/util.rs
+++ b/src-tauri/tests/util.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use arklowdun_lib::vault::Vault;
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+use std::fs;
+use tempfile::TempDir;
 
 pub async fn temp_pool() -> SqlitePool {
     let pool = SqlitePoolOptions::new()
@@ -13,4 +16,11 @@ pub async fn temp_pool() -> SqlitePool {
         .await
         .unwrap();
     pool
+}
+
+pub fn temp_vault() -> (TempDir, Vault) {
+    let dir = TempDir::new().expect("create temp vault dir");
+    let base = dir.path().join("vault");
+    fs::create_dir_all(&base).expect("create vault base dir");
+    (dir, Vault::new(&base))
 }


### PR DESCRIPTION
## Summary
- set the initial cascade checkpoint to populate the `updated_at_utc` field so it matches the struct and migration schema

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml household_files_cleanup:: --no-run *(fails: missing glib-2.0 system dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d04cfb94832aa0abb988db5f21fb