### PR TITLE
docs(logging): PR-0 completeness corrections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation Index
+
+## Active Features
+- [Logging](./logging/OVERVIEW.md) — in-app log viewer, IPC contract, export format

--- a/docs/logging/EXPORT.md
+++ b/docs/logging/EXPORT.md
@@ -1,0 +1,40 @@
+# Logging Export Guide
+
+Status: Draft
+Owner: Ged Kelly
+Last updated: 2025-10-07
+
+## Audience
+Frontend engineers implementing export mechanics and support staff validating exported files.
+
+## Format
+* Exported tails use JSON Lines (NDJSON) exclusively.
+* Entries remain in the exact order received from `diagnostics_summary`; no re-sorting or deduping occurs.
+
+## File layout
+1. **`_meta` line:** JSON object with keys `app_version`, `schema_version`, `os_version`, `exported_at_utc`, and a `filters` summary capturing severity level and selected categories.
+2. **Payload lines:** Raw log entries exactly as delivered by the IPC response.
+3. **`_checksum` line:** JSON object containing `sha256` (hex digest computed over the payload lines joined by `\n`) and `record_count` (number of payload records).
+
+## Filename pattern
+`arklowdun-tail_{appver}_{YYYY-MM-DDTHH-mm-ssZ}_sev-{level}_cats-{comma-list}.jsonl`
+
+## Checksum computation
+* Use the Web Crypto API to compute a SHA-256 digest of the UTF-8 encoded payload portion joined with newline (`\n`) separators.
+* Exclude the `_meta` and `_checksum` lines from the hash input; include a trailing newline only if present in the payload source.
+* Convert the resulting ArrayBuffer to a lowercase hexadecimal string for embedding in the `_checksum` line.
+
+## Post-export UX
+* After writing the file, display a toast summarising the export location and presenting the checksum.
+* Provide a "Copy" action within the toast so that support staff can quickly place the checksum on the clipboard.
+
+## Support verification steps
+1. Open the JSONL file in a text editor to confirm three segments: `_meta`, payload, `_checksum`.
+2. Count the payload lines and ensure they match the `record_count` value.
+3. Recompute the SHA-256 over the payload portion and confirm the digest matches the `sha256` value.
+4. Validate that the filename reflects the captured severity level and categories.
+
+## Related references
+* [OVERVIEW](./OVERVIEW.md)
+* [SPEC](./SPEC.md)
+* [IPC](./IPC.md)

--- a/docs/logging/IPC.md
+++ b/docs/logging/IPC.md
@@ -1,0 +1,48 @@
+# Logging IPC Contract
+
+Status: Draft
+Owner: Ged Kelly
+Last updated: 2025-10-07
+
+## Audience
+Backend engineers maintaining `diagnostics_summary` and frontend engineers consuming its output.
+
+## Request shape
+* The UI issues a `diagnostics_summary` request with no parameters (`{}` when serialization requires a body).
+* The backend flushes pending buffers, reads the latest rotating file tail, and returns the newest ~200 log entries.
+
+## Response schema
+```json
+{
+  "lines": [
+    {
+      "ts": "2025-10-07T18:22:10Z",
+      "level": "info",
+      "event": "fs_guard_check",
+      "message": "...",
+      "household_id": "...",
+      "...": "..."
+    }
+  ],
+  "dropped_count": 0,
+  "log_write_status": "ok"
+}
+```
+
+Returned lines are ordered **oldest-first**. The list contains up to 200 entries—fewer if logs have not yet reached that length.
+
+## Field notes
+* `ts` is an RFC-3339 UTC timestamp and sorts lexicographically.
+* `level` always belongs to {`trace`, `debug`, `info`, `warn`, `error`}.
+* `event` identifies the originating category and drives filter options in the UI.
+* Additional fields may appear at any time; consumers must ignore unknown keys safely.
+* `dropped_count` reports how many lines the non-blocking writer dropped (0 when none).
+* `log_write_status` communicates the latest writer state (`"ok"` or `"io_error"`).
+
+## Usage requirements
+* Responses should be treated as immutable snapshots; replace the in-memory tail rather than merging.
+* Polling (for Live Tail) must stop immediately upon leaving the Logs view.
+
+## Related references
+* [SPEC](./SPEC.md)
+* [EXPORT](./EXPORT.md)

--- a/docs/logging/OVERVIEW.md
+++ b/docs/logging/OVERVIEW.md
@@ -1,0 +1,92 @@
+# Logging Overview
+
+Status: Draft
+Owner: Ged Kelly
+Last updated: 2025-10-07
+
+All documentation under `docs/logging/` will use **kebab-case** filenames to remain portable and consistent.
+
+## Audience
+Paula, testers, and product management stakeholders who need to understand how the in-app logging experience behaves during the beta phase.
+
+## What the Logs view is
+The Logs view is reached by selecting the bug icon located in the footer at the bottom-right of the application. Activating the icon routes the main content pane into the logging experience while leaving the existing sidebar and footer elements visible. Within that pane, users can inspect the most recent diagnostics tail without navigating away from the rest of the interface.
+
+## Why logging exists
+The logging experience underpins beta stability work, accelerates troubleshooting during testing, and gives support teams the context they need for handoffs. By standardising how logs are viewed and exported inside the application, we reduce the latency between identifying an issue, gathering evidence, and sharing it with engineering.
+
+## High-level capabilities
+* Optional live tail that refreshes the visible log list without reloading the page.
+* Category filters derived from the `event` field and severity filters that respect inclusive-upward ordering.
+* Time display toggle that switches between Europe/London local time and UTC, re-rendering rows immediately.
+* Export action that produces a JSONL tail for downstream analysis or attachment to tickets.
+
+## Scope and current limits
+* Available on macOS only during the beta period.
+* Each diagnostics pull returns roughly the most recent 200 log lines; older history requires external tooling.
+* No redaction pipeline is in place, so sensitive data that reaches logs remains visible.
+* Session identifiers and request correlation identifiers are not present unless explicitly added in later iterations.
+
+## How to access and use it
+1. Click the bug icon in the footer (bottom-right) to load the Logs view in the main content pane.
+2. Use severity and category filters to narrow the list. Filters apply client-side to the ~200 line tail.
+3. Toggle between Local and UTC timestamps to match the context of the investigation.
+4. Enable Live Tail to poll in the background while remaining on the Logs view; disable it or navigate away to stop polling.
+5. Use the Export button to download the current tail as JSONL for archival or sharing.
+
+## PR plan summary
+* **PR-0 — Docs groundwork (this PR).** Establish the documentation suite that defines the logging experience and link it from the primary docs index.
+* **PR-1 — Entry & Display.** Implement the bug icon route to render the Logs view within the main content pane while preserving sidebar and footer.
+* **PR-2 — Data Source.** Request the diagnostics tail through `diagnostics_summary`, maintaining a 200-line in-memory buffer and avoiding direct file reads.
+* **PR-3 — Viewing & Filtering.** Render the core table, category multi-select, and free-text search working entirely on the client.
+* **PR-4 — Time Handling.** Standardise on UTC storage while offering an instantaneous Local↔UTC display toggle defaulting to Europe/London.
+* **PR-5 — Live Tail.** Add the polling loop (3–5 s) that keeps the tail fresh only while the Logs view is active.
+* **PR-6 — Backpressure & Rotation Safety.** Surface drop counters and writer status via the IPC contract and display a banner solely when data loss or errors are reported.
+* **PR-7 — Export (JSONL).** Deliver the structured JSONL export with metadata, payload, checksum, deterministic naming, and completion toast.
+* **PR-8 — Cleanup & QA.** Final polish to ensure timers, state, and QA checklist compliance before exiting beta scope.
+
+## PR sequence (PR-0 → PR-8)
+* **PR-0 — Docs groundwork (this PR).**
+  Create `docs/logging/` with OVERVIEW, SPEC, UI, IPC, EXPORT. Link from `docs/README.md`.
+
+* **PR-1 — Entry & Display.**
+  Wire bug icon to route into Logs view in the main content pane. Sidebar/footer unchanged. No drawers/modals.
+
+* **PR-2 — Data Source.**
+  Call `diagnostics_summary` on load; hold returned tail (~200 lines) in memory. No file reads from UI.
+
+* **PR-3 — Viewing & Filtering.**
+  Render table (timestamp, level, event, message). Add category multi-select (OR). Add free-text search. All client-side.
+
+* **PR-4 — Time Handling.**
+  Sort/filter on UTC epoch; display Local (Europe/London) by default. Add Local↔UTC toggle with instant re-render.
+
+* **PR-5 — Live Tail.**
+  Add Live Tail toggle; poll `diagnostics_summary` every 3–5 s while view is active; stop on exit.
+
+* **PR-6 — Backpressure & Rotation Safety.**
+  Extend IPC to include `dropped_count` + `log_write_status`; show banner only when needed. No persistent handles.
+
+* **PR-7 — Export (JSONL).**
+  Export tail with `_meta` line, raw payload lines, `_checksum` line; deterministic filename; toast with SHA-256.
+
+* **PR-8 — Cleanup & QA.**
+  Ensure all timers/state cleared on route change; UX polish; acceptance checklist pass on macOS.
+
+Each PR references the relevant section(s) of `SPEC.md` and updates them **only if** behaviour changes. Otherwise, no doc edits.
+
+## Related documents
+* [SPEC](./SPEC.md)
+* [UI](./UI.md)
+* [IPC](./IPC.md)
+* [EXPORT](./EXPORT.md)
+
+## Acceptance checklist (PR-0)
+- All five Markdown files present with header blocks and cross-links.
+- Relative links verified in GitHub viewer.
+- docs/README.md updated and functional.
+- SPEC includes rationale and rotation details.
+- IPC ordering clarified.
+- UI severity colours defined.
+
+Status changes to *Stable* once PR-8 merges and all logging acceptance criteria have passed.

--- a/docs/logging/SPEC.md
+++ b/docs/logging/SPEC.md
@@ -1,0 +1,95 @@
+# Logging Specification
+
+Status: Draft
+Owner: Ged Kelly
+Last updated: 2025-10-07
+
+All documentation under `docs/logging/` will use **kebab-case** filenames to remain portable and consistent.
+
+## Audience
+Engineering teams implementing the logging surface and integrating the supporting IPC contract.
+
+## Entry and display
+* **Entry & display:** Bug icon → Logs view in main content pane; no drawers or modals. The Logs view reuses the primary layout shell so navigation chrome remains stable.
+
+## Data source contract
+* **Data source:** Sole source is `diagnostics_summary` IPC. Each call flushes then returns the latest ~200 JSON lines from rotating files. The UI must not read raw files.
+
+## Filtering rules
+* **Categories:** Derived from the `event` field in the returned payload. Multi-select with OR semantics; an empty selection means “all categories.”
+* **Severity:** Uses an inclusive-upward model (e.g., selecting `warn` includes `warn` and `error`; selecting `info` includes `info`, `warn`, and `error`).
+
+## Time handling
+* Store, sort, and filter using the UTC instant contained in each record.
+* Display defaults to Europe/London local time.
+* Toggling Local↔UTC re-renders timestamps in place without re-fetching data.
+
+## Live tail behaviour
+* Live tail is optional and controlled by a toggle.
+* When enabled, poll `diagnostics_summary` every 3–5 seconds.
+* Leaving the Logs view stops polling immediately.
+* Each poll replaces the entire 200-line tail with the latest response; no diffing or incremental merges.
+
+## Rotation and backpressure safety
+* Rotation retains five 5 MB JSON files (≈25 MB total). This defines the maximum on-disk footprint for logs.
+* The UI never holds file handles.
+* The backend writer is non-blocking with a 50k line buffer.
+* `diagnostics_summary` responses include `dropped_count` and `log_write_status` (values: `"ok"` or `"io_error"`).
+* The UI shows a small banner only when `dropped_count > 0` or `log_write_status` is not `"ok"`.
+
+## Export contract
+* **Format:** JSONL only.
+* **Structure:**
+  1. `_meta` line containing `app_version`, `schema_version`, `os_version`, `exported_at_utc`, and a filter summary.
+  2. Raw ~200 lines exactly as returned by `diagnostics_summary`.
+  3. `_checksum` line with a SHA-256 computed over the payload lines plus the `record_count`.
+* **Filename pattern:** `arklowdun-tail_{appver}_{YYYY-MM-DDTHH-mm-ssZ}_sev-{level}_cats-{comma-list}.jsonl`.
+
+## Cleanup expectations
+Leaving the Logs view clears timers, local state, and any transient UI indicators to ensure no leaks persist after navigation.
+
+## PR sequence (PR-0 → PR-8)
+* **PR-0 — Docs groundwork (this PR).**
+  Create `docs/logging/` with OVERVIEW, SPEC, UI, IPC, EXPORT. Link from `docs/README.md`.
+
+* **PR-1 — Entry & Display.**
+  Wire bug icon to route into Logs view in the main content pane. Sidebar/footer unchanged. No drawers/modals.
+
+* **PR-2 — Data Source.**
+  Call `diagnostics_summary` on load; hold returned tail (~200 lines) in memory. No file reads from UI.
+
+* **PR-3 — Viewing & Filtering.**
+  Render table (timestamp, level, event, message). Add category multi-select (OR). Add free-text search. All client-side.
+
+* **PR-4 — Time Handling.**
+  Sort/filter on UTC epoch; display Local (Europe/London) by default. Add Local↔UTC toggle with instant re-render.
+
+* **PR-5 — Live Tail.**
+  Add Live Tail toggle; poll `diagnostics_summary` every 3–5 s while view is active; stop on exit.
+
+* **PR-6 — Backpressure & Rotation Safety.**
+  Extend IPC to include `dropped_count` + `log_write_status`; show banner only when needed. No persistent handles.
+
+* **PR-7 — Export (JSONL).**
+  Export tail with `_meta` line, raw payload lines, `_checksum` line; deterministic filename; toast with SHA-256.
+
+* **PR-8 — Cleanup & QA.**
+  Ensure all timers/state cleared on route change; UX polish; acceptance checklist pass on macOS.
+
+Each PR references the relevant section(s) of `SPEC.md` and updates them **only if** behaviour changes. Otherwise, no doc edits.
+
+## Acceptance checklist
+* Loading the Logs view retrieves ~200 lines through `diagnostics_summary` with no UI file access.
+* Applying category filters updates instantly using OR semantics.
+* Severity selections follow the inclusive-upward model and apply immediately.
+* Local↔UTC toggle re-renders timestamps without re-fetching data.
+* Live Tail polling runs every 3–5 seconds and stops when navigating away.
+* Banner appears only when `dropped_count > 0` or `log_write_status` differs from `"ok"`.
+* Exported file contains `_meta`, payload, and `_checksum` lines in that order with a valid SHA-256 checksum.
+
+## Design rationale
+* **200-line tail:** chosen to keep payload <1 MB and guarantee IPC safety margin.
+* **3–5 s polling:** balances freshness and CPU/network overhead; derived from tracing buffer flush cadence.
+* **UTC storage:** avoids DST ambiguity; Europe/London chosen for local display as the only supported zone.
+* **Inclusive-upward severity:** matches `tracing_subscriber` level filtering semantics.
+* **No diffing:** full-tail replacement ensures determinism under rotation.

--- a/docs/logging/UI.md
+++ b/docs/logging/UI.md
@@ -1,0 +1,40 @@
+# Logging UI Guide
+
+Status: Draft
+Owner: Ged Kelly
+Last updated: 2025-10-07
+
+## Audience
+Frontend engineers implementing the Logs page presentation and interactive behaviour.
+
+## Layout
+* The Logs view adopts the standard application content grid. Sidebar and footer elements remain visible while the main content pane displays the logs.
+* A top header row combines the view title with control toggles and the export action. A narrow banner row appears below the header only when backpressure status needs to be communicated.
+* The remaining vertical space is devoted to the log table, which scrolls within the pane while keeping controls visible.
+
+## Controls
+* **Severity control:** Presented as ordered buttons or a slider that enforces the inclusive-upward model (e.g., choosing `warn` displays `warn` + `error`).
+* **Category selection:** Checkboxes or chips generated from distinct `event` values within the current tail. Multiple selections apply OR semantics.
+* **Search box:** Client-side substring match operating across rendered text, including timestamp, level, event, and message columns.
+* **Time toggle:** Switch between Local (Europe/London) and UTC display instantly without extra IPC calls.
+* **Live Tail toggle:** Start polling `diagnostics_summary` every 3–5 seconds while active; stop polling when toggled off or on navigation away.
+* **Export button:** Visible at all times to trigger JSONL export per the specification.
+
+## Table structure
+* Columns display `timestamp`, `level`, `event`, and `message`. Messages may truncate with ellipsis while preserving access to raw content.
+* Row click may open an optional detail surface showing full JSON for the selected line; if implemented, it must not block core interactions.
+* Table data is limited to the ~200 line tail returned by the IPC call, so no virtualisation is required. Smooth scrolling and consistent row heights are expected.
+* Rows should colour-code the `level` field using shared theme tokens: info = blue, warn = amber, error = red.
+
+## Performance considerations
+* Hold all records in memory within the view; re-fetching only occurs via manual refresh or Live Tail polling.
+* Client-side filtering and search must execute instantly over the 200-line dataset without noticeable lag.
+
+## Error handling
+* IPC failures render a structured error block within the main pane, offering retry without crashing the shell.
+* Malformed lines are skipped gracefully and optionally reported through a non-blocking toast or console log.
+
+## Related references
+* [SPEC](./SPEC.md)
+* [IPC](./IPC.md)
+* [EXPORT](./EXPORT.md)


### PR DESCRIPTION
## Summary
- restate the logging documentation’s portability guidance and add acceptance content for PR-0 inside the overview
- expand the specification with kebab-case naming policy, rotation limits, and design rationale for tail size, polling, and severity model
- clarify IPC ordering semantics and UI severity colour expectations to keep frontend and backend behaviour aligned

## Testing
- not run (docs only)

Docs only; foundation for PR-1…PR-8 per included SPEC.

------
https://chatgpt.com/codex/tasks/task_e_68e54fa3cf40832a950055e3b270b847