### PR TITLE
feat(logging): PR-1 entry & display — #logs route + bug icon

### DIFF
--- a/src/layout/Footer.ts
+++ b/src/layout/Footer.ts
@@ -82,13 +82,33 @@ export function Footer(items: FooterItemConfig[]): FooterInstance {
 
   const diagnostics = document.createElement("button");
   diagnostics.type = "button";
-  diagnostics.title = "Diagnostics / Logs";
-  diagnostics.setAttribute("aria-label", "Diagnostics and logs");
+  diagnostics.id = "footer-logs";
+  diagnostics.title = "Open logs";
+  diagnostics.setAttribute("aria-label", "Open logs");
+  diagnostics.classList.add("footer__logs");
   const bug = document.createElement("i");
   bug.className = "fa-regular fa-bug";
   bug.setAttribute("aria-hidden", "true");
   diagnostics.appendChild(bug);
   utilities.appendChild(diagnostics);
+
+  const focusableDiagnostics = diagnostics as HTMLButtonElement;
+
+  const navigateToLogs = () => {
+    if (location.hash === "#/logs") return;
+    location.hash = "#/logs";
+  };
+
+  focusableDiagnostics.addEventListener("click", (event) => {
+    event.preventDefault();
+    navigateToLogs();
+  });
+
+  focusableDiagnostics.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    navigateToLogs();
+  });
 
   const help = document.createElement("button");
   help.type = "button";
@@ -113,6 +133,11 @@ export function Footer(items: FooterItemConfig[]): FooterInstance {
       if (isActive) entry.link.setAttribute("aria-current", "page");
       else entry.link.removeAttribute("aria-current");
     });
+
+    const isLogs = id === "logs";
+    diagnostics.classList.toggle("is-current", isLogs);
+    if (isLogs) diagnostics.setAttribute("aria-current", "page");
+    else diagnostics.removeAttribute("aria-current");
   }
 
   function getLink(id: AppPane): HTMLAnchorElement | undefined {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,7 +13,9 @@ import { InventoryView } from "./InventoryView";
 import { BudgetView } from "./BudgetView";
 import { NotesView } from "./NotesView";
 import { ManageView } from "./ManageView";
+import { mountLogsView } from "./ui/views/logsView";
 import type { AppPane } from "./store";
+import { registerViewCleanup } from "./utils/viewLifecycle";
 import { ImportModal } from "@ui/ImportModal";
 
 const envRecord =
@@ -152,6 +154,22 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
       ariaLabel: "Settings",
       className: "footer__settings",
       icon: { name: "fa-gear", defaultVariant: "solid", activeVariant: "solid", fixed: true },
+    },
+  },
+  {
+    id: "logs",
+    hash: "#/logs",
+    legacyHashes: ["#logs"],
+    mount: (container) => {
+      const cleanup = mountLogsView(container);
+      registerViewCleanup(container, cleanup);
+      return cleanup;
+    },
+    display: {
+      placement: "hidden",
+      label: "Logs",
+      ariaLabel: "Logs",
+      icon: { name: "fa-bug", defaultVariant: "regular", activeVariant: "solid", fixed: true },
     },
   },
   {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,6 +26,7 @@ export type AppPane =
   | "budget"
   | "notes"
   | "settings"
+  | "logs"
   | "manage";
 
 export type AppError = {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 @use "./styles/manage";
+@use "./ui/styles/logs";
 
 :root {
   --radius-sm: 6px;
@@ -960,6 +961,16 @@ footer a.footer__settings {
   font-weight: 600;
   line-height: 1;
   transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.footer__utilities .footer__logs.is-current {
+  background-color: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.footer__logs:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .footer__settings i {

--- a/src/ui/styles/logs.scss
+++ b/src/ui/styles/logs.scss
@@ -1,0 +1,39 @@
+.logs-view {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.logs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border-block-end: 1px solid var(--color-border-subtle);
+}
+
+.logs-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.logs-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 32px;
+}
+
+.logs-content {
+  flex: 1;
+  padding: var(--space-4);
+}
+
+.logs-content .empty {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-style: italic;
+  opacity: 0.85;
+}

--- a/src/ui/views/logsView.ts
+++ b/src/ui/views/logsView.ts
@@ -1,0 +1,23 @@
+export function mountLogsView(container: HTMLElement): () => void {
+  container.innerHTML = `
+    <section class="logs-view" aria-labelledby="logs-title">
+      <header class="logs-header">
+        <h1 id="logs-title" class="logs-title">Logs</h1>
+        <div class="logs-actions" aria-live="polite" aria-atomic="true">
+          <!-- placeholders for PR-3/4/5: severity, categories, time toggle, live-tail, export -->
+        </div>
+      </header>
+      <div class="logs-content">
+        <div class="empty" data-testid="logs-empty-stub">
+          Logging console wired. Data & controls arrive in PR-2/3/4/5/7.
+        </div>
+      </div>
+    </section>
+  `;
+
+  const cleanup = () => {
+    // Placeholder cleanup; no resources to dispose yet.
+  };
+
+  return cleanup;
+}

--- a/tests/unit/logs-view.spec.ts
+++ b/tests/unit/logs-view.spec.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+
+import { mountLogsView } from "../../src/ui/views/logsView";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+const { document } = dom.window;
+
+test("mountLogsView renders the logs scaffold", () => {
+  const container = document.createElement("div");
+
+  const cleanup = mountLogsView(container);
+
+  const section = container.querySelector("section.logs-view");
+  assert.ok(section, "logs view section should render");
+  assert.equal(section?.getAttribute("aria-labelledby"), "logs-title");
+
+  const title = container.querySelector<HTMLHeadingElement>("#logs-title");
+  assert.ok(title, "logs title should exist");
+  assert.equal(title?.textContent?.trim(), "Logs");
+
+  const stub = container.querySelector("[data-testid='logs-empty-stub']");
+  assert.ok(stub, "logs stub placeholder should exist");
+
+  assert.equal(typeof cleanup, "function");
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- add the `logs` route definition resolving from `#logs` and mount the stub view
- wire the footer bug control to navigate to the logs pane and update active state styling
- scaffold the logs view shell with minimal styling and a DOM harness test

## Testing
- node --import ./scripts/test-preload.mjs --test tests/unit/logs-view.spec.ts

## Scope
- routing only; no IPC

## Links
- docs/logging/SPEC.md#entry-and-display
- docs/logging/OVERVIEW.md

------
https://chatgpt.com/codex/tasks/task_e_68e555a8f62c832aa6fd39a3e100d45e