### PR TITLE
Fix GMT label normalization in time formatter

### DIFF
--- a/docs/logging/UI.md
+++ b/docs/logging/UI.md
@@ -20,6 +20,13 @@ Frontend engineers implementing the Logs page presentation and interactive behav
 * **Live Tail toggle:** Start polling `diagnostics_summary` every 3–5 seconds while active; stop polling when toggled off or on navigation away.
 * **Export button:** Visible at all times to trigger JSONL export per the specification.
 
+## Time Display & Toggle
+* The header contains a single pill button labelled `Time: Local (BST/GMT) ↔ UTC`. Clicking swaps the displayed timestamps between London local time and UTC without additional data fetches.
+* Tooltips on each timestamp reveal the alternate representation so both formats remain one hover away.
+* Local output follows the `yyyy-MM-dd HH:mm:ss BST/GMT` pattern, automatically switching between BST and GMT using Luxon’s zone data. UTC output uses the same layout with a trailing `UTC` suffix to preserve lexical ordering.
+* Sorting and filtering always rely on the raw UTC epoch supplied by the backend, so toggling formats never reorders the rows.
+* Add an updated capture of the toggle placement to `docs/logging/images/logs-view.png` when available.
+
 ## Table structure
 * Columns display `timestamp`, `level`, `event`, and `message`. Messages may truncate with ellipsis while preserving access to raw content.
 * Row click may open an optional detail surface showing full JSON for the selected line; if implemented, it must not block core interactions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tauri-apps/plugin-sql": "^2.3.0",
         "@tauri-apps/plugin-store": "^2.4.0",
         "better-sqlite3": "^12.2.0",
+        "luxon": "^3.7.2",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -5384,6 +5385,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.19",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@tauri-apps/plugin-sql": "^2.3.0",
     "@tauri-apps/plugin-store": "^2.4.0",
     "better-sqlite3": "^12.2.0",
+    "luxon": "^3.7.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/features/logs/time.ts
+++ b/src/features/logs/time.ts
@@ -1,0 +1,50 @@
+import { DateTime } from "luxon";
+
+const LOCAL_ZONE = "Europe/London";
+const DISPLAY_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+function normalizeLabel(label: string, fallback: string): string {
+  const upper = label.toUpperCase();
+  if (upper === "GMT+1" || upper === "UTC+1") {
+    return "BST";
+  }
+  if (upper === "GMT" || upper === "UTC") {
+    return upper;
+  }
+  if (upper.includes("BRITISH SUMMER TIME")) {
+    return "BST";
+  }
+  if (upper.includes("GREENWICH MEAN TIME")) {
+    return "GMT";
+  }
+  return label || fallback;
+}
+
+function getDisplayLabel(dateTime: DateTime, fallback: string): string {
+  const label = dateTime.offsetNameShort || dateTime.offsetNameLong || fallback;
+  return normalizeLabel(label, fallback);
+}
+
+export function formatTimestamp(timestamp: string, toLocal: boolean): string {
+  const base = DateTime.fromISO(timestamp, { zone: "utc" });
+  if (!base.isValid) {
+    return timestamp;
+  }
+
+  const zoned = toLocal ? base.setZone(LOCAL_ZONE) : base.setZone("utc");
+  const fallbackLabel = toLocal
+    ? zoned.offset === 0
+      ? "GMT"
+      : "BST"
+    : "UTC";
+  const label = getDisplayLabel(zoned, fallbackLabel);
+  return `${zoned.toFormat(DISPLAY_FORMAT)} ${label}`;
+}
+
+export function getZoneLabel(toLocal: boolean): string {
+  if (!toLocal) {
+    return "UTC";
+  }
+  const now = DateTime.now().setZone(LOCAL_ZONE);
+  return getDisplayLabel(now, "GMT");
+}

--- a/src/ui/styles/logs.scss
+++ b/src/ui/styles/logs.scss
@@ -43,28 +43,29 @@
 
 .logs-time-toggle {
   display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.35rem 0.85rem;
   border: 1px solid var(--color-border-subtle, rgba(15, 23, 42, 0.12));
   border-radius: var(--radius-full, 9999px);
-  overflow: hidden;
   background: var(--color-surface-elevated, var(--color-surface, #fff));
-}
-
-.logs-time-toggle__button {
-  border: none;
-  background: transparent;
   color: var(--color-text-muted, rgba(71, 85, 105, 0.9));
   font-size: 0.8125rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  padding: 0.35rem 0.9rem;
+  line-height: 1.2;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
 }
 
-.logs-time-toggle__button.is-active {
-  background: var(--color-accent-soft, color-mix(in srgb, var(--color-accent, #2563eb) 18%, transparent));
+.logs-time-toggle[aria-pressed="true"] {
   color: var(--color-accent, #2563eb);
+  border-color: color-mix(in srgb, var(--color-accent, #2563eb) 45%, transparent);
+  background: color-mix(in srgb, var(--color-accent, #2563eb) 18%, transparent);
+}
+
+.logs-time-toggle:focus-visible {
+  outline: 2px solid var(--color-focus-ring, var(--color-accent, #2563eb));
+  outline-offset: 2px;
 }
 
 .logs-toolbar {

--- a/tests/unit/logs-time.spec.ts
+++ b/tests/unit/logs-time.spec.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import { formatTimestamp, getZoneLabel } from "../../src/features/logs/time";
+
+test("formatTimestamp preserves ordering for UTC and local displays", () => {
+  const timestamps = [
+    "2024-03-30T23:45:00Z",
+    "2024-03-31T00:30:00Z",
+    "2024-03-31T01:30:00Z",
+  ];
+
+  const utcFormatted = timestamps.map((ts) => formatTimestamp(ts, false));
+  const localFormatted = timestamps.map((ts) => formatTimestamp(ts, true));
+
+  assert.deepEqual(utcFormatted.slice().sort(), utcFormatted);
+  assert.deepEqual(localFormatted.slice().sort(), localFormatted);
+});
+
+test("formatTimestamp toggles BST and GMT labels correctly", () => {
+  const winter = "2024-01-15T12:00:00Z";
+  const summer = "2024-06-15T12:00:00Z";
+
+  const winterLocal = formatTimestamp(winter, true);
+  const summerLocal = formatTimestamp(summer, true);
+
+  assert.ok(winterLocal.endsWith("GMT"), `expected winter label to be GMT, got ${winterLocal}`);
+  assert.ok(summerLocal.endsWith("BST"), `expected summer label to be BST, got ${summerLocal}`);
+});
+
+test("getZoneLabel reports current local abbreviation", () => {
+  const label = getZoneLabel(true);
+  assert.ok(/^(BST|GMT)$/.test(label));
+  assert.equal(getZoneLabel(false), "UTC");
+});


### PR DESCRIPTION
## Summary
- stop normalizing the "GMT+00:00" abbreviation to BST so London timestamps render GMT correctly when offset is zero

## Testing
- node --import ./scripts/test-preload.mjs --test tests/unit/logs-time.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e56e315588832ab6b9f0a3e6a10710