### PR TITLE
feat: enforce view teardown and stabilize logs lifecycle

### DIFF
--- a/src/features/logs/logs.api.ts
+++ b/src/features/logs/logs.api.ts
@@ -1,5 +1,8 @@
 import { call } from "@lib/ipc/call";
 
-export function getTail(): Promise<unknown> {
+export function getTail({ signal }: { signal?: AbortSignal } = {}): Promise<unknown> {
+  if (signal?.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
   return call<unknown>("diagnostics_summary");
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,21 +1,23 @@
-import { DashboardView } from "./DashboardView";
-import { CalendarView } from "./CalendarView";
-import { FilesView } from "./FilesView";
-import { ShoppingListView } from "./ShoppingListView";
-import { BillsView } from "./BillsView";
-import { InsuranceView } from "./InsuranceView";
-import { VehiclesView } from "./VehiclesView";
-import { PetsView } from "./PetsView";
-import { FamilyView } from "./FamilyView";
-import { PropertyView } from "./PropertyView";
-import { SettingsView } from "./SettingsView";
-import { InventoryView } from "./InventoryView";
-import { BudgetView } from "./BudgetView";
-import { NotesView } from "./NotesView";
-import { ManageView } from "./ManageView";
-import { mountLogsView } from "./ui/views/logsView";
+import {
+  mountBillsView,
+  mountBudgetView,
+  mountCalendarView,
+  mountDashboardView,
+  mountFamilyView,
+  mountFilesView,
+  mountInsuranceView,
+  mountInventoryView,
+  mountLogsView,
+  mountManageView,
+  mountNotesView,
+  mountPetsView,
+  mountPropertyView,
+  mountSettingsView,
+  mountShoppingListView,
+  mountVehiclesView,
+} from "./ui/views";
+import { wrapLegacyView } from "./ui/views/wrapLegacyView";
 import type { AppPane } from "./store";
-import { registerViewCleanup } from "./utils/viewLifecycle";
 import { ImportModal } from "@ui/ImportModal";
 
 const envRecord =
@@ -42,11 +44,13 @@ export interface RouteDisplayConfig {
   icon?: RouteIconConfig;
 }
 
+export type RouteMountResult = void | (() => void);
+
 export interface RouteDefinition {
   id: AppPane;
   hash: `#/${string}`;
   legacyHashes?: string[];
-  mount: (container: HTMLElement) => void | Promise<void>;
+  mount: (container: HTMLElement) => RouteMountResult | Promise<RouteMountResult>;
   display?: RouteDisplayConfig;
 }
 
@@ -86,7 +90,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "manage",
     hash: "#/manage",
     legacyHashes: ["#manage"],
-    mount: (container) => ManageView(container),
+    mount: mountManageView,
     display: {
       placement: "hub",
       label: "Manage",
@@ -99,7 +103,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "dashboard",
     hash: "#/dashboard",
     legacyHashes: ["#dashboard"],
-    mount: (container) => DashboardView(container),
+    mount: mountDashboardView,
     display: {
       placement: "sidebar",
       label: "Dashboard",
@@ -110,7 +114,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "calendar",
     hash: "#/calendar",
     legacyHashes: ["#calendar"],
-    mount: (container) => CalendarView(container),
+    mount: mountCalendarView,
     display: {
       placement: "sidebar",
       label: "Calendar",
@@ -121,7 +125,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "files",
     hash: "#/files",
     legacyHashes: ["#files"],
-    mount: (container) => FilesView(container),
+    mount: mountFilesView,
     display: {
       placement: "sidebar",
       label: "Files",
@@ -132,7 +136,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "notes",
     hash: "#/notes",
     legacyHashes: ["#notes"],
-    mount: (container) => NotesView(container),
+    mount: mountNotesView,
     display: {
       placement: "sidebar",
       label: "Notes",
@@ -143,10 +147,13 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "settings",
     hash: "#/settings",
     legacyHashes: ["#settings"],
-    mount: (container) => {
-      SettingsView(container);
+    mount: async (container) => {
+      const cleanup = await mountSettingsView(container);
       const settingsContainer = container.querySelector<HTMLElement>(".settings");
       if (settingsContainer) addImportButtonToSettings(settingsContainer);
+      return () => {
+        cleanup();
+      };
     },
     display: {
       placement: "footer",
@@ -160,11 +167,7 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "logs",
     hash: "#/logs",
     legacyHashes: ["#logs"],
-    mount: (container) => {
-      const cleanup = mountLogsView(container);
-      registerViewCleanup(container, cleanup);
-      return cleanup;
-    },
+    mount: mountLogsView,
     display: {
       placement: "hidden",
       label: "Logs",
@@ -176,84 +179,84 @@ const ROUTE_DEFINITIONS: RouteDefinition[] = [
     id: "primary",
     hash: "#/primary",
     legacyHashes: ["#primary"],
-    mount: (container) => renderPlaceholder(container, "Primary"),
+    mount: wrapLegacyView((container) => renderPlaceholder(container, "Primary")),
     display: { placement: "hidden", label: "Primary" },
   },
   {
     id: "secondary",
     hash: "#/secondary",
     legacyHashes: ["#secondary"],
-    mount: (container) => renderPlaceholder(container, "Secondary"),
+    mount: wrapLegacyView((container) => renderPlaceholder(container, "Secondary")),
     display: { placement: "hidden", label: "Secondary" },
   },
   {
     id: "tasks",
     hash: "#/tasks",
     legacyHashes: ["#tasks"],
-    mount: (container) => renderPlaceholder(container, "Tasks"),
+    mount: wrapLegacyView((container) => renderPlaceholder(container, "Tasks")),
     display: { placement: "hidden", label: "Tasks" },
   },
   {
     id: "shopping",
     hash: "#/shopping",
     legacyHashes: ["#shopping"],
-    mount: (container) => ShoppingListView(container),
+    mount: mountShoppingListView,
     display: { placement: "hidden", label: "Shopping" },
   },
   {
     id: "bills",
     hash: "#/bills",
     legacyHashes: ["#bills"],
-    mount: (container) => BillsView(container),
+    mount: mountBillsView,
     display: { placement: "hidden", label: "Bills" },
   },
   {
     id: "insurance",
     hash: "#/insurance",
     legacyHashes: ["#insurance"],
-    mount: (container) => InsuranceView(container),
+    mount: mountInsuranceView,
     display: { placement: "hidden", label: "Insurance" },
   },
   {
     id: "property",
     hash: "#/property",
     legacyHashes: ["#property"],
-    mount: (container) => PropertyView(container),
+    mount: mountPropertyView,
     display: { placement: "hidden", label: "Property" },
   },
   {
     id: "vehicles",
     hash: "#/vehicles",
     legacyHashes: ["#vehicles"],
-    mount: (container) => VehiclesView(container),
+    mount: mountVehiclesView,
     display: { placement: "hidden", label: "Vehicles" },
   },
   {
     id: "pets",
     hash: "#/pets",
     legacyHashes: ["#pets"],
-    mount: (container) => PetsView(container),
+    mount: mountPetsView,
     display: { placement: "hidden", label: "Pets" },
   },
   {
     id: "family",
     hash: "#/family",
     legacyHashes: ["#family"],
-    mount: (container) => FamilyView(container),
+    mount: mountFamilyView,
     display: { placement: "hidden", label: "Family" },
   },
   {
     id: "inventory",
     hash: "#/inventory",
     legacyHashes: ["#inventory"],
-    mount: (container) => InventoryView(container),
+    mount: mountInventoryView,
     display: { placement: "hidden", label: "Inventory" },
   },
   {
     id: "budget",
     hash: "#/budget",
     legacyHashes: ["#budget"],
-    mount: (container) => BudgetView(container),
+    mount: mountBudgetView,
     display: { placement: "hidden", label: "Budget" },
   },
 ];

--- a/src/ui/styles/logs.scss
+++ b/src/ui/styles/logs.scss
@@ -350,19 +350,15 @@
 }
 
 .logs__status {
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.6rem;
   border-radius: var(--radius-base, 8px);
-  border: 1px solid
-    var(
-      --color-warn-border,
-      color-mix(in srgb, var(--color-warning, #d48806) 35%, transparent)
-    );
-  background: var(
-    --color-warn-bg,
-    color-mix(in srgb, var(--color-warning, #d48806) 18%, transparent)
-  );
+  border: 1px solid var(--color-warn-border, rgba(212, 136, 6, 0.85));
+  background: var(--color-warn-bg, rgba(212, 136, 6, 0.14));
   color: var(--color-warn-text, var(--color-warning, #d48806));
   font-size: 0.875rem;
+  transition: opacity 0.2s ease-in-out;
+  max-width: 640px;
+  margin-inline: auto;
 }
 
 .logs-banners {

--- a/src/ui/views/billsView.ts
+++ b/src/ui/views/billsView.ts
@@ -1,0 +1,4 @@
+import { BillsView } from "../../BillsView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountBillsView = wrapLegacyView(BillsView);

--- a/src/ui/views/budgetView.ts
+++ b/src/ui/views/budgetView.ts
@@ -1,0 +1,4 @@
+import { BudgetView } from "../../BudgetView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountBudgetView = wrapLegacyView(BudgetView);

--- a/src/ui/views/calendarView.ts
+++ b/src/ui/views/calendarView.ts
@@ -1,0 +1,4 @@
+import { CalendarView } from "../../CalendarView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountCalendarView = wrapLegacyView(CalendarView);

--- a/src/ui/views/dashboardView.ts
+++ b/src/ui/views/dashboardView.ts
@@ -1,0 +1,4 @@
+import { DashboardView } from "../../DashboardView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountDashboardView = wrapLegacyView(DashboardView);

--- a/src/ui/views/familyView.ts
+++ b/src/ui/views/familyView.ts
@@ -1,0 +1,4 @@
+import { FamilyView } from "../../FamilyView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountFamilyView = wrapLegacyView(FamilyView);

--- a/src/ui/views/filesView.ts
+++ b/src/ui/views/filesView.ts
@@ -1,0 +1,4 @@
+import { FilesView } from "../../FilesView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountFilesView = wrapLegacyView(FilesView);

--- a/src/ui/views/index.ts
+++ b/src/ui/views/index.ts
@@ -1,0 +1,16 @@
+export { mountBillsView } from "./billsView";
+export { mountBudgetView } from "./budgetView";
+export { mountCalendarView } from "./calendarView";
+export { mountDashboardView } from "./dashboardView";
+export { mountFamilyView } from "./familyView";
+export { mountFilesView } from "./filesView";
+export { mountInsuranceView } from "./insuranceView";
+export { mountInventoryView } from "./inventoryView";
+export { mountLogsView } from "./logsView";
+export { mountManageView } from "./manageView";
+export { mountNotesView } from "./notesView";
+export { mountPetsView } from "./petsView";
+export { mountPropertyView } from "./propertyView";
+export { mountSettingsView } from "./settingsView";
+export { mountShoppingListView } from "./shoppingListView";
+export { mountVehiclesView } from "./vehiclesView";

--- a/src/ui/views/insuranceView.ts
+++ b/src/ui/views/insuranceView.ts
@@ -1,0 +1,4 @@
+import { InsuranceView } from "../../InsuranceView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountInsuranceView = wrapLegacyView(InsuranceView);

--- a/src/ui/views/inventoryView.ts
+++ b/src/ui/views/inventoryView.ts
@@ -1,0 +1,4 @@
+import { InventoryView } from "../../InventoryView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountInventoryView = wrapLegacyView(InventoryView);

--- a/src/ui/views/manageView.ts
+++ b/src/ui/views/manageView.ts
@@ -1,0 +1,4 @@
+import { ManageView } from "../../ManageView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountManageView = wrapLegacyView(ManageView);

--- a/src/ui/views/notesView.ts
+++ b/src/ui/views/notesView.ts
@@ -1,0 +1,4 @@
+import { NotesView } from "../../NotesView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountNotesView = wrapLegacyView(NotesView);

--- a/src/ui/views/petsView.ts
+++ b/src/ui/views/petsView.ts
@@ -1,0 +1,4 @@
+import { PetsView } from "../../PetsView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountPetsView = wrapLegacyView(PetsView);

--- a/src/ui/views/propertyView.ts
+++ b/src/ui/views/propertyView.ts
@@ -1,0 +1,4 @@
+import { PropertyView } from "../../PropertyView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountPropertyView = wrapLegacyView(PropertyView);

--- a/src/ui/views/settingsView.ts
+++ b/src/ui/views/settingsView.ts
@@ -1,0 +1,4 @@
+import { SettingsView } from "../../SettingsView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountSettingsView = wrapLegacyView(SettingsView);

--- a/src/ui/views/shoppingListView.ts
+++ b/src/ui/views/shoppingListView.ts
@@ -1,0 +1,4 @@
+import { ShoppingListView } from "../../ShoppingListView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountShoppingListView = wrapLegacyView(ShoppingListView);

--- a/src/ui/views/vehiclesView.ts
+++ b/src/ui/views/vehiclesView.ts
@@ -1,0 +1,4 @@
+import { VehiclesView } from "../../VehiclesView";
+import { wrapLegacyView } from "./wrapLegacyView";
+
+export const mountVehiclesView = wrapLegacyView(VehiclesView);

--- a/src/ui/views/wrapLegacyView.ts
+++ b/src/ui/views/wrapLegacyView.ts
@@ -1,0 +1,21 @@
+import { runViewCleanups } from "../../utils/viewLifecycle";
+
+export type LegacyViewMount = (container: HTMLElement) => void | Promise<void>;
+
+export function wrapLegacyView(
+  mount: LegacyViewMount,
+): (container: HTMLElement) => void | Promise<() => void> {
+  return (container) => {
+    const result = mount(container);
+    if (result && typeof (result as PromiseLike<void>).then === "function") {
+      return (result as PromiseLike<void>).then(() => () => {
+        runViewCleanups(container);
+        container.replaceChildren();
+      });
+    }
+    return () => {
+      runViewCleanups(container);
+      container.replaceChildren();
+    };
+  };
+}

--- a/tests/logs-lifecycle.test.ts
+++ b/tests/logs-lifecycle.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import { mountLogsView } from '../src/ui/views/logsView.ts';
+import {
+  logsStore,
+  __setTailFetcherForTests,
+  __resetTailFetcherForTests,
+} from '../src/features/logs/logs.store.ts';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost',
+});
+
+dom.window.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+  dom.window.setTimeout(() => callback(performance.now()), 0)) as typeof dom.window.requestAnimationFrame;
+
+(globalThis as any).window = dom.window as unknown as typeof globalThis & Window;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).HTMLInputElement = dom.window.HTMLInputElement;
+(globalThis as any).HTMLSelectElement = dom.window.HTMLSelectElement;
+(globalThis as any).HTMLTableSectionElement = dom.window.HTMLTableSectionElement;
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('Logs view cleanup clears timers, entries, and subscriptions', async () => {
+  logsStore.clear();
+  __setTailFetcherForTests(async () => ({
+    lines: [
+      {
+        ts: '2025-10-07T18:24:00Z',
+        level: 'info',
+        event: 'alpha',
+        message: 'Alpha info',
+      },
+    ],
+  }));
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const createdIntervals: number[] = [];
+  const clearedIntervals: number[] = [];
+  let nextIntervalId = 1;
+  const originalSetInterval = window.setInterval;
+  const originalClearInterval = window.clearInterval;
+
+  window.setInterval = ((callback: TimerHandler, delay?: number) => {
+    const id = nextIntervalId++;
+    createdIntervals.push(id);
+    return id as unknown as number;
+  }) as typeof window.setInterval;
+
+  window.clearInterval = ((handle: number | NodeJS.Timeout) => {
+    clearedIntervals.push(handle as number);
+  }) as typeof window.clearInterval;
+
+  try {
+    const cleanup = mountLogsView(container);
+    await flush();
+
+    const toggle = container.querySelector<HTMLInputElement>("[data-testid='logs-live-toggle']");
+    assert.ok(toggle, 'expected live tail toggle to be present');
+    toggle!.checked = true;
+    toggle!.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+
+    await flush();
+
+    assert.equal(createdIntervals.length, 1, 'live tail should schedule one interval');
+
+    const tableBody = container.querySelector<HTMLTableSectionElement>('.logs-table tbody');
+    assert.ok(tableBody);
+
+    cleanup();
+
+    assert.deepEqual(
+      clearedIntervals,
+      createdIntervals,
+      'cleanup should clear all created intervals',
+    );
+    assert.equal(createdIntervals.length, clearedIntervals.length);
+    assert.equal(logsStore.state.status, 'idle');
+    assert.equal(logsStore.state.entries.length, 0);
+    assert.equal(tableBody?.children.length, 0);
+  } finally {
+    window.setInterval = originalSetInterval;
+    window.clearInterval = originalClearInterval;
+    container.remove();
+    __resetTailFetcherForTests();
+    logsStore.clear();
+  }
+});

--- a/tests/logs-status.test.ts
+++ b/tests/logs-status.test.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import { mountLogsView } from '../src/ui/views/logsView.ts';
+import {
+  logsStore,
+  __setTailFetcherForTests,
+  __resetTailFetcherForTests,
+} from '../src/features/logs/logs.store.ts';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost',
+});
+
+dom.window.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+  dom.window.setTimeout(() => callback(performance.now()), 0)) as typeof dom.window.requestAnimationFrame;
+
+(globalThis as any).window = dom.window as unknown as typeof globalThis & Window;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).HTMLInputElement = dom.window.HTMLInputElement;
+(globalThis as any).HTMLSelectElement = dom.window.HTMLSelectElement;
+(globalThis as any).HTMLTableSectionElement = dom.window.HTMLTableSectionElement;
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('Logs status banner reflects dropped entries and IO errors', async () => {
+  logsStore.clear();
+
+  const responses = [
+    {
+      lines: [
+        { ts: '2025-10-07T18:24:00Z', level: 'info', event: 'alpha', message: 'Alpha info' },
+      ],
+      dropped_count: 2,
+      log_write_status: 'ok',
+    },
+    {
+      lines: [
+        { ts: '2025-10-07T18:25:00Z', level: 'warn', event: 'beta', message: 'Beta warn' },
+      ],
+      log_write_status: 'io_error',
+    },
+    {
+      lines: [
+        { ts: '2025-10-07T18:26:00Z', level: 'info', event: 'gamma', message: 'Gamma info' },
+      ],
+      log_write_status: 'ok',
+    },
+  ];
+
+  __setTailFetcherForTests(async () => {
+    return responses.shift() ?? { lines: [] };
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  try {
+    const cleanup = mountLogsView(container);
+    await flush();
+
+    const status = container.querySelector<HTMLElement>('#logs-status');
+    assert.ok(status);
+    assert.equal(
+      status?.textContent,
+      '⚠ Some log entries may have been skipped (buffer full).',
+    );
+    assert.equal(status?.hidden, false);
+
+    await logsStore.fetchTail();
+    await flush();
+    assert.equal(status?.textContent, '⚠ Logging paused – disk write issue detected.');
+    assert.equal(status?.hidden, false);
+
+    await logsStore.fetchTail();
+    await flush();
+    assert.equal(status?.textContent, '');
+    assert.equal(status?.hidden, true);
+
+    cleanup();
+  } finally {
+    container.remove();
+    __resetTailFetcherForTests();
+    logsStore.clear();
+  }
+});


### PR DESCRIPTION
## Summary
- add reusable mount wrappers so every routed view returns a cleanup function and renderApp enforces teardown with assertions
- harden the logs view lifecycle, resetting timers, state, and focus while improving accessibility feedback and banner styling
- update the logs store with abortable fetches and deterministic clear(), and add lifecycle/status unit tests covering teardown flows

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e60cb42398832a9fe56ad3e155d7e2