### PR TITLE
Add right-column layout banners

### DIFF
--- a/src/layout/Page.ts
+++ b/src/layout/Page.ts
@@ -26,6 +26,13 @@ export function Page({ sidebar, content, footer, toolbar }: PageProps): PageInst
   liveRegion.className = "sr-only";
   liveRegion.setAttribute("aria-live", "polite");
 
+  const bannerHost = document.createElement("div");
+  bannerHost.id = "page-banner";
+  bannerHost.className = "page-banner";
+  bannerHost.setAttribute("role", "img");
+  bannerHost.setAttribute("aria-hidden", "true");
+  bannerHost.hidden = true;
+
   function mount(target: HTMLElement = document.body) {
     if (toolbar && !content.element.contains(toolbar.element)) {
       content.element.prepend(toolbar.element);
@@ -46,6 +53,7 @@ export function Page({ sidebar, content, footer, toolbar }: PageProps): PageInst
     nextChildren.push(
       sidebar.element,
       content.element,
+      bannerHost,
       footer.element,
       modalRoot,
       liveRegion,

--- a/src/main.ts
+++ b/src/main.ts
@@ -431,12 +431,16 @@ function updatePageBanner(route: RouteDefinition): void {
   if (url) {
     bannerEl.hidden = false;
     bannerEl.style.backgroundImage = `url("${url}")`;
+    bannerEl.style.setProperty("--banner-pos-x", "50%");
+    bannerEl.style.setProperty("--banner-pos-y", "50%");
     bannerEl.setAttribute("aria-hidden", "false");
     bannerEl.setAttribute("aria-label", `${label} banner`);
     body.dataset.bannerVisibility = "visible";
   } else {
     bannerEl.hidden = true;
     bannerEl.style.removeProperty("background-image");
+    bannerEl.style.removeProperty("--banner-pos-x");
+    bannerEl.style.removeProperty("--banner-pos-y");
     bannerEl.setAttribute("aria-hidden", "true");
     bannerEl.removeAttribute("aria-label");
     delete body.dataset.bannerVisibility;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -115,8 +115,10 @@ main.container {
   grid-column: 3;
   grid-row: 2;
   align-self: stretch;
+  --banner-pos-x: 50%;
+  --banner-pos-y: 50%;
   background-repeat: no-repeat;
-  background-position: center right;
+  background-position: var(--banner-pos-x) var(--banner-pos-y);
   background-size: cover;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
   opacity: 0.98;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,6 +11,8 @@
   --window-surface-inset: 0px;
   /* Height for the custom macOS-style toolbar (2x previous) */
   --app-toolbar-height: 64px;
+  --banner-w: 112px;
+  --banner-gap: 12px;
 }
 
 /* Animatable gradient variables for the app-wide backdrop */
@@ -80,8 +82,49 @@ body {
   display: grid;
   grid-template-columns: minmax(160px, max-content) 1fr;
   grid-template-rows: var(--app-toolbar-height) 1fr auto;
+  column-gap: 0;
   margin: 0;
   position: relative;
+}
+
+body[data-banner-visibility="visible"] {
+  grid-template-columns:
+    minmax(160px, max-content)
+    1fr
+    var(--banner-w);
+  column-gap: var(--banner-gap);
+}
+
+body[data-banner-visibility="hidden"],
+body:not([data-banner-visibility]) {
+  grid-template-columns: minmax(160px, max-content) 1fr;
+  column-gap: 0;
+}
+
+.sidebar {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+main.container {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.page-banner {
+  grid-column: 3;
+  grid-row: 2;
+  align-self: stretch;
+  background-repeat: no-repeat;
+  background-position: center right;
+  background-size: cover;
+  border-left: 1px solid rgba(0, 0, 0, 0.06);
+  opacity: 0.98;
+}
+
+body[data-banner-visibility="hidden"] .page-banner,
+body:not([data-banner-visibility]) .page-banner {
+  display: none;
 }
 
 /* App-wide backdrop layer: sits behind toolbar/sidebar/content/footer */
@@ -182,13 +225,22 @@ footer {
 .window-surface { display: none !important; }
 
 @media (max-width: 900px) {
-  body {
+  body,
+  body[data-banner-visibility="visible"],
+  body[data-banner-visibility="hidden"] {
     grid-template-columns: var(--layout-sidebar-collapsed) 1fr;
+    column-gap: 0;
+  }
+
+  .page-banner {
+    display: none !important;
   }
 }
 
 @media (max-width: 600px) {
-  body {
+  body,
+  body[data-banner-visibility="visible"],
+  body[data-banner-visibility="hidden"] {
     grid-template-columns: var(--layout-sidebar-collapsed-sm) 1fr;
   }
 }

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -1,0 +1,22 @@
+const imports = import.meta.glob("/src/assets/banners/*/*.png", {
+  eager: true,
+  query: "?url",
+  import: "default",
+}) as Record<string, string>;
+
+function keyFrom(path: string): string | null {
+  const match = path.match(/\/banners\/([^/]+)\/\1\.png$/);
+  return match ? match[1] : null;
+}
+
+const BANNERS: Record<string, string> = {};
+for (const [path, url] of Object.entries(imports)) {
+  const key = keyFrom(path);
+  if (key) {
+    BANNERS[key] = url;
+  }
+}
+
+export function bannerFor(pageKey: string): string | undefined {
+  return BANNERS[pageKey];
+}


### PR DESCRIPTION
## Summary
- add a build-time map of page banner assets and expose a lookup helper
- extend the page layout and global styles with a dedicated right banner column
- update routing to toggle the banner per route and collapse the column when no image is available

## Testing
- npm run build *(fails: TypeScript errors in existing logs view code)*

------
https://chatgpt.com/codex/tasks/task_e_68e6247cfe38832a867dc0baa2fb4379