### PR TITLE
Add baseline documentation for Family module

### DIFF
--- a/docs/family/README.md
+++ b/docs/family/README.md
@@ -1,0 +1,24 @@
+# Family module baseline documentation
+
+This directory captures how the Family area behaves **as shipped today**, spanning storage, IPC, UI, and diagnostics. It is the frozen reference point for upcoming feature work.
+
+## Quick links
+- [Architecture](architecture.md)
+- [Database](database.md)
+- [IPC contracts](ipc.md)
+- [Frontend behaviour](frontend.md)
+- [Diagnostics & logging](diagnostics.md)
+- [Changelog](changelog.md)
+
+## Snapshot highlights
+- The Rust command surface exposes six generic `family_members_*` handlers generated in `src-tauri/src/lib.rs`; they delegate straight into the shared command helpers without extra logging.【F:src-tauri/src/lib.rs†L638-L853】
+- TypeScript talks to those commands through `familyRepo` in `src/repos.ts`, which applies the `"position, created_at, id"` ordering for every list call.【F:src/repos.ts†L32-L107】
+- The web UI is implemented entirely in `src/FamilyView.ts`, which mounts a `<section>` inside the supplied container, renders the list/form markup with `innerHTML`, and wires event listeners per element.【F:src/FamilyView.ts†L20-L145】
+- Persistent data lives in the `family_members` table defined in the baseline migration and `schema.sql`, with `position INTEGER NOT NULL DEFAULT 0` plus a filtered uniqueness index on `(household_id, position)`.【F:migrations/0001_baseline.sql†L129-L139】【F:schema.sql†L115-L125】【F:schema.sql†L273-L274】
+- Diagnostics currently surface Family only via aggregate counts (`familyMembers`) and export routines; no dedicated log events are emitted when the commands run.【F:src-tauri/src/diagnostics.rs†L90-L116】【F:src-tauri/src/lib.rs†L638-L853】【F:src-tauri/src/export/mod.rs†L224-L268】
+
+## Known limitations (documented facts)
+- There is no user-facing error messaging: the create path lacks a `try/catch`, and the update handlers swallow errors silently.【F:src/FamilyView.ts†L58-L145】
+- Family has no automated coverage; a repository search for `family_members` inside `tests/` returns no matches (ripgrep exits with status 1).【6d1e6d†L1-L3】
+- The module has no dedicated styling or shared components beyond layout/banner plumbing; no selectors for `family` exist in the global stylesheet, and routing simply mounts the legacy view under the hidden navigation group.【F:src/styles.scss†L392-L3872】【F:src/routes.ts†L1-L260】
+- There are no reordering controls or additional IPC endpoints beyond the CRUD set; the UI only lists, creates, and opens members, and the backend exposes the generic helpers listed above.【F:src/FamilyView.ts†L41-L145】【F:src-tauri/src/lib.rs†L638-L853】

--- a/docs/family/architecture.md
+++ b/docs/family/architecture.md
@@ -1,0 +1,41 @@
+# Architecture
+
+## Module layout
+- **Rust IPC surface:** `src-tauri/src/lib.rs` expands `gen_domain_cmds!` with `family_members`, generating the six IPC entry points that proxy into the shared command helpers.【F:src-tauri/src/lib.rs†L638-L853】
+- **Shared command helpers:** `src-tauri/src/commands.rs` handles `list`, `get`, `create`, `update`, `delete`, and `restore`, forwarding into `repo::*` for filtering, inserts, and soft-delete workflows.【F:src-tauri/src/commands.rs†L669-L734】【F:src-tauri/src/commands.rs†L1120-L1138】
+- **Repository layer:** `src-tauri/src/repo.rs` provides the `list_active`, `get_active`, `clear_deleted_at`, and `renumber_positions` routines that implement household scoping, deleted filters, and stable ordering.【F:src-tauri/src/repo.rs†L165-L205】【F:src-tauri/src/repo.rs†L220-L260】【F:src-tauri/src/repo.rs†L300-L339】【F:src-tauri/src/repo.rs†L450-L506】
+- **TypeScript repo:** `familyRepo` in `src/repos.ts` is the only exported client for the module and is consumed solely by the legacy `FamilyView` wrapper.【F:src/repos.ts†L32-L107】【F:src/ui/views/familyView.ts†L1-L4】【F:src/ui/views/index.ts†L1-L16】
+- **UI layer:** `src/FamilyView.ts` mounts the page, renders the list/profile states, and calls `familyRepo` directly. No other view imports this module aside from the router plumbing (`mountFamilyView`).【F:src/FamilyView.ts†L20-L148】【F:src/routes.ts†L1-L260】【5403e3†L1-L11】
+
+## Data flow
+```mermaid
+flowchart LR
+  subgraph Renderer
+    View[FamilyView.ts]
+    RepoTS[familyRepo (repos.ts)]
+  end
+  subgraph Backend
+    IPC[family_members_* commands]
+    Cmd[commands.rs helpers]
+    RepoRust[repo.rs]
+  end
+  DB[(SQLite family_members table)]
+
+  View --> RepoTS
+  RepoTS --> IPC
+  IPC --> Cmd
+  Cmd --> RepoRust
+  RepoRust --> DB
+  DB --> RepoRust
+  RepoRust --> Cmd
+  Cmd --> IPC
+  IPC --> RepoTS
+  RepoTS --> View
+```
+
+The renderer issues list/create/update calls through `familyRepo`, which invokes the IPC commands via the generic `call` wrapper. Those commands enter the Rust helpers that enforce household scoping, soft-delete filters, and ordering before executing SQL against `family_members` via `repo.rs` and SQLite.【F:src/FamilyView.ts†L27-L145】【F:src/repos.ts†L32-L107】【F:src/lib/ipc/call.ts†L26-L110】【F:src-tauri/src/lib.rs†L638-L853】【F:src-tauri/src/commands.rs†L669-L734】【F:src-tauri/src/repo.rs†L165-L339】
+
+## Layout & navigation integration
+- The view is mounted through `wrapLegacyView(FamilyView)` and registered under the hidden navigation pane with route ID `family`, hash `#/family`, and legacy alias `#family`. The router does not lazy-load the module; it is part of the main bundle imports.【F:src/ui/views/familyView.ts†L1-L4】【F:src/routes.ts†L1-L260】
+- Application layout creates the shared `#page-banner` host and injects the Family banner image when navigating to the route. `bannerFor` maps `/src/assets/banners/family/family.png` and `updatePageBanner` toggles visibility/ARIA state on every route change.【F:src/layout/Page.ts†L24-L53】【F:src/main.ts†L420-L460】【F:src/ui/banner.ts†L1-L18】【ee8b46†L1-L1】
+- No other modules import Family code directly; references are limited to the view wrapper, re-export hub, and router registration confirmed by the repository-wide search output.【5403e3†L1-L11】

--- a/docs/family/changelog.md
+++ b/docs/family/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+_No entries — the Family baseline described in this folder matches the repository state at the time of writing._

--- a/docs/family/database.md
+++ b/docs/family/database.md
@@ -1,0 +1,37 @@
+# Database
+
+## Table definition
+```sql
+CREATE TABLE family_members (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  birthday INTEGER,
+  notes TEXT,
+  household_id TEXT NOT NULL REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
+  position INTEGER NOT NULL DEFAULT 0
+);
+```
+The table was introduced in the baseline migration (`migrations/0001_baseline.sql`) and the schema mirror (`schema.sql`) still matches that definition today.【F:migrations/0001_baseline.sql†L129-L139】【F:schema.sql†L115-L125】
+
+### Constraints & indexes
+- Foreign key: `household_id` cascades on delete and update into the owning household.【F:schema.sql†L120-L120】
+- Defaults / nullability: `name`, `household_id`, `created_at`, `updated_at`, and `position` are `NOT NULL`, with `position` defaulting to `0`; `birthday`, `notes`, and `deleted_at` are nullable.【F:schema.sql†L115-L125】
+- Ordering index: a partial unique index enforces `(household_id, position)` uniqueness for active rows (`deleted_at IS NULL`).【F:schema.sql†L273-L274】
+- Secondary index: `(household_id, updated_at)` supports ordered lookups during sync/refresh operations.【F:schema.sql†L273-L274】
+- No triggers or views reference `family_members`; the schema file lists only the table and these two indexes with no additional database objects for the domain.【F:schema.sql†L115-L274】
+
+### Lifecycle behaviour
+- Reads always filter on `deleted_at IS NULL` via `repo::list_active` / `get_active`, which also enforce household scoping and stable ordering (`position, created_at, id`).【F:src-tauri/src/repo.rs†L165-L239】
+- Soft deletion sets `deleted_at`, bumps `updated_at`, and renumbers positions inside a transaction; restore clears `deleted_at`, adds `1_000_000` to the stored position, and then recomputes sequential positions via `renumber_positions`.【F:src-tauri/src/repo.rs†L300-L339】【F:src-tauri/src/repo.rs†L450-L506】
+- Inserts and updates stamp `created_at`/`updated_at` in the command helper before writing to SQLite, so rows always carry timestamps.【F:src-tauri/src/commands.rs†L695-L734】
+
+### Migration lineage & ownership
+- The migration lives in `migrations/0001_baseline.sql`, alongside other legacy tables. There are no later migrations that alter `family_members`; schema evolution has not touched the table since the baseline file.【F:migrations/0001_baseline.sql†L90-L160】
+- No other table carries a foreign key to `family_members`; related domains (pets, bills, notes, etc.) remain household-scoped only.【F:schema.sql†L115-L274】
+- Household cascade deletes include `family_members` in the phase list, ensuring vacuum/hard-repair sweeps the table with the rest of the tenant data.【F:src-tauri/src/household.rs†L380-L418】
+
+### SQLite runtime configuration
+The SQLite pool enforces `journal_mode=WAL`, `synchronous=FULL`, `foreign_keys=ON`, sets a 5 s busy timeout, and enables WAL autocheckpointing when connections are established; `log_effective_pragmas` records the effective values for diagnostics.【F:src-tauri/src/db.rs†L139-L219】

--- a/docs/family/diagnostics.md
+++ b/docs/family/diagnostics.md
@@ -1,0 +1,15 @@
+# Diagnostics & logging
+
+## Logging configuration
+- The Tauri runtime configures rotating JSON logs with a 5 MB max size and five retained files, stored under `logs/arklowdun.log`. These constants live at the top of `src-tauri/src/lib.rs` and apply globally, including Family operations.【F:src-tauri/src/lib.rs†L56-L120】
+- No additional tracing or structured log events are emitted by the Family IPC handlers; the generated functions call the shared command helpers without invoking `tracing::*` macros.【F:src-tauri/src/lib.rs†L638-L853】
+
+## Health & diagnostics surfaces
+- Household diagnostics collect table counts under the alias `familyMembers`, ensuring support bundles report active row totals for the module.【F:src-tauri/src/diagnostics.rs†L90-L116】
+- Database exports include `family_members` in the list of tables dumped with `deleted_at IS NULL`, so backups and support packages capture the current active roster.【F:src-tauri/src/export/mod.rs†L224-L268】
+- Hard-repair and cascade-delete routines treat `family_members` as one of the phase tables, so repair telemetry covers the Family dataset along with other household-scoped domains.【F:src-tauri/src/household.rs†L380-L418】
+
+## Database environment reporting
+- When the SQLite pool is created, the code enforces `journal_mode=WAL`, `synchronous=FULL`, `foreign_keys=ON`, sets `busy_timeout = 5000`, and calls `log_effective_pragmas` to record the observed values—these settings apply to every Family query executed through the shared pool.【F:src-tauri/src/db.rs†L139-L219】
+
+Overall, Family contributes diagnostic counts and appears in export manifests, but it does not yet emit any module-specific logs beyond the shared infrastructure described above.

--- a/docs/family/frontend.md
+++ b/docs/family/frontend.md
@@ -1,0 +1,23 @@
+# Frontend behaviour
+
+## Mount & layout
+`FamilyView` clears the supplied container, inserts a single `<section>`, and keeps all subsequent renders confined to that element. Rendering is performed with `section.innerHTML = …`, so each transition between the list and profile views rebuilds the DOM from scratch.【F:src/FamilyView.ts†L20-L148】
+
+## Listing & creation flow
+- `load()` calls `familyRepo.list({ householdId, orderBy: "position, created_at, id" })` and stores the array in the module-level `members` variable; `refresh()` re-runs the same query.【F:src/FamilyView.ts†L27-L39】
+- `showList()` draws an unordered list plus the “Add Member” form. `renderMembers` empties the list and appends `<li>` rows with “Open” buttons for each member.【F:src/FamilyView.ts†L41-L85】【F:src/FamilyView.ts†L7-L18】
+- The form uses required `<input>` fields and, on submit, parses the `YYYY-MM-DD` date at local noon before calling `familyRepo.create`. After awaiting the create, it refreshes, re-renders the list, and resets the form without additional validation feedback.【F:src/FamilyView.ts†L45-L77】
+
+## Profile editing
+- Clicking an “Open” button looks up the member by ID and calls `showProfile(member)`, replacing the section markup with inline birthday and notes controls.【F:src/FamilyView.ts†L79-L145】
+- The “Back” button gathers staged edits into a patch, sets `updated_at = nowMs()`, and attempts to persist via `familyRepo.update` before returning to the list. Errors are swallowed by an empty `catch` block.【F:src/FamilyView.ts†L103-L125】
+- Notes and birthday fields attach their own `input`/`change` listeners, issuing immediate updates with optimistic UI; failures are ignored silently (`catch {}`) so the view never surfaces error messages to the user.【F:src/FamilyView.ts†L127-L145】
+
+## Event wiring & UX characteristics
+- Event listeners are attached per element: the form listens for `submit`, the list delegates `click` events to buttons, and profile controls register their own handlers—there is no shared event bus or global shortcuts in this view.【F:src/FamilyView.ts†L41-L145】
+- Because the list is rebuilt with `innerHTML = ""` followed by fresh node creation, there is no diffing or animation; scroll position resets whenever `showList()` reruns after a profile edit.【F:src/FamilyView.ts†L41-L125】
+- Date handling uses `toDate(...).toISOString().slice(0,10)` for display and constructs new `Date(y, m-1, d, 12, 0, 0, 0)` instances to store birthdays as epoch milliseconds, matching the integer column in SQLite.【F:src/FamilyView.ts†L62-L144】
+
+## Integration points
+- The view obtains the active household via `getHouseholdIdForCalls()` and performs all IPC work through `familyRepo`, with no additional caching or memoisation of the member list beyond the local `members` array.【F:src/FamilyView.ts†L25-L39】【F:src/repos.ts†L32-L107】
+- Styling is inherited from the global stylesheet; there are no Family-specific selectors or CSS modules, so the UI relies on default layout styles plus the shared banner configured in the architecture layer.【F:src/styles.scss†L392-L3872】【F:src/layout/Page.ts†L24-L53】

--- a/docs/family/ipc.md
+++ b/docs/family/ipc.md
@@ -1,0 +1,25 @@
+# IPC contracts
+
+## Registered commands
+The `gen_domain_cmds!` macro in `src-tauri/src/lib.rs` registers the six Family endpoints:
+
+| Command | Parameters | Return value |
+| --- | --- | --- |
+| `family_members_list` | `household_id`, optional `order_by`, `limit`, `offset` | `Vec<serde_json::Value>` rows filtered to the active household | 
+| `family_members_get` | optional `household_id`, `id` | `Option<serde_json::Value>` for the matching active row |
+| `family_members_create` | JSON object (`data`) | Inserted row as a JSON object |
+| `family_members_update` | `id`, JSON `data`, optional `household_id` | `()` |
+| `family_members_delete` | `household_id`, `id` | `()` |
+| `family_members_restore` | `household_id`, `id` | `()` |
+
+Each command is an async Tauri handler that immediately delegates to the shared command helpers without adding logging or tracing statements.【F:src-tauri/src/lib.rs†L638-L853】
+
+## Behaviour of shared helpers
+- `list_command` / `get_command` call `repo::list_active` / `repo::get_active`, guaranteeing `deleted_at IS NULL` and enforcing household scoping and order before converting rows to JSON values.【F:src-tauri/src/commands.rs†L669-L693】
+- `create_command` injects a UUID, fills `created_at`/`updated_at`, validates that every column has a value, and returns the inserted payload. Missing fields trigger `COMMANDS/MISSING_FIELD` with the offending column in the context map.【F:src-tauri/src/commands.rs†L695-L734】
+- `update_command` (not shown above) and `delete_command` call into `repo` to apply partial updates or soft-deletes, while `restore_command` clears `deleted_at` and renumbers positions for ordered tables such as `family_members`.【F:src-tauri/src/commands.rs†L695-L734】【F:src-tauri/src/commands.rs†L1120-L1138】【F:src-tauri/src/repo.rs†L300-L506】
+- SQLx errors are normalised through `AppError::from_sqlx_ref`, which preserves the SQLite constraint name (e.g., the unique `(household_id, position)` index) when present.【F:src-tauri/src/error/mod.rs†L302-L328】
+
+## Frontend invocation & error mapping
+- The renderer calls these commands via `familyRepo` (`src/repos.ts`), which simply forwards arguments to `call("family_members_*", …)` and expects the full row on create. There is no local caching layer for the Family list.【F:src/repos.ts†L32-L107】
+- The IPC adapter wraps errors with `normalizeError`, standardising `code`, `message`, and optional `context` before rethrowing. No additional UI handling is implemented in `FamilyView`, so errors surface only via rejected promises/console output.【F:src/lib/ipc/call.ts†L26-L110】【F:src/FamilyView.ts†L58-L145】


### PR DESCRIPTION
## Summary
- add a dedicated docs/family directory capturing the current Family module baseline
- document architecture, database schema, IPC contracts, frontend behaviour, diagnostics, and changelog stub with citations

## Testing
- npm run lint *(fails: pre-existing no-restricted-imports violation in src/features/logs/exportLogsJsonl.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e693645008832abb74c035f86c14a6