### PR TITLE
docs: polish family expansion blueprint

### DIFF
--- a/docs/family/plan/attachments.md
+++ b/docs/family/plan/attachments.md
@@ -1,0 +1,51 @@
+# Member attachments (PR9)
+
+Attachments provide per-member document storage starting in PR1 (schema) and PR9 (UI). This document defines storage rules, IPC expectations, UI behaviour, and security constraints.
+
+## Table summary
+See [schema_changes.md](schema_changes.md#member_attachments-table) for DDL. Each row maps a vault file to a member.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | TEXT primary key | UUIDv4 generated in Rust. |
+| `household_id` | TEXT NOT NULL | Must match the owning member's household. |
+| `member_id` | TEXT NOT NULL | References `family_members.id`. |
+| `title` | TEXT | Optional user-friendly name. |
+| `root_key` | TEXT NOT NULL | Vault root identifier. |
+| `relative_path` | TEXT NOT NULL | Path inside the vault root. |
+| `mime_hint` | TEXT | Optional MIME type hint. |
+| `added_at` | INTEGER NOT NULL | Epoch ms when attachment created. |
+
+Unique index `(household_id, root_key, relative_path)` prevents duplicate registrations of the same file.
+
+## IPC operations
+Detailed in [ipc_extensions.md](ipc_extensions.md#new-commands).
+- Add: Validates the path via the vault service. Rejects symlinks and paths outside the root. On success, logs INFO with `attachment_id`.
+- Remove: Deletes the row; does **not** delete the underlying file. Vault cleanup remains manual to avoid data loss.
+- List: Returns attachments sorted by `added_at DESC`.
+
+## UI experience
+- Located in `tabs/Documents.tsx` within the member drawer (PR9).
+- Drag-and-drop target accepts files; on drop, the renderer invokes `member_attachments_add` with `root_key` resolved from vault configuration and `relative_path` computed via Tauri API.
+- Each attachment card shows title (fallback to filename), added timestamp, and action buttons:
+  - **Open**: Launches the file with the OS default handler via existing vault API.
+  - **Reveal**: Opens Finder at the file location (macOS beta scope).
+  - **Remove**: Calls `member_attachments_remove` and updates the store.
+- Errors show toast messages based on error codes:
+  - `ATTACHMENTS/OUT_OF_VAULT`: "File must live inside the vault."
+  - `ATTACHMENTS/SYMLINK_REJECTED`: "Symbolic links are not supported."
+  - `ATTACHMENTS/PATH_CONFLICT`: "This file is already attached." (includes reference to existing attachment in toast detail).
+
+## Logging
+- Renderer emits `ui.family.attach.add`/`ui.family.attach.remove` logs per [logging_policy.md](logging_policy.md).
+- Backend logs include redacted `relative_path` (filename only) and `root_key`. Full absolute paths are never logged.
+
+## Security considerations
+- Vault service must confirm the provided `root_key` belongs to the current user session before registering the attachment.
+- Attachments follow household membership: when a member is deleted, cascade removal ensures no orphan attachments remain.
+- Export routines (PR12) include attachment metadata but not file blobs; see [diagnostics_and_export.md](diagnostics_and_export.md).
+
+## Future enhancements (out of scope)
+- Encrypting attachment metadata.
+- Automatic duplicate detection based on file hash.
+- Background sync when attachments change outside the app.

--- a/docs/family/plan/diagnostics_and_export.md
+++ b/docs/family/plan/diagnostics_and_export.md
@@ -1,0 +1,32 @@
+# Diagnostics and export updates (PR12)
+
+PR12 augments diagnostics and export tooling so support engineers can evaluate Family data health. This document specifies the counters, payload shape, and redaction requirements.
+
+**WARNING:** Sensitive fields (passport, licence, NHS, NI, tax, bank, pension) remain stored in plaintext until the encryption follow-up; never attach unredacted exports to public tickets.
+
+## Diagnostics (`src-tauri/src/diagnostics.rs`)
+Add the following fields to the diagnostics payload under the `family` section:
+- `members_total`: count of rows in `family_members` where `deleted_at IS NULL`.
+- `attachments_total`: count of rows in `member_attachments`.
+- `renewals_total`: count of rows in `member_renewals`.
+- `notes_linked_total`: count of rows in `notes` where `member_id IS NOT NULL`.
+- `members_stale`: count of active members (`status = 'active'`) where `last_verified` is null or older than 365 days.
+
+Each counter logs alongside the standard diagnostics output and participates in [logging_policy.md](logging_policy.md) when errors occur.
+
+## Export (`src-tauri/src/export/mod.rs`)
+- Include `family_members`, `member_attachments`, `member_renewals`, and `notes` (with `member_id`) in the JSON export.
+- For sensitive fields, apply redaction:
+  - `passport_number`, `driving_licence_number`, `nhs_number`, `national_insurance_number`, `tax_id`: keep last four characters only (prefix with `***`).
+  - Phone numbers and email addresses remain full text to aid support.
+  - Attachment paths export `root_key` and `relative_path` exactly; no blobs.
+- Annotate the export header with `"family_plan_version": "PR0.5"` to indicate alignment with this blueprint.
+
+## Redaction TODO
+- Full redaction policy for bank account numbers and pension details is deferred. Document this TODO in the export output as `"TODO_redaction": "Bank and pension details require encryption"` and in [rollout_checklist.md](rollout_checklist.md).
+
+## Testing
+- Diagnostics unit test asserts new counters exist and return expected values against seeded data.
+- Export integration test checks that redacted fields maintain correct masking (e.g., `***1234`).
+
+These changes do not alter runtime behaviour before PR12. Documentation ensures the implementation matches support expectations.

--- a/docs/family/plan/ipc_extensions.md
+++ b/docs/family/plan/ipc_extensions.md
@@ -1,0 +1,101 @@
+# IPC extensions (PR2)
+
+PR2 introduces the full backend command surface required for the Family expansion. All commands are exposed through Tauri `invoke` handlers, registered in `src-tauri/src/lib.rs`, implemented in `src-tauri/src/commands_family.rs`, and backed by repository helpers in `src-tauri/src/repo_family.rs`. TypeScript adapters live in `src/repos.ts`.
+
+## New commands
+| Command | Request payload | Response payload | Notes |
+| --- | --- | --- | --- |
+| `member_attachments_list` | `{ household_id: string, member_id: string }` | `{ attachments: AttachmentRef[] }` | Sorted by `added_at DESC`. Returns empty array when no attachments exist. |
+| `member_attachments_add` | `{ household_id: string, member_id: string, title?: string, root_key: string, relative_path: string, mime_hint?: string }` | `{ id: string }` | Generates UUIDv4 in Rust. Rejects paths outside the vault guard (see [attachments.md](attachments.md)). |
+| `member_attachments_remove` | `{ id: string }` | `{}` | Idempotent: removing a missing attachment succeeds silently. |
+| `member_renewals_list` | `{ household_id: string, member_id?: string }` | `{ renewals: Renewal[] }` | When `member_id` omitted, returns all rows in the household ordered by `expires_at ASC`. |
+| `member_renewals_upsert` | `{ household_id: string, data: RenewalInput }` | `{ id: string }` | Uses `data.id` when present, otherwise creates a UUIDv4. Updates `updated_at` automatically. |
+| `member_renewals_delete` | `{ id: string }` | `{}` | Idempotent delete. |
+
+### TypeScript facades
+- `familyRepo.list(householdId)` continues to return `FamilyMember[]`, now including the additive fields documented in [schema_changes.md](schema_changes.md).
+- New helpers under `familyRepo.attachments` and `familyRepo.renewals` wrap the commands above and normalise JSON parsing (`*_json` string fields → typed arrays/objects, `keyholder` → boolean).
+- `familyRepo.notes.listByMember(memberId)` filters the existing notes list client-side, using the new `member_id` column.
+
+## Data contracts
+### AttachmentRef
+```ts
+interface AttachmentRef {
+  id: string
+  household_id: string
+  member_id: string
+  title?: string
+  root_key: string
+  relative_path: string
+  mime_hint?: string
+  added_at: number
+}
+```
+
+### RenewalInput
+```ts
+interface RenewalInput {
+  id?: string
+  member_id: string
+  kind: string
+  label?: string
+  expires_at: number
+  remind_on_expiry: boolean
+  remind_offset_days: number
+}
+```
+
+- `kind` values accepted: `passport`, `driving_licence`, `photo_id`, `insurance`, `pension`. Additional kinds require updating the renderer allow-list and tests.
+- `remind_offset_days` must be `>= 0` and `<= 365`. Enforcement occurs in the Rust layer with a dedicated error.
+
+## Error taxonomy
+All commands return structured errors with `code` and `message` fields. The codes below are final and must not change without revisiting release documentation.
+
+| Code | Trigger | HTTP status equivalent |
+| --- | --- | --- |
+| `ATTACHMENTS/PATH_CONFLICT` | Unique constraint hit on `(household_id, root_key, relative_path)` | 409 |
+| `ATTACHMENTS/OUT_OF_VAULT` | Attempt to access a path outside the configured vault root | 403 |
+| `ATTACHMENTS/SYMLINK_REJECTED` | Attachment resolves to a symlink when policy forbids it | 400 |
+| `RENEWALS/INVALID_KIND` | `kind` not recognised | 400 |
+| `RENEWALS/INVALID_OFFSET` | `remind_offset_days` outside `0..365` | 400 |
+| `VALIDATION/EMAIL` | `email` column fails validation | 400 |
+| `VALIDATION/PHONE` | `phone_*` field fails validation | 400 |
+| `VALIDATION/URL` | URL field (website or social link) fails validation | 400 |
+| `VALIDATION/JSON` | JSON payload fails to parse or validate | 400 |
+
+Renderer code translates these into user-facing toasts (see [ui_spec.md](ui_spec.md)). Unknown errors fall back to a generic failure toast.
+
+### Error code appendix
+Complete list of error identifiers consumed across backend, renderer, and logging:
+
+```
+ATTACHMENTS/PATH_CONFLICT
+ATTACHMENTS/OUT_OF_VAULT
+ATTACHMENTS/SYMLINK_REJECTED
+RENEWALS/INVALID_KIND
+RENEWALS/INVALID_OFFSET
+VALIDATION/EMAIL
+VALIDATION/PHONE
+VALIDATION/URL
+VALIDATION/JSON
+```
+
+SQLite constraint errors (e.g., `SQLITE_CONSTRAINT_UNIQUE`) may still bubble up; wrap them with human-readable messages while preserving the original `code` for diagnostics.
+
+## Logging hooks
+Every new command participates in the logging strategy defined in [logging_policy.md](logging_policy.md): DEBUG on entry, INFO on success with elapsed milliseconds, WARN on validation rejections, and ERROR on unexpected failures.
+
+## Versioning and compatibility
+- The baseline `family_members_*` commands maintain their input/output shape; only the returned `FamilyMember` object grows new optional properties.
+- IPC schema versioning remains implicit. The renderer must guard access to new commands behind PR-specific feature flags during development, but by PR3 all commands are unconditional and part of the stable surface.
+
+## Concurrency guarantees
+- Attachment add/remove operations run within a transaction per command, ensuring consistent vault updates.
+- Renewals upsert uses `INSERT OR REPLACE` semantics keyed by `id` and `household_id`. Repository helpers ensure we never upsert rows belonging to another household.
+
+## Validation summary
+- Email and phone validation happen in both renderer and backend; backend is the final arbiter.
+- URL validation ensures schemes are `http` or `https` and that the host is non-empty.
+- Offset validation prevents integer overflow by clamping to `0..365` and emitting `RENEWALS/INVALID_OFFSET` when outside the range.
+
+These command contracts remain stable through PR14.

--- a/docs/family/plan/logging_policy.md
+++ b/docs/family/plan/logging_policy.md
@@ -1,0 +1,50 @@
+# Logging policy (PR3)
+
+PR3 introduces structured logging for all Family flows. Logs are JSON objects written through the existing Tauri logging infrastructure and subject to the global retention policy (5 files × 5 MB). This document defines the required fields, levels, and emission points.
+
+## Log envelope
+```json
+{
+  "ts": 0,                // epoch ms
+  "level": "INFO",       // TRACE | DEBUG | INFO | WARN | ERROR
+  "area": "family",      // constant for every log in this plan
+  "cmd": "family_members_update", // IPC command name or ui event id
+  "household_id": "...", // optional for UI events when available
+  "member_id": "...",    // optional, omit when not relevant
+  "rows": 1,              // optional count of affected rows
+  "ms": 12,               // optional duration in milliseconds
+  "crash_id": "...",     // optional; populated when bubbling errors include crash reports
+  "msg": "updated member",// human-readable summary
+  "details": { ... }      // optional JSON object for additional context
+}
+```
+
+## Backend instrumentation
+- **Entry logs**: DEBUG level emitted at the start of every Family command (existing CRUD plus new commands from [ipc_extensions.md](ipc_extensions.md)). Include `cmd`, `household_id`, and `member_id` when present.
+- **Success logs**: INFO level emitted on completion with `ms` (duration), `rows` (rows changed or returned), and `msg` summarising the operation.
+- **Validation warnings**: WARN level when a request fails explicit validation (error codes listed in [ipc_extensions.md](ipc_extensions.md#error-code-appendix), e.g., `VALIDATION/EMAIL`, `RENEWALS/INVALID_OFFSET`). Include `details` describing the failing field and value (mask sensitive data such as full account numbers by redacting middle digits).
+- **Errors**: ERROR level when an unexpected failure occurs. Include `details.error` with the Rust error chain and any SQLite constraint name.
+- **Special case**: When the repository detects database health issues (write lock timeouts, disk full), log WARN with `msg = "DB_UNHEALTHY"` and propagate the error.
+
+## UI instrumentation
+- Emit INFO logs under synthetic command names prefixed with `ui.`:
+  - `ui.family.load` with `{ ms, household_id, members: count }` when the initial `familyStore.load` resolves.
+  - `ui.family.drawer.save` with `{ ms, member_id }` when save completes (success or failure). Use WARN for validation failures.
+  - `ui.family.attach.add` / `ui.family.attach.remove` with `{ ms, member_id, attachment_id }`.
+  - `ui.family.renewal.save` and `ui.family.renewal.delete` with relevant identifiers.
+- UI logs reuse the same JSON structure as backend logs and flow through the same transport.
+
+## Redaction rules
+- Do not log full contents of sensitive fields. For example, log `passport_number` as `"***1234"` by keeping only the last four characters.
+- Phone numbers and email addresses may be logged in full for validation messages, but ensure they reside under `details` to keep top-level fields clean.
+- Attachment paths should be split into `root_key` and `relative_path`; avoid logging absolute filesystem paths.
+
+## Sampling and rate limiting
+- No sampling is applied. Commands expected to fire frequently (list, store load) must still log each invocation due to their diagnostic value.
+- To avoid log storms during drag/drop operations, coalesce consecutive failures (e.g., multiple invalid files) into a single WARN with `details.count`.
+
+## Testing requirements
+- Integration tests in PR3 assert that calling `family_members_update` results in DEBUG (entry) and INFO (success) logs.
+- Renderer tests spy on the logging transport to confirm `ui.family.drawer.save` fires once per save.
+
+These rules remain in force for all subsequent PRs. Any new Family-related command introduced later must adopt the same envelope and levels.

--- a/docs/family/plan/notes_linking.md
+++ b/docs/family/plan/notes_linking.md
@@ -1,0 +1,30 @@
+# Notes linking (PR10)
+
+Linking notes to family members enables person-specific narratives without losing household-wide notes. This document clarifies how the `notes.member_id` column behaves and how the renderer consumes it.
+
+## Column behaviour
+- Added in PR1 via `ALTER TABLE notes ADD COLUMN member_id TEXT NULL;` (see [schema_changes.md](schema_changes.md#notes-table-alteration)).
+- Nullable to support existing household/general notes. `NULL` means the note applies to the household.
+- No foreign key constraint in SQLite to avoid table rebuild. Application logic ensures referential integrity.
+
+## Repository rules (PR2)
+- When creating or updating a note via existing commands, `member_id` may be set to a valid `family_members.id` or `null`.
+- `notes.list` returns all notes. Renderer filters to `member_id` when showing person-scoped notes.
+- On member deletion (soft or hard), repository helpers set `member_id = NULL` for affected notes before removing or archiving the member. This prevents dangling references and ensures household visibility remains.
+
+## UI behaviour (PR10)
+- Notes tab lists only notes where `member_id` matches the active member. Provide a toggle to "Show household notes" which includes `NULL` entries for reference.
+- Creating a note within the tab sets `member_id` automatically.
+- Deleting a member moves their notes to household scope by setting `member_id = NULL` and appending "(Former member: <name>)" to the note body. This behaviour is implemented in the backend repo to ensure consistency regardless of UI path.
+
+## Search and filters
+- Global notes search (outside Family) remains unchanged. Person-linked notes still appear in global listings but display a "Linked to <member>" badge.
+- Export routines (PR12) include `member_id` associations so support teams can trace note provenance.
+
+## Testing
+- Backend test: deleting a member with linked notes retains the notes and sets `member_id` to `NULL`.
+- Renderer test: toggling the "Show household notes" control swaps between member-only and combined views.
+
+## Future considerations
+- Introduce hard foreign keys when SQLite version update allows table rebuild without downtime.
+- Support linking a note to multiple members (requires join table, not planned here).

--- a/docs/family/plan/overview.md
+++ b/docs/family/plan/overview.md
@@ -1,0 +1,48 @@
+# Family expansion master plan
+
+This plan defines the full Family-module expansion that will land across PR1 through PR14. It locks the scope, naming, storage shape, UI affordances, logging touchpoints, diagnostics additions, and validation strategy for the entire sequence. Every specification item in this directory is binding until superseded by a future baseline.
+
+## Objectives
+- Establish Family as the central, household-scoped record that aggregates rich member profiles, attachments, notes, and renewal tracking.
+- Preserve compatibility with the PR0 baseline by keeping all new schema additions optional and additive until explicit backfill work is scheduled.
+- Clarify that the existing `name` column remains authoritative until backfill: the new `nickname` field is optional and acts as the preferred display name when present.
+- Deliver deterministic UI building blocks: header, banner, grid, drawer, modal, tabs, and orchestration store.
+- Introduce observability and diagnostics hooks so support teams can triage issues without direct database inspection.
+
+## Non-goals for this wave
+- No background schedulers run in-app or via OS services; reminder storage captures intent only.
+- No deep-link routing, push notifications, or cross-module automation.
+- No at-rest encryption beyond existing vault behaviour (a future TODO shared in [rollout_checklist.md](rollout_checklist.md)).
+- Pronoun capture is deliberately excluded to avoid schema churn; revisit in a later programme.
+
+## Platform assumptions
+- macOS is the only supported platform for the PR1–PR14 rollout. Other platforms inherit the PR0 experience until a separate track is planned.
+
+## Workstream overview
+- [schema_changes.md](schema_changes.md) defines the authoritative database DDL for PR1 and the expected evolution of baseline SQL snapshots.
+- [ipc_extensions.md](ipc_extensions.md) enumerates every new command, payload, and error code introduced through PR2.
+- [ui_spec.md](ui_spec.md) documents the renderer architecture, component tree, validation rules, and behavioural contracts for PR4–PR11.
+- [logging_policy.md](logging_policy.md) captures how TRACE/DEBUG/INFO/WARN/ERROR events wrap the entire Family flow starting in PR3.
+- [attachments.md](attachments.md), [reminders.md](reminders.md), and [notes_linking.md](notes_linking.md) give focused specs for their respective data domains.
+- [relationships_future.md](relationships_future.md) records how future household-linked entities will attach to the Family schema without conflicting with the current wave.
+- [diagnostics_and_export.md](diagnostics_and_export.md) prescribes the counters, summaries, and redaction TODOs that must accompany PR12.
+- [test_strategy.md](test_strategy.md) lists the deterministic coverage plan for backend and renderer code.
+- [rollout_checklist.md](rollout_checklist.md) aggregates the acceptance criteria for every PR so release management can tick items without cross-referencing other documents.
+
+## Sequencing summary
+1. **PR1** – Schema migration and DDL mirrors.
+2. **PR2** – IPC surface extensions and error taxonomy.
+3. **PR3** – Logging instrumentation for backend and UI.
+4. **PR4** – Renderer store and orchestration glue.
+5. **PR5** – Header and banner widgets.
+6. **PR6** – Members grid layout.
+7. **PR7** – Member drawer with validation tabs.
+8. **PR8** – Add member modal flow.
+9. **PR9** – Attachments UI integration.
+10. **PR10** – Person-scoped notes surface.
+11. **PR11** – Renewals UI for reminder intent.
+12. **PR12** – Diagnostics and export updates.
+13. **PR13** – QA matrix and deterministic seeding.
+14. **PR14** – Packaging and beta release deliverables.
+
+Each downstream document references the specific PR in which its requirements become enforceable. No runtime code changes occur as part of PR0.5; the plan alone is the deliverable.

--- a/docs/family/plan/relationships_future.md
+++ b/docs/family/plan/relationships_future.md
@@ -1,0 +1,27 @@
+# Future relationship modelling
+
+This document records how the Family schema will accommodate non-member relationships in future releases without conflicting with the PR1–PR14 plan. No changes here are implemented during the current wave.
+
+## Current stance (PR1–PR14)
+- Household-level records continue to store `member_id = NULL` in any shared tables (e.g., `notes`).
+- All new tables introduced in PR1 (`member_attachments`, `member_renewals`) require a `member_id` and cascade delete with the member.
+- `family_members.status` differentiates `active`, `inactive`, and `deceased` members but does not model relationships to external entities.
+
+## Future additions (not in scope yet)
+- **Pets, vehicles, bills**: When added, these entities will reference the household via `household_id` and optionally link to a primary member with nullable foreign keys using `ON DELETE SET NULL`.
+- **Shared documents**: Introduce `household_attachments` table mirroring `member_attachments` but without `member_id`. This avoids overloading person-specific storage.
+- **Relationship graph**: Potential `member_relationships` table with columns `from_member_id`, `to_member_id`, `relationship_type` (e.g., parent, sibling). If introduced, enforce symmetrical entries via application logic.
+
+## Naming and column guidance
+- Foreign keys pointing to family members must use the suffix `_member_id` to avoid ambiguity.
+- Status fields remain `TEXT` with constrained vocab; expand via allow-list rather than new tables.
+- When modelling non-person entities, prefer dedicated tables rather than overloading `family_members`.
+
+## Data migration strategy
+- Future migrations will follow the additive-first approach: add nullable columns/ tables, backfill in dedicated PRs, then enforce constraints.
+- Avoid renaming or dropping columns added in PR1–PR14 until after a full release cycle.
+
+## Documentation obligations
+- Any future relationship work must update this file and cross-link into [schema_changes.md](schema_changes.md) and [rollout_checklist.md](rollout_checklist.md).
+
+By freezing these rules now, later teams can extend Family without conflicting with the blueprint established in PR0.5.

--- a/docs/family/plan/reminders.md
+++ b/docs/family/plan/reminders.md
@@ -1,0 +1,51 @@
+# Renewal reminders (PR11 foundation)
+
+Renewal tracking is stored in the `member_renewals` table introduced in PR1. PR11 adds the renderer surfaces to manage renewal intent; no automated reminder delivery occurs in this wave.
+
+## Data model recap
+See [schema_changes.md](schema_changes.md#member_renewals-table) for DDL. Each row captures a single renewal item for one member.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | TEXT primary key | UUIDv4 generated client-side or server-side. |
+| `household_id` | TEXT | Scopes the renewal to a household. |
+| `member_id` | TEXT | Foreign key to `family_members.id`. |
+| `kind` | TEXT | Enum-like string; valid values listed below. |
+| `label` | TEXT | Optional display text (e.g., "Passport (GB)"). |
+| `expires_at` | INTEGER | Epoch ms of expiry date. |
+| `remind_on_expiry` | INTEGER (0/1) | Toggle for same-day reminder. |
+| `remind_offset_days` | INTEGER | Days before expiry to trigger reminder. |
+| `created_at` | INTEGER | Epoch ms when the row was created. |
+| `updated_at` | INTEGER | Epoch ms when last modified. |
+
+Valid `kind` values for this release:
+- `passport`
+- `driving_licence`
+- `photo_id`
+- `insurance`
+- `pension`
+- Future-proof: renderer allows custom strings but warns via toast when unrecognised; backend blocks via `RENEWALS/INVALID_KIND`.
+
+## UI behaviour (PR11)
+- Renewals appear on the "Renewals" tab in the member drawer (see [ui_spec.md](ui_spec.md#tab-details)).
+- Users can add, edit, and delete rows. Edits happen inline with autosave on blur/submit.
+- The tab computes the reminder schedule text client-side (e.g., "Remind 30 days before").
+- Sorting is ascending by `expires_at`. Past renewals display with a warning icon.
+
+## Reminder engine status
+- Storage only. No background jobs, notifications, or integrations fire in PR11.
+- The plan documents a **TODO** to build the reminder engine in a future wave. Mention this TODO in [rollout_checklist.md](rollout_checklist.md).
+
+## Validation rules
+- `expires_at` must be in the future (>= today). Renderer prevents past dates; backend rejects with `RENEWALS/EXPIRED_DATE` (mapped to `RENEWALS/INVALID_OFFSET` if reused to avoid extra codes).
+- `remind_offset_days` range: 0–365. UI clamps values; backend enforces range.
+- Combination of `kind`, `member_id`, and `expires_at` may appear multiple times; no uniqueness constraint is imposed.
+
+## Logging
+- Saving a renewal logs `ui.family.renewal.save` (INFO) with `{ member_id, id, ms }` on success or WARN on validation failure (see [logging_policy.md](logging_policy.md)).
+- Backend emits DEBUG/INFO/WARN/ERROR per standard policy.
+
+## Future considerations (not part of PR11)
+- Support recurring reminders or renewal templates.
+- Hook reminders into system notifications once cross-platform design exists.
+- Allow household-level renewals (no `member_id`). This requires schema adjustments documented in [relationships_future.md](relationships_future.md).

--- a/docs/family/plan/rollout_checklist.md
+++ b/docs/family/plan/rollout_checklist.md
@@ -1,0 +1,86 @@
+# Rollout checklist
+
+This checklist consolidates the acceptance criteria across PR1–PR14. Each item must be ticked before tagging the macOS beta in PR14.
+
+## PR1 – Schema migration
+- [ ] `migrations/0027_family_expansion.up.sql` applied successfully on seeded database.
+- [ ] Down migration verified to restore PR0 schema.
+- [ ] `schema.sql` updated with all new columns/tables/indexes.
+- [ ] `family_members` new columns default to `NULL` or documented defaults; no data loss.
+
+## PR2 – IPC extensions
+- [ ] All new commands registered in `src-tauri/src/lib.rs`.
+- [ ] Repository functions validate payloads and emit documented error codes.
+- [ ] TypeScript adapters expose attachments and renewals helpers.
+- [ ] End-to-end round-trip of new fields confirmed.
+
+## PR3 – Logging
+- [ ] DEBUG entry and INFO exit logs exist for every Family IPC command.
+- [ ] WARN logs fire for validation failures with redacted details.
+- [ ] UI emits `ui.family.*` logs for load, save, attachments, renewals.
+- [ ] Log redaction verified (no full passport numbers, etc.).
+
+## PR4 – Store orchestration
+- [ ] `familyStore` caches members, attachments, renewals, and exposes subscription API.
+- [ ] Store hydration occurs once per household visit.
+- [ ] Optimistic updates reconcile with server responses.
+
+## PR5 – Header & banner
+- [ ] Header displays household name, active member count, next birthday.
+- [ ] Banner shows up to three upcoming birthdays within 60 days.
+- [ ] Feature flag can hide header/banner without code removal.
+
+## PR6 – Members grid
+- [ ] Card layout replaces legacy list.
+- [ ] Keyboard navigation and scroll behaviour match spec.
+- [ ] Ordering remains `position, created_at, id`.
+
+## PR7 – Drawer & tabs
+- [ ] Drawer opens per member, preserves list scroll.
+- [ ] All tabs render specified fields and validations.
+- [ ] Save/Cancel triggers toasts and logging.
+- [ ] Audit tab updates `last_verified`/`verified_by` correctly.
+
+## PR8 – Add member modal
+- [ ] Modal flow captures minimum data and optional extras.
+- [ ] New member card receives focus post-create.
+- [ ] Duplicate position error surfaces friendly toast.
+
+## PR9 – Attachments UI
+- [ ] Drag/drop add works with vault guard.
+- [ ] Open/Reval/Remove actions execute successfully.
+- [ ] Error toasts map to attachment error codes.
+
+## PR10 – Notes tab
+- [ ] Notes filtered by `member_id` with toggle for household notes.
+- [ ] Member deletion moves notes to household scope with suffix.
+
+## PR11 – Renewals tab
+- [ ] Add/edit/delete flows persist data via IPC.
+- [ ] Offset validation enforced (0–365 days).
+- [ ] Reminder engine documented as TODO; no background scheduler runs.
+
+## PR12 – Diagnostics & export
+- [ ] Diagnostics payload includes new counters.
+- [ ] Export includes Family tables with redacted sensitive fields.
+- [ ] Export includes `family_plan_version` metadata and redaction TODO note.
+
+## PR13 – QA & performance
+- [ ] Deterministic seed script checked in and runnable.
+- [ ] QA walkthrough completed on Intel and Apple Silicon macOS (Monterey–Sonoma).
+- [ ] Performance logs show drawer save and list render within target (<25% CPU during 200-card scroll).
+
+## PR14 – Packaging & release
+- [ ] `scripts/release-macos.sh` handles codesign and notarisation (document dry-run path).
+- [ ] DMG installs and runs on clean macOS machine.
+- [ ] About dialog shows version + commit.
+- [ ] Release notes document known limitations: no deep links, no background reminders, encryption TODO.
+
+## Outstanding TODOs post-wave
+- [ ] Build reminder delivery engine.
+- [ ] Implement field-level encryption for sensitive columns.
+- [ ] Define diagnostics redaction policy for financial data.
+- [ ] Add deep-link support (`#/family/<id>`).
+- [ ] Plan migration to make `nickname` mandatory (replace legacy `name`).
+
+All boxes must be checked (or explicitly deferred with stakeholder sign-off) before shipping the Family beta.

--- a/docs/family/plan/schema_changes.md
+++ b/docs/family/plan/schema_changes.md
@@ -1,0 +1,137 @@
+# Schema changes (PR1)
+
+This document specifies the exact database evolution for PR1. The commands apply to SQLite as used by the Tauri runtime and must be mirrored in `schema.sql` and any snapshot schemas. All new columns are additive and nullable unless noted otherwise. Existing tables keep their current column ordering; the listing below reflects the order enforced in the migration scripts.
+
+## Migration files
+- `migrations/0027_family_expansion.up.sql`
+- `migrations/0027_family_expansion.down.sql`
+
+The up migration is authoritative. The down migration reverses each step to restore the PR0 baseline without data reordering.
+
+## family_members alterations
+
+```sql
+ALTER TABLE family_members
+  ADD COLUMN nickname TEXT,
+  ADD COLUMN full_name TEXT,
+  ADD COLUMN relationship TEXT,
+  ADD COLUMN photo_path TEXT,
+  ADD COLUMN phone_mobile TEXT,
+  ADD COLUMN phone_home TEXT,
+  ADD COLUMN phone_work TEXT,
+  ADD COLUMN email TEXT,
+  ADD COLUMN address TEXT,
+  ADD COLUMN personal_website TEXT,
+  ADD COLUMN social_links_json TEXT,
+  ADD COLUMN passport_number TEXT,
+  ADD COLUMN passport_expiry INTEGER,
+  ADD COLUMN driving_licence_number TEXT,
+  ADD COLUMN driving_licence_expiry INTEGER,
+  ADD COLUMN nhs_number TEXT,
+  ADD COLUMN national_insurance_number TEXT,
+  ADD COLUMN tax_id TEXT,
+  ADD COLUMN photo_id_expiry INTEGER,
+  ADD COLUMN blood_group TEXT,
+  ADD COLUMN allergies TEXT,
+  ADD COLUMN medical_notes TEXT,
+  ADD COLUMN gp_contact TEXT,
+  ADD COLUMN emergency_contact_name TEXT,
+  ADD COLUMN emergency_contact_phone TEXT,
+  ADD COLUMN bank_accounts_json TEXT,
+  ADD COLUMN pension_details_json TEXT,
+  ADD COLUMN insurance_refs TEXT,
+  ADD COLUMN tags_json TEXT,
+  ADD COLUMN groups_json TEXT,
+  ADD COLUMN last_verified INTEGER,
+  ADD COLUMN verified_by TEXT,
+  ADD COLUMN keyholder INTEGER DEFAULT 0,
+  ADD COLUMN status TEXT DEFAULT 'active'
+;
+```
+
+### Field notes
+- `nickname` becomes the primary display name in the UI when populated. Until a backfill runs, the renderer treats `name` as the fallback nickname.
+- `photo_path` stores a vault-relative path (`root_key` + `relative_path` combination lives in `member_attachments`).
+- `*_json` fields are opaque JSON strings persisted without validation at the SQL layer. Renderer-level validation ensures the shapes described in [ui_spec.md](ui_spec.md).
+- `passport_expiry`, `driving_licence_expiry`, `photo_id_expiry`, and `last_verified` store epoch milliseconds (`INTEGER`).
+- `keyholder` is a boolean represented as `0`/`1` in SQLite; higher layers convert to/from `true`/`false`.
+- `status` accepts `active`, `inactive`, or `deceased`. No check constraint is added to avoid SQLite rewrite overhead; validation occurs in the renderer.
+
+### Indexing
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_family_members_house_bday
+  ON family_members(household_id, birthday);
+```
+
+This index accelerates upcoming birthday lookups for the banner. It remains even if PR5 feature flags are toggled off.
+
+## member_attachments table
+
+```sql
+CREATE TABLE IF NOT EXISTS member_attachments (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  title TEXT,
+  root_key TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  mime_hint TEXT,
+  added_at INTEGER NOT NULL,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_member_attachments_path
+  ON member_attachments(household_id, root_key, relative_path);
+CREATE INDEX IF NOT EXISTS idx_member_attachments_member
+  ON member_attachments(member_id, added_at);
+```
+
+- `root_key` identifies the vault partition; `relative_path` is the scoped path inside that root. The unique index forbids duplicate file references per household.
+- Attachments cascade-delete with their owning member.
+- `added_at` captures epoch milliseconds for audit displays.
+
+## member_renewals table
+
+```sql
+CREATE TABLE IF NOT EXISTS member_renewals (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT,
+  expires_at INTEGER NOT NULL,
+  remind_on_expiry INTEGER NOT NULL DEFAULT 0,
+  remind_offset_days INTEGER NOT NULL DEFAULT 30,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_member_renewals_house_kind
+  ON member_renewals(household_id, kind, expires_at);
+CREATE INDEX IF NOT EXISTS idx_member_renewals_member
+  ON member_renewals(member_id, expires_at);
+```
+
+- `kind` is a free-form string, with renderer validation restricting values to documented kinds (`passport`, `driving_licence`, `photo_id`, `insurance`, `pension`, plus allow-listed future variants).
+- `remind_on_expiry` is an INTEGER treated as boolean.
+- `remind_offset_days` defaults to 30 and must remain non-negative.
+- Sorting by `(member_id, expires_at)` supports list rendering in [ui_spec.md](ui_spec.md).
+
+## notes table alteration
+
+```sql
+ALTER TABLE notes ADD COLUMN member_id TEXT NULL;
+CREATE INDEX IF NOT EXISTS idx_notes_member ON notes(member_id);
+```
+
+- The column is nullable to preserve household-level notes. Only PR10 consumes the linkage.
+- No foreign key is added in SQLite to avoid table rebuilds; application logic enforces referential consistency and handles soft-deleted members as documented in [notes_linking.md](notes_linking.md).
+
+## Down migration order
+The down script removes indexes first, then drops tables, and finally removes columns in reverse order. This ordering prevents dependency errors and mirrors SQLite's limited `ALTER TABLE DROP COLUMN` behaviour implemented via table rebuilds in our migration harness.
+
+## Snapshot updates
+- Update `src-tauri/src/schema.sql` to mirror every change so new installs match the migrated database.
+- `schema/family_members.json` or equivalent snapshots (if present) must add the new keys with nullable types; values default to `null` when omitted.
+
+No data manipulation is performed in PR1; existing rows remain untouched until subsequent PRs populate the new fields.

--- a/docs/family/plan/test_strategy.md
+++ b/docs/family/plan/test_strategy.md
@@ -1,0 +1,68 @@
+# Test strategy
+
+This strategy covers automated and manual verification across PR1–PR14. Each PR references the relevant sections here; together they ensure deterministic coverage for the Family expansion.
+
+## PR1 – Schema migration
+- **Migration smoke test**: Apply `0027_family_expansion.up.sql` on seeded database and verify row counts before/after match.
+- **Down migration test**: Apply down migration and ensure the schema matches PR0 snapshots (no leftover tables/columns).
+- **Schema snapshot diff**: Automated check to confirm `src-tauri/src/schema.sql` reflects new columns and tables.
+
+## PR2 – IPC extensions
+- **Rust unit tests**: Cover each new command with valid and invalid payloads, asserting error codes (`ATTACHMENTS/OUT_OF_VAULT`, etc.).
+- **TypeScript adapter tests**: Ensure JSON fields parse correctly and boolean conversion (`keyholder`) works.
+
+## PR3 – Logging
+- **Backend integration test**: Invoke `family_members_update` and assert DEBUG + INFO logs exist with expected fields.
+- **Renderer test**: Mock logging transport and confirm `ui.family.drawer.save` fires with `member_id`.
+
+## PR4 – Store orchestration
+- **Store tests**: Verify `load`, `get`, `getAll`, `upsert`, and `subscribe` behaviours, including optimistic updates and reconciliation.
+- **Regression**: Ensure subscribers are deduplicated and unsubscribing removes listeners.
+
+## PR5 – Header & banner
+- **Unit tests**: Validate birthday calculations (including leap year handling) and list truncation to three entries.
+- **Visual regression**: Snapshot test for header layout at desktop and narrow widths.
+
+## PR6 – Members grid
+- **Rendering test**: Confirm 200-card render completes within performance budget (React testing library + timers).
+- **Keyboard navigation test**: Simulate tab/enter interactions opening the drawer.
+
+## PR7 – Drawer & validation
+- **Form validation tests**: Cover phone, email, URL, expiry rules in `validators.ts`.
+- **Save flow test**: Successful save triggers toast and closes drawer; failed save keeps drawer open with inline error.
+- **Audit tab test**: "Mark verified" updates `last_verified` and `verified_by`.
+
+## PR8 – Add member modal
+- **Modal flow test**: Step progression, validation for nickname/name requirement, and focus handling after creation.
+- **Error handling test**: Simulate duplicate position constraint and ensure user-facing toast appears.
+
+## PR9 – Attachments UI
+- **Drag/drop test**: Mock file drop and confirm add command invoked with correct payload.
+- **Error mapping test**: Each attachment error code maps to the correct toast message.
+
+## PR10 – Notes tab
+- **Filtering test**: Ensure only member-linked notes display by default; toggle reveals household notes.
+- **Deletion test**: Deleting a member reassigns notes to household scope with appended suffix.
+
+## PR11 – Renewals tab
+- **Sorting test**: Renewals list ordered by `expires_at` ascending.
+- **Validation test**: Offsets outside 0–365 trigger UI error and backend error mapping.
+- **Autosave test**: Editing a field triggers save after debounce and success toast.
+
+## PR12 – Diagnostics & export
+- **Diagnostics counters test**: Validate each counter against seeded data set.
+- **Export redaction test**: Export fixture ensures sensitive fields masked.
+
+## PR13 – QA & performance
+- **Seed script test**: Running `tools/seed/seed_family.ts` produces deterministic dataset (identical IDs for repeated runs).
+- **Performance sniff**: Manual run on Intel and Apple Silicon machines with logging of CPU usage and UI timings.
+
+## PR14 – Packaging
+- **Release script test**: Dry-run `scripts/release-macos.sh` to verify codesign/notarise commands run with `--dry-run` flags.
+- **Smoke test**: Install DMG on clean macOS VM and ensure Family module loads with new UI components.
+
+## Continuous integration
+- Update CI pipelines to run new tests introduced above.
+- Ensure linting/formatting covers newly added directories (`src/ui/family/**`).
+
+This test strategy provides the baseline coverage expectations and should be updated only if the implementation deviates from the plan.

--- a/docs/family/plan/ui_spec.md
+++ b/docs/family/plan/ui_spec.md
@@ -1,0 +1,103 @@
+# UI specification (PR4–PR11)
+
+This document defines the renderer architecture and behavioural contracts for the Family redesign. All file paths reference the React/TSX implementation inside `src/ui/family/` unless otherwise noted.
+
+## Component hierarchy
+```
+FamilyShell (PR5)
+└─ Header (PR5)
+└─ BannerBirthdays (PR5)
+└─ FamilyList (PR6)
+   └─ Card (inline component)
+└─ FamilyDrawer (PR7)
+   ├─ tabs/Personal (PR7)
+   ├─ tabs/Finance (PR7)
+   ├─ tabs/Documents (PR9)
+   ├─ tabs/Notes (PR10)
+   ├─ tabs/Renewals (PR11)
+   └─ tabs/Audit (PR7)
+└─ AddMemberModal (PR8)
+```
+
+## State orchestration
+- `familyStore` (PR4) owns the canonical household state. It caches `FamilyMember[]`, keeps attachment and renewal maps keyed by `member_id`, and exposes subscription APIs for React components.
+- All network operations funnel through `familyRepo` helpers described in [ipc_extensions.md](ipc_extensions.md). Optimistic updates mutate the store first, then reconcile with server responses.
+- The store emits typed events (`members:changed`, `attachments:changed`, `renewals:changed`) so tabs can subscribe narrowly.
+
+### `familyStore` API surface
+Declared in `src/ui/family/store.ts`.
+
+```ts
+familyStore.load(householdId: string): Promise<void>
+familyStore.getAll(): FamilyMember[]
+familyStore.get(id: string): FamilyMember | undefined
+familyStore.upsert(patch: Partial<FamilyMember> & { id: string }): Promise<void>
+familyStore.subscribe(listener: () => void): () => void
+```
+
+Attachment and renewal helpers live under `familyStore.attachments` and `familyStore.renewals` namespaces with `load`, `list`, `add`, and `remove`/`delete` methods mirroring the IPC commands.
+
+## Layout and styling
+- The shell uses CSS grid with three rows: header, banner, content. Desktop width breakpoint at 960px; below that, the banner stacks under the header.
+- Cards in `FamilyList` maintain a fixed width of 280px with responsive wrapping. Keyboard focus uses `:focus-visible` outlines.
+- Drawer slides in from the right (width 420px) and is dismissible via escape or outside click.
+
+## Header (PR5)
+- Displays household name (`familyStore.meta.householdName`), total active members count, and the next upcoming birthday (computed client-side using `birthday` + current date).
+- Includes an "Add member" button that opens `AddMemberModal`.
+
+## BannerBirthdays (PR5)
+- Renders up to three members with birthdays occurring within the next 60 days (inclusive). Sorting prioritises soonest upcoming, then alphabetical by nickname/name fallback.
+- Uses `idx_family_members_house_bday` via the cached dataset; no additional IPC.
+
+## FamilyList (PR6)
+- Cards show nickname (fallback `name`), relationship (when provided), and a birthday badge with day/month.
+- Clicking or pressing Enter opens the drawer anchored to that member.
+- Maintains scroll position when drawer opens/closes.
+
+## FamilyDrawer (PR7)
+- Tabbed interface with local state forms for each section. Save/Cancel apply across all tabs simultaneously.
+- Save triggers `familyStore.upsert`, which invokes `familyRepo.update` and rehydrates the store on success.
+- Errors surface via toast + inline field message. Tab headers display a red dot when any field inside fails validation.
+
+### Tab details
+- **Personal**: fields for nickname, full name, relationship, phones, emails, address, website, social links (managed as key/value pairs stored in `social_links_json`).
+- **Finance**: bank accounts and pensions presented as editable lists. Each entry maps to the JSON arrays described in [overview.md](overview.md#workstream-overview) and [schema_changes.md](schema_changes.md). Validation ensures account numbers and sort codes are numeric strings, but enforcement remains client-side.
+- **Documents** (PR9): lists attachments, exposes drag-and-drop area, and provides buttons for `Open`, `Reveal in Finder`, and `Remove`. Uses `familyRepo.attachments` helpers.
+- **Notes** (PR10): renders notes filtered by `member_id` with create/edit/delete inline using existing notes infrastructure.
+- **Renewals** (PR11): table of renewal items with kind selector, expiry date picker, toggle for `remind_on_expiry`, and numeric input for offset days.
+- **Audit**: read-only history showing `created_at`, `updated_at`, `last_verified`, `verified_by`, and status. The tab derives its data from existing fields—no dedicated audit table or IPC lands in this wave.
+
+## AddMemberModal (PR8)
+- Multi-step: Step 1 (Basic info) collects nickname/name/relationship; Step 2 (Optional details) allows phone/email entry.
+- On submit, calls `familyRepo.create`, appends to the store, focuses the new card, and scrolls it into view.
+- Validation prevents blank nickname/name pair (at least one must be provided).
+
+## Validation rules (shared)
+Defined in `validators.ts` (PR7) and reused across UI and backend error mapping.
+- Phone numbers must match `^\+?[1-9]\d{6,14}$`.
+- Emails must match simplified RFC 5322 regex used elsewhere in the app.
+- URLs must start with `http://` or `https://` and contain a valid hostname.
+- Expiry dates must be >= current day in epoch milliseconds.
+- JSON arrays (`bank_accounts_json`, `pension_details_json`, `tags_json`, `groups_json`) must parse successfully; invalid JSON blocks save with a toast referencing `VALIDATION/JSON` (renderer-only guard).
+
+## Error mapping
+Renderer toast messages map one-to-one with the error taxonomy listed in [ipc_extensions.md](ipc_extensions.md#error-code-appendix). Unknown or unexpected errors fall back to a generic "Something went wrong" toast and emit an ERROR log with the raw message.
+
+## Toast catalogue
+- Success: "Family member saved", "Attachment added", "Renewal updated", etc.
+- Error: Strings map to error codes listed in [ipc_extensions.md](ipc_extensions.md). Unknown errors show "Something went wrong" and log at ERROR level.
+
+## Accessibility considerations
+- Drawer trap focus while open; close restores focus to originating card.
+- All buttons have `aria-label` text for screen readers.
+- Banner birthdays include text alternatives (e.g., "Birthday in 12 days").
+
+## Feature flag strategy
+- During development, each PR may guard new UI under `ENABLE_FAMILY_EXPANSION`. The flag lives in `src/config/flags.ts` and is read in `FamilyShell` before mounting feature components.
+- The plan assumes the flag defaults to `true` when the sequence completes. Hide-only rollbacks (PR5–PR11) rely on toggling the flag off without altering data.
+
+## Analytics & logging
+- UI components emit structured logs defined in [logging_policy.md](logging_policy.md), e.g., `family.ui.load.ms`, `family.ui.save.ms`, `family.ui.attach.add.ms` with payload `{ member_id, ms }`.
+
+This specification must remain consistent with the backend contracts. Deviations require updating all linked documents and revisiting acceptance criteria in [rollout_checklist.md](rollout_checklist.md).


### PR DESCRIPTION
## Summary
- highlight the nickname fallback and macOS scope in the overview and add a plaintext warning for exports
- expand the IPC appendix and cross-link logging/UI specs with explicit error mapping guidance
- document the familyStore API, audit tab scope, and feature-flag location to keep the UI plan implementable

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6aaf353b4832ab6d620bb31d02d73