### PR TITLE
Add family expansion schema migration

### DIFF
--- a/migrations/0027_family_expansion.down.sql
+++ b/migrations/0027_family_expansion.down.sql
@@ -1,0 +1,129 @@
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+PRAGMA busy_timeout=5000;
+BEGIN IMMEDIATE;
+
+PRAGMA foreign_keys=OFF;
+
+DROP INDEX IF EXISTS idx_member_renewals_member;
+DROP INDEX IF EXISTS idx_member_renewals_house_kind;
+DROP TABLE IF EXISTS member_renewals;
+
+DROP INDEX IF EXISTS idx_member_attachments_member;
+DROP INDEX IF EXISTS idx_member_attachments_path;
+DROP TABLE IF EXISTS member_attachments;
+
+DROP INDEX IF EXISTS idx_notes_member;
+
+CREATE TABLE notes__baseline (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  category_id TEXT REFERENCES categories(id) ON DELETE SET NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
+  z INTEGER NOT NULL DEFAULT 0,
+  text TEXT NOT NULL DEFAULT '',
+  color TEXT NOT NULL DEFAULT '#FFF4B8',
+  x REAL NOT NULL DEFAULT 0,
+  y REAL NOT NULL DEFAULT 0,
+  deadline INTEGER,
+  deadline_tz TEXT
+);
+
+INSERT INTO notes__baseline (
+  id,
+  household_id,
+  category_id,
+  position,
+  created_at,
+  updated_at,
+  deleted_at,
+  z,
+  text,
+  color,
+  x,
+  y,
+  deadline,
+  deadline_tz
+)
+SELECT
+  id,
+  household_id,
+  category_id,
+  position,
+  created_at,
+  updated_at,
+  deleted_at,
+  z,
+  text,
+  color,
+  x,
+  y,
+  deadline,
+  deadline_tz
+FROM notes;
+
+DROP TABLE notes;
+ALTER TABLE notes__baseline RENAME TO notes;
+
+CREATE UNIQUE INDEX IF NOT EXISTS notes_household_position_idx
+  ON notes(household_id, position) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS notes_deadline_idx
+  ON notes(household_id, deadline);
+CREATE INDEX IF NOT EXISTS notes_household_category_deleted_idx
+  ON notes(household_id, category_id, deleted_at);
+CREATE INDEX IF NOT EXISTS notes_created_cursor_idx
+  ON notes(household_id, created_at, id);
+CREATE INDEX IF NOT EXISTS notes_scope_z_idx
+  ON notes(household_id, deleted_at, z, position);
+
+CREATE TABLE family_members__baseline (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  birthday INTEGER,
+  notes TEXT,
+  household_id TEXT NOT NULL REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
+  position INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO family_members__baseline (
+  id,
+  name,
+  birthday,
+  notes,
+  household_id,
+  created_at,
+  updated_at,
+  deleted_at,
+  position
+)
+SELECT
+  id,
+  name,
+  birthday,
+  notes,
+  household_id,
+  created_at,
+  updated_at,
+  deleted_at,
+  position
+FROM family_members;
+
+DROP TABLE family_members;
+ALTER TABLE family_members__baseline RENAME TO family_members;
+
+CREATE UNIQUE INDEX IF NOT EXISTS family_members_household_position_idx
+  ON family_members(household_id, position) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS family_members_household_updated_idx
+  ON family_members(household_id, updated_at);
+DROP INDEX IF EXISTS idx_family_members_house_bday;
+
+PRAGMA foreign_keys=ON;
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/migrations/0027_family_expansion.down.sql
+++ b/migrations/0027_family_expansion.down.sql
@@ -1,8 +1,3 @@
-PRAGMA journal_mode=WAL;
-PRAGMA foreign_keys=ON;
-PRAGMA busy_timeout=5000;
-BEGIN IMMEDIATE;
-
 PRAGMA foreign_keys=OFF;
 
 DROP INDEX IF EXISTS idx_member_renewals_member;
@@ -122,8 +117,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS family_members_household_position_idx
 CREATE INDEX IF NOT EXISTS family_members_household_updated_idx
   ON family_members(household_id, updated_at);
 DROP INDEX IF EXISTS idx_family_members_house_bday;
-
-PRAGMA foreign_keys=ON;
-COMMIT;
 
 PRAGMA foreign_keys=ON;

--- a/migrations/0027_family_expansion.up.sql
+++ b/migrations/0027_family_expansion.up.sql
@@ -1,8 +1,3 @@
-PRAGMA journal_mode=WAL;
-PRAGMA foreign_keys=ON;
-PRAGMA busy_timeout=5000;
-BEGIN IMMEDIATE;
-
 -- Contact / naming
 ALTER TABLE family_members ADD COLUMN nickname TEXT;
 ALTER TABLE family_members ADD COLUMN full_name TEXT;
@@ -101,5 +96,3 @@ CREATE INDEX IF NOT EXISTS idx_member_renewals_member
 ALTER TABLE notes ADD COLUMN member_id TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_notes_member ON notes(member_id);
-
-COMMIT;

--- a/migrations/0027_family_expansion.up.sql
+++ b/migrations/0027_family_expansion.up.sql
@@ -1,0 +1,105 @@
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+PRAGMA busy_timeout=5000;
+BEGIN IMMEDIATE;
+
+-- Contact / naming
+ALTER TABLE family_members ADD COLUMN nickname TEXT;
+ALTER TABLE family_members ADD COLUMN full_name TEXT;
+ALTER TABLE family_members ADD COLUMN relationship TEXT;
+ALTER TABLE family_members ADD COLUMN photo_path TEXT;
+ALTER TABLE family_members ADD COLUMN phone_mobile TEXT;
+ALTER TABLE family_members ADD COLUMN phone_home TEXT;
+ALTER TABLE family_members ADD COLUMN phone_work TEXT;
+ALTER TABLE family_members ADD COLUMN email TEXT;
+ALTER TABLE family_members ADD COLUMN address TEXT;
+ALTER TABLE family_members ADD COLUMN personal_website TEXT;
+ALTER TABLE family_members ADD COLUMN social_links_json TEXT;
+
+-- Identity & medical
+ALTER TABLE family_members ADD COLUMN passport_number TEXT;
+ALTER TABLE family_members ADD COLUMN passport_expiry INTEGER;
+ALTER TABLE family_members ADD COLUMN driving_licence_number TEXT;
+ALTER TABLE family_members ADD COLUMN driving_licence_expiry INTEGER;
+ALTER TABLE family_members ADD COLUMN nhs_number TEXT;
+ALTER TABLE family_members ADD COLUMN national_insurance_number TEXT;
+ALTER TABLE family_members ADD COLUMN tax_id TEXT;
+ALTER TABLE family_members ADD COLUMN photo_id_expiry INTEGER;
+ALTER TABLE family_members ADD COLUMN blood_group TEXT;
+ALTER TABLE family_members ADD COLUMN allergies TEXT;
+ALTER TABLE family_members ADD COLUMN medical_notes TEXT;
+ALTER TABLE family_members ADD COLUMN gp_contact TEXT;
+ALTER TABLE family_members ADD COLUMN emergency_contact_name TEXT;
+ALTER TABLE family_members ADD COLUMN emergency_contact_phone TEXT;
+
+-- Finance & meta
+ALTER TABLE family_members ADD COLUMN bank_accounts_json TEXT;
+ALTER TABLE family_members ADD COLUMN pension_details_json TEXT;
+ALTER TABLE family_members ADD COLUMN insurance_refs TEXT;
+ALTER TABLE family_members ADD COLUMN tags_json TEXT;
+ALTER TABLE family_members ADD COLUMN groups_json TEXT;
+ALTER TABLE family_members ADD COLUMN last_verified INTEGER;
+ALTER TABLE family_members ADD COLUMN verified_by TEXT;
+ALTER TABLE family_members ADD COLUMN keyholder INTEGER DEFAULT 0;
+ALTER TABLE family_members ADD COLUMN status TEXT DEFAULT 'active';
+
+CREATE INDEX IF NOT EXISTS idx_family_members_house_bday
+  ON family_members(household_id, birthday);
+
+CREATE TABLE IF NOT EXISTS member_attachments (
+  id            TEXT PRIMARY KEY,
+  household_id  TEXT NOT NULL,
+  member_id     TEXT NOT NULL,
+  title         TEXT,
+  root_key      TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  mime_hint     TEXT,
+  added_at      INTEGER NOT NULL,
+  FOREIGN KEY(household_id)
+    REFERENCES household(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE,
+  FOREIGN KEY(member_id)
+    REFERENCES family_members(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_member_attachments_path
+  ON member_attachments(household_id, root_key, relative_path);
+
+CREATE INDEX IF NOT EXISTS idx_member_attachments_member
+  ON member_attachments(member_id, added_at);
+
+CREATE TABLE IF NOT EXISTS member_renewals (
+  id                 TEXT PRIMARY KEY,
+  household_id       TEXT NOT NULL,
+  member_id          TEXT NOT NULL,
+  kind               TEXT NOT NULL,
+  label              TEXT,
+  expires_at         INTEGER NOT NULL,
+  remind_on_expiry   INTEGER NOT NULL DEFAULT 0,
+  remind_offset_days INTEGER NOT NULL DEFAULT 30,
+  created_at         INTEGER NOT NULL,
+  updated_at         INTEGER NOT NULL,
+  FOREIGN KEY(household_id)
+    REFERENCES household(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE,
+  FOREIGN KEY(member_id)
+    REFERENCES family_members(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_member_renewals_house_kind
+  ON member_renewals(household_id, kind, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_member_renewals_member
+  ON member_renewals(member_id, expires_at);
+
+ALTER TABLE notes ADD COLUMN member_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_notes_member ON notes(member_id);
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -47,7 +47,8 @@ CREATE TABLE notes (
   x REAL NOT NULL DEFAULT 0,
   y REAL NOT NULL DEFAULT 0,
   deadline INTEGER,
-  deadline_tz TEXT
+  deadline_tz TEXT,
+  member_id TEXT
 );
 CREATE TABLE files_index (
   id INTEGER PRIMARY KEY,
@@ -121,7 +122,67 @@ CREATE TABLE family_members (
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   deleted_at INTEGER,
-  position INTEGER NOT NULL DEFAULT 0
+  position INTEGER NOT NULL DEFAULT 0,
+  nickname TEXT,
+  full_name TEXT,
+  relationship TEXT,
+  photo_path TEXT,
+  phone_mobile TEXT,
+  phone_home TEXT,
+  phone_work TEXT,
+  email TEXT,
+  address TEXT,
+  personal_website TEXT,
+  social_links_json TEXT,
+  passport_number TEXT,
+  passport_expiry INTEGER,
+  driving_licence_number TEXT,
+  driving_licence_expiry INTEGER,
+  nhs_number TEXT,
+  national_insurance_number TEXT,
+  tax_id TEXT,
+  photo_id_expiry INTEGER,
+  blood_group TEXT,
+  allergies TEXT,
+  medical_notes TEXT,
+  gp_contact TEXT,
+  emergency_contact_name TEXT,
+  emergency_contact_phone TEXT,
+  bank_accounts_json TEXT,
+  pension_details_json TEXT,
+  insurance_refs TEXT,
+  tags_json TEXT,
+  groups_json TEXT,
+  last_verified INTEGER,
+  verified_by TEXT,
+  keyholder INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'active'
+);
+CREATE TABLE member_attachments (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  title TEXT,
+  root_key TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  mime_hint TEXT,
+  added_at INTEGER NOT NULL,
+  FOREIGN KEY(household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE TABLE member_renewals (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT,
+  expires_at INTEGER NOT NULL,
+  remind_on_expiry INTEGER NOT NULL DEFAULT 0,
+  remind_offset_days INTEGER NOT NULL DEFAULT 30,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 CREATE TABLE import_id_map (
   entity TEXT NOT NULL,
@@ -272,6 +333,7 @@ CREATE INDEX expenses_category_date_idx ON expenses(category_id, date);
 CREATE INDEX expenses_household_updated_idx ON expenses(household_id, updated_at);
 CREATE UNIQUE INDEX family_members_household_position_idx ON family_members(household_id, position) WHERE deleted_at IS NULL;
 CREATE INDEX family_members_household_updated_idx ON family_members(household_id, updated_at);
+CREATE INDEX IF NOT EXISTS idx_family_members_house_bday ON family_members(household_id, birthday);
 CREATE INDEX idx_bills_household_due ON bills(household_id, due_date);
 CREATE INDEX idx_events_household_active ON events(household_id, updated_at) WHERE deleted_at IS NULL;
 CREATE INDEX idx_events_household_rrule ON events(household_id, rrule);
@@ -283,6 +345,7 @@ CREATE UNIQUE INDEX notes_household_position_idx ON notes(household_id, position
 CREATE INDEX notes_deadline_idx ON notes(household_id, deadline);
 CREATE INDEX notes_household_category_deleted_idx ON notes(household_id, category_id, deleted_at);
 CREATE INDEX notes_created_cursor_idx ON notes(household_id, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_notes_member ON notes(member_id);
 CREATE INDEX pet_medical_household_updated_idx ON pet_medical(household_id, updated_at);
 CREATE INDEX pet_medical_pet_date_idx ON pet_medical(pet_id, date);
 CREATE UNIQUE INDEX pets_household_position_idx ON pets(household_id, position) WHERE deleted_at IS NULL;
@@ -293,6 +356,10 @@ CREATE UNIQUE INDEX property_documents_household_position_idx ON property_docume
 CREATE INDEX property_documents_household_updated_idx ON property_documents(household_id, updated_at);
 CREATE UNIQUE INDEX shopping_household_position_idx ON shopping_items(household_id, position) WHERE deleted_at IS NULL;
 CREATE INDEX shopping_scope_idx ON shopping_items(household_id, deleted_at, position);
+CREATE UNIQUE INDEX idx_member_attachments_path ON member_attachments(household_id, root_key, relative_path);
+CREATE INDEX idx_member_attachments_member ON member_attachments(member_id, added_at);
+CREATE INDEX idx_member_renewals_house_kind ON member_renewals(household_id, kind, expires_at);
+CREATE INDEX idx_member_renewals_member ON member_renewals(member_id, expires_at);
 CREATE INDEX vehicle_maintenance_household_updated_idx ON vehicle_maintenance(household_id, updated_at);
 CREATE INDEX vehicle_maintenance_vehicle_date_idx ON vehicle_maintenance(vehicle_id, date);
 CREATE UNIQUE INDEX vehicles_household_position_idx ON vehicles(household_id, position) WHERE deleted_at IS NULL;

--- a/src-tauri/schema.sql
+++ b/src-tauri/schema.sql
@@ -49,7 +49,8 @@ CREATE TABLE notes (
   x REAL NOT NULL DEFAULT 0,
   y REAL NOT NULL DEFAULT 0,
   deadline INTEGER,
-  deadline_tz TEXT
+  deadline_tz TEXT,
+  member_id TEXT
 );
 CREATE TABLE files_index (
   id INTEGER PRIMARY KEY,
@@ -123,7 +124,67 @@ CREATE TABLE family_members (
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   deleted_at INTEGER,
-  position INTEGER NOT NULL DEFAULT 0
+  position INTEGER NOT NULL DEFAULT 0,
+  nickname TEXT,
+  full_name TEXT,
+  relationship TEXT,
+  photo_path TEXT,
+  phone_mobile TEXT,
+  phone_home TEXT,
+  phone_work TEXT,
+  email TEXT,
+  address TEXT,
+  personal_website TEXT,
+  social_links_json TEXT,
+  passport_number TEXT,
+  passport_expiry INTEGER,
+  driving_licence_number TEXT,
+  driving_licence_expiry INTEGER,
+  nhs_number TEXT,
+  national_insurance_number TEXT,
+  tax_id TEXT,
+  photo_id_expiry INTEGER,
+  blood_group TEXT,
+  allergies TEXT,
+  medical_notes TEXT,
+  gp_contact TEXT,
+  emergency_contact_name TEXT,
+  emergency_contact_phone TEXT,
+  bank_accounts_json TEXT,
+  pension_details_json TEXT,
+  insurance_refs TEXT,
+  tags_json TEXT,
+  groups_json TEXT,
+  last_verified INTEGER,
+  verified_by TEXT,
+  keyholder INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'active'
+);
+CREATE TABLE member_attachments (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  title TEXT,
+  root_key TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  mime_hint TEXT,
+  added_at INTEGER NOT NULL,
+  FOREIGN KEY(household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE TABLE member_renewals (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL,
+  member_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT,
+  expires_at INTEGER NOT NULL,
+  remind_on_expiry INTEGER NOT NULL DEFAULT 0,
+  remind_offset_days INTEGER NOT NULL DEFAULT 30,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY(household_id) REFERENCES household(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY(member_id) REFERENCES family_members(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 CREATE TABLE import_id_map (
   entity TEXT NOT NULL,
@@ -278,6 +339,7 @@ CREATE INDEX expenses_category_date_idx ON expenses(category_id, date);
 CREATE INDEX expenses_household_updated_idx ON expenses(household_id, updated_at);
 CREATE UNIQUE INDEX family_members_household_position_idx ON family_members(household_id, position) WHERE deleted_at IS NULL;
 CREATE INDEX family_members_household_updated_idx ON family_members(household_id, updated_at);
+CREATE INDEX IF NOT EXISTS idx_family_members_house_bday ON family_members(household_id, birthday);
 CREATE INDEX idx_bills_household_due ON bills(household_id, due_date);
 CREATE INDEX idx_events_household_active ON events(household_id, updated_at) WHERE deleted_at IS NULL;
 CREATE INDEX idx_events_household_rrule ON events(household_id, rrule);
@@ -292,6 +354,7 @@ CREATE INDEX notes_scope_z_idx ON notes(household_id, deleted_at, z, position);
 CREATE INDEX IF NOT EXISTS notes_deadline_idx ON notes(household_id, deadline);
 CREATE INDEX notes_household_category_idx
   ON notes(household_id, category_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notes_member ON notes(member_id);
 CREATE UNIQUE INDEX pet_medical_household_category_path_idx ON pet_medical(household_id, category, relative_path) WHERE deleted_at IS NULL AND relative_path IS NOT NULL;
 CREATE INDEX pet_medical_household_updated_idx ON pet_medical(household_id, updated_at);
 CREATE INDEX pet_medical_pet_date_idx ON pet_medical(pet_id, date);
@@ -305,6 +368,10 @@ CREATE UNIQUE INDEX property_documents_household_position_idx ON property_docume
 CREATE INDEX property_documents_household_updated_idx ON property_documents(household_id, updated_at);
 CREATE UNIQUE INDEX shopping_household_position_idx ON shopping_items(household_id, position) WHERE deleted_at IS NULL;
 CREATE INDEX shopping_scope_idx ON shopping_items(household_id, deleted_at, position);
+CREATE UNIQUE INDEX idx_member_attachments_path ON member_attachments(household_id, root_key, relative_path);
+CREATE INDEX idx_member_attachments_member ON member_attachments(member_id, added_at);
+CREATE INDEX idx_member_renewals_house_kind ON member_renewals(household_id, kind, expires_at);
+CREATE INDEX idx_member_renewals_member ON member_renewals(member_id, expires_at);
 CREATE UNIQUE INDEX vehicle_maintenance_household_category_path_idx ON vehicle_maintenance(household_id, category, relative_path) WHERE deleted_at IS NULL AND relative_path IS NOT NULL;
 CREATE INDEX vehicle_maintenance_household_updated_idx ON vehicle_maintenance(household_id, updated_at);
 CREATE INDEX vehicle_maintenance_vehicle_date_idx ON vehicle_maintenance(vehicle_id, date);


### PR DESCRIPTION
## Summary
- add the macOS-only PR1 schema migration that enriches `family_members`, introduces member attachment and renewal tables, and links notes to members
- provide a down migration that rebuilds affected tables and indexes to restore the PR0 baseline
- refresh the schema mirrors and update the family plan documentation to call out the new guardrails
- ensure the member attachment and renewal tables enforce the `household_id` foreign key alongside the member linkage

## Testing
- sqlite3 /tmp/family.sqlite <<'SQL'
.read migrations/0001_baseline.sql
.read migrations/0027_family_expansion.up.sql
SQL
- sqlite3 /tmp/family.sqlite "PRAGMA foreign_key_list('member_attachments');"
- sqlite3 /tmp/family.sqlite "PRAGMA foreign_key_list('member_renewals');"
- sqlite3 /tmp/family.sqlite <<'SQL'
.read migrations/0027_family_expansion.down.sql
SQL
- sqlite3 /tmp/family.sqlite "SELECT name FROM sqlite_master WHERE type='table' AND name='member_attachments';"

------
https://chatgpt.com/codex/tasks/task_e_68e6b0538f74832a9a07165b5d529cdc