### PR TITLE
Bridge Family UI logs to backend sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Family PR3
+- Added structured JSON logging to Family backend IPC and UI actions.
+- Log levels: DEBUG, INFO, WARN, ERROR across commands and renderer events.
+- New documentation: [`docs/family/logging.md`](docs/family/logging.md).

--- a/docs/family/README.md
+++ b/docs/family/README.md
@@ -8,14 +8,15 @@ This directory captures how the Family area behaves **as shipped today**, spanni
 - [IPC contracts](ipc.md)
 - [Frontend behaviour](frontend.md)
 - [Diagnostics & logging](diagnostics.md)
+- [Logging model](logging.md)
 - [Changelog](changelog.md)
 
 ## Snapshot highlights
-- The Rust command surface exposes six generic `family_members_*` handlers generated in `src-tauri/src/lib.rs`; they delegate straight into the shared command helpers without extra logging.【F:src-tauri/src/lib.rs†L638-L853】
+- The Rust command surface exposes six generic `family_members_*` handlers generated in [`src-tauri/src/lib.rs`](../../src-tauri/src/lib.rs); each command now emits structured entry/exit logs through the [`family_logging::LogScope` helper](../../src-tauri/src/family_logging.rs).
 - TypeScript talks to those commands through `familyRepo` in `src/repos.ts`, which applies the `"position, created_at, id"` ordering for every list call.【F:src/repos.ts†L32-L107】
 - The web UI is implemented entirely in `src/FamilyView.ts`, which mounts a `<section>` inside the supplied container, renders the list/form markup with `innerHTML`, and wires event listeners per element.【F:src/FamilyView.ts†L20-L145】
 - Persistent data lives in the `family_members` table defined in the baseline migration and `schema.sql`, with `position INTEGER NOT NULL DEFAULT 0` plus a filtered uniqueness index on `(household_id, position)`.【F:migrations/0001_baseline.sql†L129-L139】【F:schema.sql†L115-L125】【F:schema.sql†L273-L274】
-- Diagnostics currently surface Family only via aggregate counts (`familyMembers`) and export routines; no dedicated log events are emitted when the commands run.【F:src-tauri/src/diagnostics.rs†L90-L116】【F:src-tauri/src/lib.rs†L638-L853】【F:src-tauri/src/export/mod.rs†L224-L268】
+- Diagnostics now include structured log output for every Family IPC and renderer action; see [`docs/family/logging.md`](logging.md) for envelope details and the list of emitting call sites across the renderer and backend.
 
 ## Known limitations (documented facts)
 - There is no user-facing error messaging: the create path lacks a `try/catch`, and the update handlers swallow errors silently.【F:src/FamilyView.ts†L58-L145】

--- a/docs/family/logging.md
+++ b/docs/family/logging.md
@@ -1,0 +1,82 @@
+# Family logging model (PR3)
+
+Family PR3 introduces structured logging across the Family backend commands and renderer interactions. All log lines share a consistent JSON envelope written through `tracing` (Rust) or `logUI` (TypeScript).
+
+## Envelope schema
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `ts` | string (ISO 8601) | Automatically produced by the logging sink. |
+| `level` | enum (`TRACE` `DEBUG` `INFO` `WARN` `ERROR`) | Severity classification. |
+| `area` | string | Always `"family"` for PR3 events. |
+| `cmd` | string | IPC command name (`family_members_update`) or renderer event (`ui.family.drawer.save`). |
+| `household_id` | string (optional) | Household scope for the action. |
+| `member_id` | string (optional) | Target family member when applicable. |
+| `duration_ms` | integer (optional) | Milliseconds elapsed between entry and completion. |
+| `details` | object | Additional metadata (row counts, messages, identifiers). |
+
+### Sample entries
+
+```json
+{
+  "ts": "2025-10-09T12:43:17.512Z",
+  "level": "INFO",
+  "area": "family",
+  "cmd": "family_members_update",
+  "household_id": "hh-1",
+  "member_id": "mem-1",
+  "duration_ms": 23,
+  "details": {
+    "rows": 1,
+    "message": "family member updated"
+  }
+}
+```
+
+```json
+{
+  "ts": "2025-10-09T12:43:17.984Z",
+  "level": "INFO",
+  "area": "family",
+  "cmd": "ui.family.drawer.save",
+  "details": {
+    "member_id": "mem-1",
+    "duration_ms": 87
+  }
+}
+```
+
+## Backend emission points
+
+* All `family_members_*` IPC handlers create a scoped logger that records:
+  * `DEBUG` entry (`cmd = family_members_*`, identifiers populated when available).
+  * `INFO` completion with row counts and summary message.
+  * `WARN` on validation or database-health failures (for example `DB_UNHEALTHY – write blocked`).
+  * `ERROR` for unexpected faults (SQL errors, crash IDs, etc.).
+* Attachment and renewal commands (`member_attachments_*`, `member_renewals_*`) follow the same pattern.
+* Guard failures inside the generated IPC wrappers produce warn logs before returning the structured `AppError`.
+
+## Frontend emission points
+
+* `FamilyView` logs lifecycle stages through the injected `logUI` helper:
+  * Household list loads (`ui.family.list.load.start/complete`).
+  * Member creation attempts (`ui.family.create.*`).
+  * Drawer saves and autosaves (`ui.family.drawer.save`, `ui.family.drawer.autosave.*`).
+* Repository helpers emit telemetry for attachment and renewal flows under `ui.family.attachments.*` and `ui.family.renewals.*`.
+* Renderer logs invoke the `family_ui_log` Tauri command through `logUI`, so the UI shares the same tracing sinks as the backend (falling back to a JSON `console.log` only when the bridge is unavailable).
+
+## Log persistence
+
+* Both stdout and the rotating file sink (`<app-data>/logs/arklowdun.log`) receive the JSON lines emitted via `family_ui_log`. During tests the standalone subscriber writes to an in-memory buffer to allow assertions.
+
+## Verification checklist
+
+* ✅ `family_members_*` commands emit entry and completion logs. See `family_logging.rs` tests for coverage.
+* ✅ Guard failures (database unhealthy, maintenance) surface WARN logs with contextual details.
+* ✅ Renderer interactions generate `ui.family.*` events exactly once per user action (verified by `tests/family-logging.test.ts`).
+* ✅ Attachment and renewal UI helpers log start, completion, and error states.
+
+## Known omissions
+
+* Field redaction is deferred to a future PR; current logs include the identifiers supplied by the commands.
+* No sampling is applied; high-frequency UI warnings should aggregate via `details.count` if necessary in follow-up work.

--- a/src-tauri/src/family_logging.rs
+++ b/src-tauri/src/family_logging.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, field, info, warn};
 
 use crate::{ipc::guard, AppError};
 
@@ -80,7 +80,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = %wrapped_details
+            details = field::display(wrapped_details.clone())
         ),
         UiLogLevel::Info => info!(
             target: "arklowdun",
@@ -89,7 +89,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = %wrapped_details
+            details = field::display(wrapped_details.clone())
         ),
         UiLogLevel::Warn => warn!(
             target: "arklowdun",
@@ -98,7 +98,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = %wrapped_details
+            details = field::display(wrapped_details.clone())
         ),
         UiLogLevel::Error => error!(
             target: "arklowdun",
@@ -107,7 +107,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = %wrapped_details
+            details = field::display(wrapped_details)
         ),
     }
 }
@@ -133,7 +133,7 @@ impl LogScope {
             cmd = scope.cmd,
             household_id = scope.household_id.as_deref(),
             member_id = scope.member_id.as_deref(),
-            details = %json!({ "stage": "enter" })
+            details = field::display(json!({ "stage": "enter" }))
         );
         scope
     }
@@ -162,7 +162,7 @@ impl LogScope {
             household_id = self.household_id.as_deref(),
             member_id = member_id.or(self.member_id.as_deref()),
             duration_ms = self.elapsed_ms() as u64,
-            details = %wrap_details(details)
+            details = field::display(wrap_details(details))
         );
     }
 
@@ -179,7 +179,7 @@ impl LogScope {
             household_id = self.resolved_household(household_id).as_deref(),
             member_id = self.resolved_member(member_id).as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = %wrap_details(details)
+            details = field::display(wrap_details(details))
         );
     }
 
@@ -233,7 +233,7 @@ impl LogScope {
             household_id = self.household_id.as_deref(),
             member_id = self.member_id.as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = %Value::Object(map)
+            details = field::display(Value::Object(map))
         );
     }
 
@@ -245,7 +245,7 @@ impl LogScope {
             household_id = self.resolved_household(household_id).as_deref(),
             member_id = self.resolved_member(member_id).as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = %wrap_details(details)
+            details = field::display(wrap_details(details))
         );
     }
 }

--- a/src-tauri/src/family_logging.rs
+++ b/src-tauri/src/family_logging.rs
@@ -233,7 +233,7 @@ impl LogScope {
             household_id = self.household_id.as_deref(),
             member_id = self.member_id.as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = field::display(Value::Object(map))
+            details = field::display(serde_json::Value::Object(map))
         );
     }
 

--- a/src-tauri/src/family_logging.rs
+++ b/src-tauri/src/family_logging.rs
@@ -80,7 +80,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = field::display(wrapped_details.clone())
+            details = field::display(&wrapped_details)
         ),
         UiLogLevel::Info => info!(
             target: "arklowdun",
@@ -89,7 +89,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = field::display(wrapped_details.clone())
+            details = field::display(&wrapped_details)
         ),
         UiLogLevel::Warn => warn!(
             target: "arklowdun",
@@ -98,7 +98,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = field::display(wrapped_details.clone())
+            details = field::display(&wrapped_details)
         ),
         UiLogLevel::Error => error!(
             target: "arklowdun",
@@ -107,7 +107,7 @@ pub fn emit_ui_log(record: UiLogRecord) {
             household_id = household_id.as_deref(),
             member_id = member_id.as_deref(),
             duration_ms = duration_ms,
-            details = field::display(wrapped_details)
+            details = field::display(&wrapped_details)
         ),
     }
 }
@@ -226,6 +226,7 @@ impl LogScope {
         if let Some(crash) = err.crash_id() {
             map.insert("crash_id".into(), Value::String(crash.to_string()));
         }
+        let details = serde_json::Value::Object(map);
         error!(
             target: "arklowdun",
             area = "family",
@@ -233,11 +234,12 @@ impl LogScope {
             household_id = self.household_id.as_deref(),
             member_id = self.member_id.as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = field::display(serde_json::Value::Object(map))
+            details = field::display(&details)
         );
     }
 
     fn emit_warn(&self, details: Value, household_id: Option<&str>, member_id: Option<&str>) {
+        let wrapped = wrap_details(details);
         warn!(
             target: "arklowdun",
             area = "family",
@@ -245,7 +247,7 @@ impl LogScope {
             household_id = self.resolved_household(household_id).as_deref(),
             member_id = self.resolved_member(member_id).as_deref(),
             duration_ms = self.elapsed_ms() as u64,
-            details = field::display(wrap_details(details))
+            details = field::display(&wrapped)
         );
     }
 }

--- a/src-tauri/src/family_logging.rs
+++ b/src-tauri/src/family_logging.rs
@@ -1,0 +1,251 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use tracing::{debug, error, info, warn};
+
+use crate::{ipc::guard, AppError};
+
+fn context_to_json(context: &HashMap<String, String>) -> Option<Value> {
+    if context.is_empty() {
+        None
+    } else {
+        let mut map = Map::with_capacity(context.len());
+        for (key, value) in context {
+            map.insert(key.clone(), Value::String(value.clone()));
+        }
+        Some(Value::Object(map))
+    }
+}
+
+fn is_validation_error(code: &str) -> bool {
+    code.starts_with("ATTACHMENTS/")
+        || code.starts_with("RENEWALS/")
+        || code.starts_with("VALIDATION/")
+}
+
+fn wrap_details(value: Value) -> Value {
+    if value.is_object() {
+        value
+    } else {
+        json!({ "value": value })
+    }
+}
+
+fn default_details() -> Value {
+    Value::Object(Map::new())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum UiLogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UiLogRecord {
+    pub cmd: String,
+    pub level: UiLogLevel,
+    #[serde(default)]
+    pub household_id: Option<String>,
+    #[serde(default)]
+    pub member_id: Option<String>,
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
+    #[serde(default = "default_details")]
+    pub details: Value,
+}
+
+pub fn emit_ui_log(record: UiLogRecord) {
+    let UiLogRecord {
+        cmd,
+        level,
+        household_id,
+        member_id,
+        duration_ms,
+        details,
+    } = record;
+
+    let wrapped_details = wrap_details(details);
+
+    match level {
+        UiLogLevel::Debug => debug!(
+            target: "arklowdun",
+            area = "family",
+            cmd = cmd.as_str(),
+            household_id = household_id.as_deref(),
+            member_id = member_id.as_deref(),
+            duration_ms = duration_ms,
+            details = %wrapped_details
+        ),
+        UiLogLevel::Info => info!(
+            target: "arklowdun",
+            area = "family",
+            cmd = cmd.as_str(),
+            household_id = household_id.as_deref(),
+            member_id = member_id.as_deref(),
+            duration_ms = duration_ms,
+            details = %wrapped_details
+        ),
+        UiLogLevel::Warn => warn!(
+            target: "arklowdun",
+            area = "family",
+            cmd = cmd.as_str(),
+            household_id = household_id.as_deref(),
+            member_id = member_id.as_deref(),
+            duration_ms = duration_ms,
+            details = %wrapped_details
+        ),
+        UiLogLevel::Error => error!(
+            target: "arklowdun",
+            area = "family",
+            cmd = cmd.as_str(),
+            household_id = household_id.as_deref(),
+            member_id = member_id.as_deref(),
+            duration_ms = duration_ms,
+            details = %wrapped_details
+        ),
+    }
+}
+
+pub struct LogScope {
+    cmd: &'static str,
+    household_id: Option<String>,
+    member_id: Option<String>,
+    start: Instant,
+}
+
+impl LogScope {
+    pub fn new(cmd: &'static str, household_id: Option<String>, member_id: Option<String>) -> Self {
+        let scope = Self {
+            cmd,
+            household_id,
+            member_id,
+            start: Instant::now(),
+        };
+        debug!(
+            target: "arklowdun",
+            area = "family",
+            cmd = scope.cmd,
+            household_id = scope.household_id.as_deref(),
+            member_id = scope.member_id.as_deref(),
+            details = %json!({ "stage": "enter" })
+        );
+        scope
+    }
+
+    fn elapsed_ms(&self) -> u128 {
+        self.start.elapsed().as_millis()
+    }
+
+    fn resolved_household(&self, override_id: Option<&str>) -> Option<String> {
+        override_id
+            .map(|value| value.to_string())
+            .or_else(|| self.household_id.clone())
+    }
+
+    fn resolved_member(&self, override_id: Option<&str>) -> Option<String> {
+        override_id
+            .map(|value| value.to_string())
+            .or_else(|| self.member_id.clone())
+    }
+
+    pub fn success(&self, member_id: Option<&str>, details: Value) {
+        info!(
+            target: "arklowdun",
+            area = "family",
+            cmd = self.cmd,
+            household_id = self.household_id.as_deref(),
+            member_id = member_id.or(self.member_id.as_deref()),
+            duration_ms = self.elapsed_ms() as u64,
+            details = %wrap_details(details)
+        );
+    }
+
+    pub fn success_with_ids(
+        &self,
+        household_id: Option<&str>,
+        member_id: Option<&str>,
+        details: Value,
+    ) {
+        info!(
+            target: "arklowdun",
+            area = "family",
+            cmd = self.cmd,
+            household_id = self.resolved_household(household_id).as_deref(),
+            member_id = self.resolved_member(member_id).as_deref(),
+            duration_ms = self.elapsed_ms() as u64,
+            details = %wrap_details(details)
+        );
+    }
+
+    pub fn warn(&self, details: Value) {
+        self.emit_warn(details, None, None);
+    }
+
+    pub fn warn_with_ids(
+        &self,
+        household_id: Option<&str>,
+        member_id: Option<&str>,
+        details: Value,
+    ) {
+        self.emit_warn(details, household_id, member_id);
+    }
+
+    pub fn fail(&self, err: &AppError) {
+        if err.code() == guard::DB_UNHEALTHY_CODE {
+            self.emit_warn(
+                json!({ "code": err.code(), "message": "DB_UNHEALTHY – write blocked" }),
+                None,
+                None,
+            );
+            return;
+        }
+
+        if is_validation_error(err.code()) {
+            let mut map = Map::new();
+            map.insert("code".into(), Value::String(err.code().to_string()));
+            map.insert("message".into(), Value::String(err.message().to_string()));
+            if let Some(context) = context_to_json(err.context()) {
+                map.insert("context".into(), context);
+            }
+            self.emit_warn(Value::Object(map), None, None);
+            return;
+        }
+
+        let mut map = Map::new();
+        map.insert("code".into(), Value::String(err.code().to_string()));
+        map.insert("message".into(), Value::String(err.message().to_string()));
+        if let Some(context) = context_to_json(err.context()) {
+            map.insert("context".into(), context);
+        }
+        if let Some(crash) = err.crash_id() {
+            map.insert("crash_id".into(), Value::String(crash.to_string()));
+        }
+        error!(
+            target: "arklowdun",
+            area = "family",
+            cmd = self.cmd,
+            household_id = self.household_id.as_deref(),
+            member_id = self.member_id.as_deref(),
+            duration_ms = self.elapsed_ms() as u64,
+            details = %Value::Object(map)
+        );
+    }
+
+    fn emit_warn(&self, details: Value, household_id: Option<&str>, member_id: Option<&str>) {
+        warn!(
+            target: "arklowdun",
+            area = "family",
+            cmd = self.cmd,
+            household_id = self.resolved_household(household_id).as_deref(),
+            member_id = self.resolved_member(member_id).as_deref(),
+            duration_ms = self.elapsed_ms() as u64,
+            details = %wrap_details(details)
+        );
+    }
+}

--- a/src-tauri/tests/family_logging.rs
+++ b/src-tauri/tests/family_logging.rs
@@ -18,8 +18,7 @@ use arklowdun_lib::{
     household_active::StoreHandle,
     ipc::guard,
     migrate,
-    state::AppState,
-    time::now_ms,
+    AppState,
     vault::Vault,
     vault_migration::VaultMigrationManager,
 };
@@ -51,6 +50,15 @@ fn init_buffer_subscriber() -> (Arc<StdMutex<Vec<u8>>>, DefaultGuard) {
 
 fn logs_to_string(buffer: &Arc<StdMutex<Vec<u8>>>) -> String {
     String::from_utf8(buffer.lock().unwrap().clone()).expect("log utf8")
+}
+
+fn now_ms_local() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_millis() as i64
 }
 
 async fn seed_family_db() -> (TempDir, SqlitePool) {
@@ -135,7 +143,7 @@ async fn update_command_emits_family_logs() {
 
     let mut data = Map::new();
     data.insert("notes".into(), Value::String("updated".into()));
-    data.insert("updated_at".into(), Value::from(now_ms()));
+    data.insert("updated_at".into(), Value::from(now_ms_local()));
 
     commands::update_command(&pool, "family_members", "mem-1", data, Some("hh-1"), None)
         .await

--- a/src-tauri/tests/family_logging.rs
+++ b/src-tauri/tests/family_logging.rs
@@ -1,0 +1,226 @@
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use serde_json::{Map, Value};
+use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
+use tempfile::TempDir;
+use tracing::subscriber::{self, DefaultGuard};
+use tracing_subscriber::{fmt, EnvFilter};
+
+use arklowdun_lib::{
+    commands,
+    db::health::{DbHealthReport, DbHealthStatus},
+    events_tz_backfill::BackfillCoordinator,
+    family_logging::LogScope,
+    files_indexer::FilesIndexer,
+    household_active::StoreHandle,
+    ipc::guard,
+    migrate,
+    state::AppState,
+    time::now_ms,
+    vault::Vault,
+    vault_migration::VaultMigrationManager,
+};
+
+struct BufferWriter(Arc<StdMutex<Vec<u8>>>);
+
+impl std::io::Write for BufferWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn init_buffer_subscriber() -> (Arc<StdMutex<Vec<u8>>>, DefaultGuard) {
+    let buffer: Arc<StdMutex<Vec<u8>>> = Arc::new(StdMutex::new(Vec::new()));
+    let writer = buffer.clone();
+    let subscriber = fmt()
+        .with_env_filter(EnvFilter::new("arklowdun=debug"))
+        .with_writer(move || BufferWriter(writer.clone()))
+        .json()
+        .finish();
+    let guard = subscriber::set_default(subscriber);
+    (buffer, guard)
+}
+
+fn logs_to_string(buffer: &Arc<StdMutex<Vec<u8>>>) -> String {
+    String::from_utf8(buffer.lock().unwrap().clone()).expect("log utf8")
+}
+
+async fn seed_family_db() -> (TempDir, SqlitePool) {
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("family_logging.sqlite3");
+    let pool = SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .expect("open sqlite pool");
+    sqlx::query("PRAGMA foreign_keys=ON;")
+        .execute(&pool)
+        .await
+        .expect("enable fk");
+    migrate::apply_migrations(&pool)
+        .await
+        .expect("apply migrations");
+
+    sqlx::query(
+        "INSERT INTO household (id, name, created_at, updated_at, deleted_at, tz, is_default, color) \
+         VALUES (?1, 'Household', 0, 0, NULL, NULL, 1, NULL)",
+    )
+    .bind("hh-1")
+    .execute(&pool)
+    .await
+    .expect("insert household");
+
+    sqlx::query(
+        "INSERT INTO family_members (id, name, household_id, created_at, updated_at, position) \
+         VALUES (?1, 'Member', ?2, 0, 0, 0)",
+    )
+    .bind("mem-1")
+    .bind("hh-1")
+    .execute(&pool)
+    .await
+    .expect("insert member");
+
+    (dir, pool)
+}
+
+fn unhealthy_state() -> (AppState, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let attachments_root = dir.path().join("attachments");
+    fs::create_dir_all(&attachments_root).expect("create attachments root");
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("sqlite::memory:")
+        .expect("create sqlite pool");
+
+    let vault = Arc::new(Vault::new(&attachments_root));
+    let files_indexer = Arc::new(FilesIndexer::new(pool.clone(), vault.clone()));
+    let report = DbHealthReport {
+        status: DbHealthStatus::Error,
+        checks: Vec::new(),
+        offenders: Vec::new(),
+        schema_hash: "hash".into(),
+        app_version: "test".into(),
+        generated_at: "2024-01-01T00:00:00Z".into(),
+    };
+
+    let state = AppState {
+        pool: Arc::new(std::sync::RwLock::new(pool.clone())),
+        active_household_id: Arc::new(std::sync::Mutex::new(String::new())),
+        store: StoreHandle::in_memory(),
+        backfill: Arc::new(std::sync::Mutex::new(BackfillCoordinator::new())),
+        db_health: Arc::new(std::sync::Mutex::new(report)),
+        db_path: Arc::new(dir.path().join("db.sqlite3")),
+        vault,
+        vault_migration: Arc::new(
+            VaultMigrationManager::new(&attachments_root).expect("create vault migration manager"),
+        ),
+        maintenance: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        files_indexer,
+    };
+
+    (state, dir)
+}
+
+#[tokio::test]
+async fn update_command_emits_family_logs() {
+    let (_dir, pool) = seed_family_db().await;
+    let (buffer, _guard) = init_buffer_subscriber();
+
+    let mut data = Map::new();
+    data.insert("notes".into(), Value::String("updated".into()));
+    data.insert("updated_at".into(), Value::from(now_ms()));
+
+    commands::update_command(&pool, "family_members", "mem-1", data, Some("hh-1"), None)
+        .await
+        .expect("update command succeeds");
+
+    let log = logs_to_string(&buffer);
+    assert!(
+        log.contains("\"cmd\":\"family_members_update\""),
+        "missing command: {log}"
+    );
+    assert!(
+        log.contains("\"level\":\"DEBUG\""),
+        "missing debug log: {log}"
+    );
+    assert!(
+        log.contains("\"level\":\"INFO\""),
+        "missing info log: {log}"
+    );
+    assert!(
+        log.contains("\"details\":{\"rows\":1"),
+        "missing success details: {log}"
+    );
+}
+
+#[tokio::test]
+async fn list_command_emits_family_logs() {
+    let (_dir, pool) = seed_family_db().await;
+    let (buffer, _guard) = init_buffer_subscriber();
+
+    let rows = commands::list_command(
+        &pool,
+        "family_members",
+        "hh-1",
+        Some("position, created_at, id"),
+        None,
+        None,
+    )
+    .await
+    .expect("list command succeeds");
+    assert_eq!(rows.len(), 1, "expected one seeded member");
+
+    let log = logs_to_string(&buffer);
+    assert!(
+        log.contains("\"cmd\":\"family_members_list\""),
+        "missing list command log: {log}"
+    );
+    assert!(
+        log.contains("\"level\":\"DEBUG\""),
+        "missing debug log: {log}"
+    );
+    assert!(
+        log.contains("\"level\":\"INFO\""),
+        "missing info log: {log}"
+    );
+    assert!(
+        log.contains("\"rows\":1"),
+        "missing row count detail: {log}"
+    );
+}
+
+#[tokio::test]
+async fn guard_failure_emits_warn_log() {
+    let (state, _dir) = unhealthy_state();
+    let (buffer, _guard) = init_buffer_subscriber();
+
+    let err = guard::ensure_db_writable(&state).expect_err("guard should block writes");
+
+    let scope = LogScope::new(
+        "family_members_update",
+        Some("hh-1".to_string()),
+        Some("mem-1".to_string()),
+    );
+    scope.fail(&err);
+
+    let log = logs_to_string(&buffer);
+    assert!(
+        log.contains("\"cmd\":\"family_members_update\""),
+        "missing update command log: {log}"
+    );
+    assert!(
+        log.contains("\"level\":\"WARN\""),
+        "missing warn log: {log}"
+    );
+    assert!(
+        log.contains("DB_UNHEALTHY"),
+        "missing DB_UNHEALTHY indicator in warn log: {log}"
+    );
+}

--- a/src/lib/uiLog.ts
+++ b/src/lib/uiLog.ts
@@ -1,0 +1,120 @@
+export type UiLogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+export type UiLogDetails = Record<string, unknown>;
+
+type UiLogPayload = {
+  level: UiLogLevel;
+  cmd: string;
+  details: UiLogDetails;
+  household_id?: string;
+  member_id?: string;
+  duration_ms?: number;
+};
+
+type MaybeInvoker = (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+const HOUSEHOLD_KEYS = ["household_id", "householdId"] as const;
+const MEMBER_KEYS = ["member_id", "memberId"] as const;
+const DURATION_KEYS = ["duration_ms", "durationMs"] as const;
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function coerceDuration(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.round(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.round(parsed);
+    }
+  }
+  return undefined;
+}
+
+function extractFirst<T extends readonly string[]>(
+  details: UiLogDetails,
+  keys: T,
+  extractor: (value: unknown) => string | number | undefined,
+): string | number | undefined {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(details, key)) {
+      const next = extractor(details[key]);
+      if (next !== undefined) {
+        return next;
+      }
+    }
+  }
+  return undefined;
+}
+
+function buildPayload(level: UiLogLevel, cmd: string, details: UiLogDetails): UiLogPayload {
+  const normalized: UiLogDetails = { ...details };
+  const payload: UiLogPayload = { level, cmd, details: normalized };
+
+  const household = extractFirst(normalized, HOUSEHOLD_KEYS, coerceString);
+  if (typeof household === "string") {
+    payload.household_id = household;
+  }
+
+  const member = extractFirst(normalized, MEMBER_KEYS, coerceString);
+  if (typeof member === "string") {
+    payload.member_id = member;
+  }
+
+  const duration = extractFirst(normalized, DURATION_KEYS, coerceDuration);
+  if (typeof duration === "number") {
+    payload.duration_ms = duration;
+  }
+
+  return payload;
+}
+
+function toJsonLine(payload: UiLogPayload): string {
+  const envelope: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    level: payload.level,
+    area: "family",
+    cmd: payload.cmd,
+    details: payload.details,
+  };
+
+  if (payload.household_id) envelope.household_id = payload.household_id;
+  if (payload.member_id) envelope.member_id = payload.member_id;
+  if (typeof payload.duration_ms === "number") envelope.duration_ms = payload.duration_ms;
+
+  return JSON.stringify(envelope);
+}
+
+function emitThroughTauri(payload: UiLogPayload, fallbackLine: string): void {
+  const fallback = () => {
+    console.log(fallbackLine);
+  };
+
+  if (typeof window === "undefined") {
+    fallback();
+    return;
+  }
+
+  const anyWindow = window as typeof window & {
+    __TAURI__?: { invoke?: MaybeInvoker };
+  };
+
+  const directInvoker = anyWindow.__TAURI__?.invoke;
+  if (typeof directInvoker === "function") {
+    void directInvoker.call(anyWindow.__TAURI__, "family_ui_log", payload).catch(fallback);
+    return;
+  }
+
+  void import("@tauri-apps/api/core")
+    .then((mod) => mod.invoke("family_ui_log", payload))
+    .catch(fallback);
+}
+
+export function logUI(level: UiLogLevel, cmd: string, details: UiLogDetails = {}): void {
+  const payload = buildPayload(level, cmd, details);
+  const jsonLine = toJsonLine(payload);
+  emitThroughTauri(payload, jsonLine);
+}

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -1,5 +1,6 @@
 // src/repos.ts
 import { call } from "@lib/ipc/call";
+import { logUI } from "@lib/uiLog";
 import {
   AttachmentInputSchema,
   AttachmentRefSchema,
@@ -120,30 +121,132 @@ export const familyRepo = {
   ...familyMembersRepo,
   attachments: {
     async list(memberId: string): Promise<AttachmentRef[]> {
-      const response = await call("member_attachments_list", { memberId });
-      return AttachmentRefSchema.array().parse(response);
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.attachments.list.start", { member_id: memberId });
+      try {
+        const response = await call("member_attachments_list", { memberId });
+        const parsed = AttachmentRefSchema.array().parse(response);
+        logUI("INFO", "ui.family.attachments.list.complete", {
+          member_id: memberId,
+          count: parsed.length,
+          duration_ms: Math.round(performance.now() - start),
+        });
+        return parsed;
+      } catch (error) {
+        logUI("ERROR", "ui.family.attachments.list.error", {
+          member_id: memberId,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
     async add(input: AttachmentInput): Promise<AttachmentRef> {
       const payload = AttachmentInputSchema.parse(input);
-      const response = await call("member_attachments_add", payload);
-      return AttachmentRefSchema.parse(response);
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.attachments.add.start", {
+        member_id: payload.member_id,
+        household_id: payload.household_id,
+      });
+      try {
+        const response = await call("member_attachments_add", payload);
+        const parsed = AttachmentRefSchema.parse(response);
+        logUI("INFO", "ui.family.attachments.add.complete", {
+          member_id: payload.member_id,
+          attachment_id: parsed.id,
+          duration_ms: Math.round(performance.now() - start),
+        });
+        return parsed;
+      } catch (error) {
+        logUI("ERROR", "ui.family.attachments.add.error", {
+          member_id: payload.member_id,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
     async remove(id: string): Promise<void> {
-      await call("member_attachments_remove", { id });
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.attachments.remove.start", { attachment_id: id });
+      try {
+        await call("member_attachments_remove", { id });
+        logUI("INFO", "ui.family.attachments.remove.complete", {
+          attachment_id: id,
+          duration_ms: Math.round(performance.now() - start),
+        });
+      } catch (error) {
+        logUI("ERROR", "ui.family.attachments.remove.error", {
+          attachment_id: id,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
   },
   renewals: {
     async list(memberId?: string, householdId?: string): Promise<Renewal[]> {
-      const response = await call("member_renewals_list", { memberId, householdId });
-      return RenewalSchema.array().parse(response);
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.renewals.list.start", { member_id: memberId, household_id: householdId });
+      try {
+        const response = await call("member_renewals_list", { memberId, householdId });
+        const parsed = RenewalSchema.array().parse(response);
+        logUI("INFO", "ui.family.renewals.list.complete", {
+          member_id: memberId,
+          household_id: householdId,
+          count: parsed.length,
+          duration_ms: Math.round(performance.now() - start),
+        });
+        return parsed;
+      } catch (error) {
+        logUI("ERROR", "ui.family.renewals.list.error", {
+          member_id: memberId,
+          household_id: householdId,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
     async upsert(input: RenewalInput): Promise<Renewal> {
       const payload = RenewalInputSchema.parse(input);
-      const response = await call("member_renewals_upsert", payload);
-      return RenewalSchema.parse(response);
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.renewals.upsert.start", {
+        member_id: payload.member_id,
+        household_id: payload.household_id,
+      });
+      try {
+        const response = await call("member_renewals_upsert", payload);
+        const parsed = RenewalSchema.parse(response);
+        logUI("INFO", "ui.family.renewals.upsert.complete", {
+          member_id: payload.member_id,
+          household_id: payload.household_id,
+          renewal_id: parsed.id,
+          duration_ms: Math.round(performance.now() - start),
+        });
+        return parsed;
+      } catch (error) {
+        logUI("ERROR", "ui.family.renewals.upsert.error", {
+          member_id: payload.member_id,
+          household_id: payload.household_id,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
     async delete(id: string): Promise<void> {
-      await call("member_renewals_delete", { id });
+      const start = performance.now();
+      logUI("DEBUG", "ui.family.renewals.delete.start", { renewal_id: id });
+      try {
+        await call("member_renewals_delete", { id });
+        logUI("INFO", "ui.family.renewals.delete.complete", {
+          renewal_id: id,
+          duration_ms: Math.round(performance.now() - start),
+        });
+      } catch (error) {
+        logUI("ERROR", "ui.family.renewals.delete.error", {
+          renewal_id: id,
+          message: (error as Error)?.message ?? String(error),
+        });
+        throw error;
+      }
     },
   },
   notes: {

--- a/tests/family-logging.test.ts
+++ b/tests/family-logging.test.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+
+import { FamilyView } from '../src/FamilyView.ts';
+import { familyRepo } from '../src/repos.ts';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost',
+});
+
+dom.window.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+  dom.window.setTimeout(() => callback(performance.now()), 0)) as typeof dom.window.requestAnimationFrame;
+
+(globalThis as any).window = dom.window as typeof globalThis & Window;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).HTMLInputElement = dom.window.HTMLInputElement;
+(globalThis as any).HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+(globalThis as any).HTMLButtonElement = dom.window.HTMLButtonElement;
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test('FamilyView emits a single drawer save log per attempt', async () => {
+  const originalList = familyRepo.list;
+  const originalUpdate = familyRepo.update;
+
+  familyRepo.list = async () => [
+    {
+      id: 'mem-1',
+      name: 'Member One',
+      household_id: 'hh-1',
+      created_at: 0,
+      updated_at: 0,
+      position: 0,
+      birthday: null,
+      notes: 'note',
+    } as any,
+  ];
+
+  let updateCalls = 0;
+  familyRepo.update = async () => {
+    updateCalls += 1;
+  };
+
+  const events: Array<{ level: string; cmd: string; details: Record<string, unknown> }> = [];
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  await FamilyView(container, {
+    getHouseholdId: async () => 'hh-1',
+    log: (level, cmd, details) => {
+      events.push({ level, cmd, details });
+    },
+  });
+
+  await flush();
+
+  const memberButton = container.querySelector<HTMLButtonElement>('button[data-id]');
+  assert.ok(memberButton, 'member button present');
+  memberButton!.click();
+  await flush();
+
+  const backButton = container.querySelector<HTMLButtonElement>('#family-back');
+  assert.ok(backButton, 'back button present');
+  backButton!.click();
+  await flush();
+
+  assert.equal(updateCalls, 1, 'update called exactly once');
+  const drawerLogs = events.filter((entry) => entry.cmd === 'ui.family.drawer.save');
+  assert.equal(drawerLogs.length, 1, `expected one drawer save log, saw ${drawerLogs.length}`);
+  const startLogs = events.filter((entry) => entry.cmd === 'ui.family.drawer.save.start');
+  assert.equal(startLogs.length, 1, 'expected one drawer save start log');
+
+  document.body.removeChild(container);
+  familyRepo.list = originalList;
+  familyRepo.update = originalUpdate;
+});


### PR DESCRIPTION
## Summary
- route renderer `logUI` through a new `family_ui_log` Tauri command so Family UI events land in the tracing sinks instead of console-only output
- extend the Family logging helper and tests to cover read-path INFO/DEBUG pairs plus `DB_UNHEALTHY` WARNs, and update docs/README to describe the sink wiring
- refresh the logging documentation to note the renderer command path and fix README links pointing to the new guide

## Testing
- node --import ./scripts/test-preload.mjs --test tests/family-logging.test.ts
- cargo test --manifest-path src-tauri/Cargo.toml family_logging -- --nocapture *(fails: missing glib-2.0 system library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e738b57e08832a81b06e2bf3cc3f4a