### PR TITLE
Route family banner into shared page host

### DIFF
--- a/docs/family/pr5-family-shell-header-banner.md
+++ b/docs/family/pr5-family-shell-header-banner.md
@@ -1,0 +1,29 @@
+# Family PR5 – Shell, Header, and Birthday Banner
+
+## Overview
+PR5 adds the `FamilyShell` composition layer to the Family view. The shell wraps the future list/drawer/modal content and mounts two new widgets that present immediate household context while reusing the data orchestration delivered in earlier milestones.
+
+## Delivered widgets
+- **FamilyHeader**: Displays the household name from `familyStore.meta.householdName`, the number of active members, the next upcoming birthday, and an “Add member” button that will hook into the PR8 modal flow.
+- **BannerBirthdays**: Lists up to three birthdays occurring within the next 60 days, ordered by soonest date and then alphabetically. Provides accessible copy such as “Birthday in 12 days.” Shows an empty state when no birthdays meet the window.
+
+## Layout and responsiveness
+- The Family route mounts `FamilyShell`, which reserves the top grid rows for the header and banner.
+- Above a 960 px breakpoint, the banner occupies the right-hand column beside the header; below that width, it stacks underneath.
+- Both widgets subscribe to store updates and recalculate whenever the member list changes.
+
+## Data and computation
+- `familyStore` remains the sole data source. No additional IPC endpoints are introduced in PR5.
+- Birthday filtering and sorting are handled by a pure helper, `getUpcomingBirthdays(members, days = 60)`, covering leap-year edges and enforcing the three-entry cap.
+
+## Feature flagging
+- The entire shell is guarded by the `ENABLE_FAMILY_EXPANSION` flag so release managers can ship the code path ahead of full enablement.
+
+## Testing expectations
+- Unit tests cover the birthday utility for ordering, leap-year handling, and the limit of three results.
+- Snapshot coverage ensures the header and banner render correctly at desktop and narrow breakpoints, plus the empty state.
+
+## Acceptance criteria
+- Header renders household name, member count, and next birthday.
+- Banner lists up to three birthdays in the next 60 days, otherwise shows the empty card.
+- Disabling the feature flag hides the shell and falls back to the legacy Family list.

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -1,0 +1,13 @@
+const envRecord =
+  (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {};
+
+function readBoolean(key: string, fallback: boolean): boolean {
+  const value = envRecord[key];
+  if (typeof value === "string") {
+    if (value === "1" || value.toLowerCase() === "true") return true;
+    if (value === "0" || value.toLowerCase() === "false") return false;
+  }
+  return fallback;
+}
+
+export const ENABLE_FAMILY_EXPANSION = readBoolean("VITE_ENABLE_FAMILY_EXPANSION", true);

--- a/src/features/family/BannerBirthdays.ts
+++ b/src/features/family/BannerBirthdays.ts
@@ -1,0 +1,120 @@
+import { logUI } from "@lib/uiLog";
+import type { UpcomingBirthdayEntry } from "./family.utils";
+import { UPCOMING_BIRTHDAY_WINDOW_DAYS } from "./family.utils";
+
+export interface BannerBirthdaysInstance {
+  element: HTMLElement;
+  update(entries: UpcomingBirthdayEntry[], meta?: BannerUpdateMeta): void;
+  destroy(): void;
+}
+
+export interface BannerUpdateMeta {
+  totalMembers: number;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+
+function describeEntry(entry: UpcomingBirthdayEntry): string {
+  const name = entry.member.nickname?.trim() || entry.member.name?.trim() || "Unknown";
+  if (entry.daysUntil === 0) {
+    return `${name} has a birthday today (${dateFormatter.format(entry.occursOn)})`;
+  }
+  const dayLabel = entry.daysUntil === 1 ? "day" : "days";
+  return `${name} has a birthday in ${entry.daysUntil} ${dayLabel} (${dateFormatter.format(entry.occursOn)})`;
+}
+
+export function createBannerBirthdays(host: HTMLElement): BannerBirthdaysInstance {
+  const container = document.createElement("section");
+  container.className = "family-banner";
+  container.dataset.widget = "family-birthdays";
+  container.setAttribute("aria-live", "polite");
+  container.setAttribute("aria-label", "Upcoming birthdays");
+
+  const heading = document.createElement("h2");
+  heading.className = "family-banner__title";
+  heading.textContent = "Upcoming birthdays";
+
+  const list = document.createElement("ul");
+  list.className = "family-banner__list";
+
+  const emptyState = document.createElement("div");
+  emptyState.className = "family-banner__empty";
+  emptyState.textContent = `No birthdays in the next ${UPCOMING_BIRTHDAY_WINDOW_DAYS} days`;
+
+  container.append(heading, list, emptyState);
+  host.innerHTML = "";
+  host.appendChild(container);
+
+  logUI("INFO", "ui.family.banner.mounted", {});
+
+  let mounted = false;
+
+  const renderEntries = (entries: UpcomingBirthdayEntry[]) => {
+    list.innerHTML = "";
+    if (entries.length === 0) {
+      emptyState.hidden = false;
+      return;
+    }
+    emptyState.hidden = true;
+    for (const entry of entries) {
+      const item = document.createElement("li");
+      item.className = "family-banner__item";
+
+      const card = document.createElement("article");
+      card.className = "family-banner__card";
+      card.setAttribute("aria-label", describeEntry(entry));
+
+      const icon = document.createElement("span");
+      icon.className = "family-banner__icon";
+      icon.setAttribute("aria-hidden", "true");
+      icon.textContent = "🎂";
+
+      const name = document.createElement("h3");
+      name.className = "family-banner__name";
+      name.textContent = entry.member.nickname?.trim() || entry.member.name?.trim() || "Unknown";
+
+      const detail = document.createElement("p");
+      detail.className = "family-banner__detail";
+      if (entry.daysUntil === 0) {
+        detail.textContent = "Birthday is today";
+      } else {
+        const dayLabel = entry.daysUntil === 1 ? "day" : "days";
+        detail.textContent = `Birthday in ${entry.daysUntil} ${dayLabel}`;
+      }
+
+      const subtext = document.createElement("p");
+      subtext.className = "family-banner__date";
+      subtext.textContent = dateFormatter.format(entry.occursOn);
+
+      card.append(icon, name, detail, subtext);
+      item.appendChild(card);
+      list.appendChild(item);
+    }
+
+    if (!mounted) {
+      requestAnimationFrame(() => {
+        container.classList.add("family-banner--visible");
+        mounted = true;
+      });
+    }
+  };
+
+  renderEntries([]);
+
+  return {
+    element: container,
+    update(entries: UpcomingBirthdayEntry[], meta?: BannerUpdateMeta) {
+      renderEntries(entries);
+      logUI("INFO", "ui.family.banner.updated", {
+        members: meta?.totalMembers ?? null,
+        upcoming_count: entries.length,
+      });
+    },
+    destroy() {
+      container.remove();
+    },
+  };
+}

--- a/src/features/family/FamilyHeader.ts
+++ b/src/features/family/FamilyHeader.ts
@@ -1,0 +1,102 @@
+import { logUI } from "@lib/uiLog";
+import type { UpcomingBirthdayEntry } from "./family.utils";
+
+export interface FamilyHeaderState {
+  householdName: string | null;
+  memberCount: number;
+  nextBirthday: UpcomingBirthdayEntry | null;
+}
+
+export interface FamilyHeaderInstance {
+  element: HTMLElement;
+  update(state: Partial<FamilyHeaderState>): void;
+  destroy(): void;
+}
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "long",
+  day: "numeric",
+});
+
+function formatMemberCount(count: number): string {
+  if (!Number.isFinite(count) || count < 0) return "0 Members";
+  return count === 1 ? "1 Member" : `${count} Members`;
+}
+
+function formatNextBirthday(entry: UpcomingBirthdayEntry | null): string {
+  if (!entry) return "Next Birthday: —";
+  const displayName = entry.member.nickname?.trim() || entry.member.name?.trim() || "Unknown";
+  const formattedDate = dateFormatter.format(entry.occursOn);
+  return `Next Birthday: ${displayName} – ${formattedDate}`;
+}
+
+export function createFamilyHeader(host: HTMLElement): FamilyHeaderInstance {
+  const element = document.createElement("header");
+  element.className = "family-header";
+  element.dataset.widget = "family-header";
+
+  const textBlock = document.createElement("div");
+  textBlock.className = "family-header__text";
+
+  const title = document.createElement("h1");
+  title.className = "family-header__title";
+  title.textContent = "Family";
+
+  const metaList = document.createElement("div");
+  metaList.className = "family-header__meta";
+
+  const memberCountEl = document.createElement("span");
+  memberCountEl.className = "family-header__members";
+
+  const nextBirthdayEl = document.createElement("span");
+  nextBirthdayEl.className = "family-header__next";
+
+  metaList.append(memberCountEl, nextBirthdayEl);
+  textBlock.append(title, metaList);
+
+  const addButton = document.createElement("button");
+  addButton.type = "button";
+  addButton.className = "family-header__cta";
+  addButton.textContent = "Add member";
+  addButton.setAttribute("aria-label", "Add a family member");
+
+  const handleAddMember = () => {
+    logUI("INFO", "ui.family.add_member.cta", { source: "header" });
+    // Stubbed modal hook for PR8.
+    console.info("FamilyShell:AddMember", { source: "header" });
+  };
+
+  addButton.addEventListener("click", handleAddMember);
+
+  element.append(textBlock, addButton);
+  host.innerHTML = "";
+  host.appendChild(element);
+
+  logUI("INFO", "ui.family.header.mounted", {});
+
+  let state: FamilyHeaderState = {
+    householdName: null,
+    memberCount: 0,
+    nextBirthday: null,
+  };
+
+  const apply = () => {
+    title.textContent = state.householdName?.trim() || "Family";
+    memberCountEl.textContent = formatMemberCount(state.memberCount);
+    nextBirthdayEl.textContent = formatNextBirthday(state.nextBirthday);
+  };
+
+  apply();
+
+  return {
+    element,
+    update(partial: Partial<FamilyHeaderState>) {
+      state = { ...state, ...partial };
+      apply();
+    },
+    destroy() {
+      addButton.removeEventListener("click", handleAddMember);
+      element.remove();
+    },
+  };
+}

--- a/src/features/family/FamilyShell.ts
+++ b/src/features/family/FamilyShell.ts
@@ -1,0 +1,77 @@
+import {
+  createBannerBirthdays,
+  type BannerBirthdaysInstance,
+} from "./BannerBirthdays";
+import { createFamilyHeader, type FamilyHeaderInstance } from "./FamilyHeader";
+
+export interface FamilyShellInstance {
+  element: HTMLElement;
+  header: FamilyHeaderInstance;
+  banner: BannerBirthdaysInstance;
+  contentHost: HTMLElement;
+  destroy(): void;
+}
+
+export function createFamilyShell(container: HTMLElement): FamilyShellInstance {
+  const shell = document.createElement("section");
+  shell.className = "family-shell";
+  shell.dataset.widget = "family-shell";
+
+  const headerSlot = document.createElement("div");
+  headerSlot.className = "family-shell__header";
+
+  const contentSlot = document.createElement("div");
+  contentSlot.className = "family-shell__content";
+  contentSlot.setAttribute("role", "region");
+  contentSlot.setAttribute("aria-label", "Family members");
+
+  const bannerHost =
+    typeof document !== "undefined"
+      ? (document.getElementById("page-banner") as HTMLElement | null)
+      : null;
+
+  if (bannerHost) {
+    bannerHost.hidden = false;
+    bannerHost.setAttribute("aria-hidden", "false");
+    bannerHost.dataset.bannerMode = "interactive";
+    bannerHost.style.removeProperty("background-image");
+    bannerHost.style.removeProperty("--banner-pos-x");
+    bannerHost.style.removeProperty("--banner-pos-y");
+  }
+
+  let inlineBannerSlot: HTMLElement | null = null;
+  if (!bannerHost) {
+    inlineBannerSlot = document.createElement("div");
+    inlineBannerSlot.className = "family-shell__banner";
+    shell.classList.add("family-shell--inline-banner");
+  }
+
+  shell.append(headerSlot);
+  if (inlineBannerSlot) {
+    shell.append(inlineBannerSlot);
+  }
+  shell.append(contentSlot);
+  container.innerHTML = "";
+  container.appendChild(shell);
+
+  const header = createFamilyHeader(headerSlot);
+  const banner = createBannerBirthdays(bannerHost ?? inlineBannerSlot ?? contentSlot);
+
+  return {
+    element: shell,
+    header,
+    banner,
+    contentHost: contentSlot,
+    destroy() {
+      header.destroy();
+      banner.destroy();
+      if (bannerHost && bannerHost.dataset.bannerMode === "interactive") {
+        bannerHost.removeAttribute("data-banner-mode");
+        if (!bannerHost.hasAttribute("role")) {
+          bannerHost.setAttribute("role", "img");
+        }
+      }
+      shell.remove();
+    },
+  };
+}

--- a/src/features/family/__tests__/family.utils.test.ts
+++ b/src/features/family/__tests__/family.utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { FamilyMember } from "../family.types";
+import {
+  getNextBirthday,
+  getUpcomingBirthdays,
+  UPCOMING_BIRTHDAY_WINDOW_DAYS,
+} from "../family.utils";
+
+function createMember(
+  id: string,
+  birthdayUtc: number | null,
+  overrides: Partial<FamilyMember> = {},
+): FamilyMember {
+  return {
+    id,
+    householdId: "hh-1",
+    name: `Member ${id}`,
+    birthday: birthdayUtc,
+    notes: null,
+    address: null,
+    email: null,
+    phone: {},
+    ...overrides,
+  } as FamilyMember;
+}
+
+describe("getUpcomingBirthdays", () => {
+  it("returns up to three members within the window sorted by date then name", () => {
+    const reference = new Date(Date.UTC(2024, 3, 1));
+    const members: FamilyMember[] = [
+      createMember("a", Date.UTC(1990, 4, 10), { nickname: "Zoey" }),
+      createMember("b", Date.UTC(1988, 4, 1), { nickname: "Alex" }),
+      createMember("c", Date.UTC(1985, 3, 30), { nickname: "Chris" }),
+      createMember("d", Date.UTC(1992, 4, 1), { nickname: "Bea" }),
+      createMember("e", Date.UTC(1991, 9, 12)),
+    ];
+
+    const upcoming = getUpcomingBirthdays(
+      members,
+      UPCOMING_BIRTHDAY_WINDOW_DAYS,
+      reference,
+    );
+
+    expect(upcoming).toHaveLength(3);
+    expect(upcoming.map((entry) => entry.member.id)).toEqual(["c", "b", "d"]);
+    expect(upcoming[0].daysUntil).toBe(29);
+    expect(upcoming[1].daysUntil).toBe(30);
+  });
+
+  it("excludes members outside the window", () => {
+    const reference = new Date(Date.UTC(2024, 0, 1));
+    const members = [
+      createMember("soon", Date.UTC(1980, 0, 2)),
+      createMember("later", Date.UTC(1980, 3, 1)),
+    ];
+
+    const upcoming = getUpcomingBirthdays(members, 30, reference);
+    expect(upcoming).toHaveLength(1);
+    expect(upcoming[0].member.id).toBe("soon");
+  });
+
+  it("adjusts leap-day birthdays on non-leap years", () => {
+    const reference = new Date(Date.UTC(2025, 0, 15));
+    const members = [createMember("leap", Date.UTC(1992, 1, 29))];
+
+    const upcoming = getUpcomingBirthdays(
+      members,
+      UPCOMING_BIRTHDAY_WINDOW_DAYS,
+      reference,
+    );
+    expect(upcoming).toHaveLength(1);
+    expect(upcoming[0].adjustedForLeapDay).toBe(true);
+    expect(upcoming[0].occursOn.toISOString().slice(0, 10)).toBe("2025-03-01");
+  });
+});
+
+describe("getNextBirthday", () => {
+  it("returns the next chronological birthday even when wrapping to a new year", () => {
+    const reference = new Date(Date.UTC(2024, 10, 20));
+    const members = [
+      createMember("jan", Date.UTC(1980, 0, 5), { nickname: "Ada" }),
+      createMember("dec", Date.UTC(1980, 11, 25), { nickname: "Neil" }),
+    ];
+
+    const next = getNextBirthday(members, reference);
+    expect(next).not.toBeNull();
+    expect(next?.member.id).toBe("dec");
+    expect(next?.daysUntil).toBe(35);
+  });
+
+  it("returns null when no birthdays are available", () => {
+    const reference = new Date(Date.UTC(2024, 0, 1));
+    const members = [createMember("no-bday", null)];
+    expect(getNextBirthday(members, reference)).toBeNull();
+  });
+});

--- a/src/features/family/family.utils.ts
+++ b/src/features/family/family.utils.ts
@@ -1,0 +1,105 @@
+import type { FamilyMember } from "./family.types";
+
+const MS_PER_DAY = 86_400_000;
+
+export const UPCOMING_BIRTHDAY_WINDOW_DAYS = 60;
+
+export interface UpcomingBirthdayEntry {
+  member: FamilyMember;
+  occursOn: Date;
+  daysUntil: number;
+  adjustedForLeapDay: boolean;
+}
+
+function toUtcDate(year: number, month: number, day: number): number {
+  return Date.UTC(year, month, day);
+}
+
+function computeNextOccurrence(
+  member: FamilyMember,
+  referenceDate: Date,
+): UpcomingBirthdayEntry | null {
+  if (!member.birthday) return null;
+  const birthDate = new Date(member.birthday);
+  const month = birthDate.getUTCMonth();
+  const day = birthDate.getUTCDate();
+  const referenceUtc = toUtcDate(
+    referenceDate.getUTCFullYear(),
+    referenceDate.getUTCMonth(),
+    referenceDate.getUTCDate(),
+  );
+
+  let targetYear = referenceDate.getUTCFullYear();
+  let occurrenceUtc = toUtcDate(targetYear, month, day);
+  if (occurrenceUtc < referenceUtc) {
+    targetYear += 1;
+    occurrenceUtc = toUtcDate(targetYear, month, day);
+  }
+
+  const occurrence = new Date(occurrenceUtc);
+  const adjustedForLeapDay = occurrence.getUTCMonth() !== month || occurrence.getUTCDate() !== day;
+  const normalizedOccurrenceUtc = toUtcDate(
+    occurrence.getUTCFullYear(),
+    occurrence.getUTCMonth(),
+    occurrence.getUTCDate(),
+  );
+  const diffDays = Math.max(
+    0,
+    Math.round((normalizedOccurrenceUtc - referenceUtc) / MS_PER_DAY),
+  );
+
+  return {
+    member,
+    occursOn: occurrence,
+    daysUntil: diffDays,
+    adjustedForLeapDay,
+  };
+}
+
+function collectBirthdayEntries(
+  members: FamilyMember[],
+  referenceDate: Date,
+): UpcomingBirthdayEntry[] {
+  const entries: UpcomingBirthdayEntry[] = [];
+  for (const member of members) {
+    const entry = computeNextOccurrence(member, referenceDate);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+  entries.sort((a, b) => {
+    if (a.daysUntil !== b.daysUntil) return a.daysUntil - b.daysUntil;
+    const nameA = (a.member.nickname ?? a.member.name ?? "").toLocaleLowerCase();
+    const nameB = (b.member.nickname ?? b.member.name ?? "").toLocaleLowerCase();
+    if (nameA && nameB) {
+      const comparison = nameA.localeCompare(nameB, undefined, { sensitivity: "base" });
+      if (comparison !== 0) return comparison;
+    }
+    const fallbackA = a.member.nickname ?? a.member.name;
+    const fallbackB = b.member.nickname ?? b.member.name;
+    if (fallbackA && fallbackB) {
+      const comparison = fallbackA.localeCompare(fallbackB, undefined, { sensitivity: "base" });
+      if (comparison !== 0) return comparison;
+    }
+    return a.member.id.localeCompare(b.member.id);
+  });
+  return entries;
+}
+
+export function getUpcomingBirthdays(
+  members: FamilyMember[],
+  windowDays = UPCOMING_BIRTHDAY_WINDOW_DAYS,
+  referenceDate: Date = new Date(),
+): UpcomingBirthdayEntry[] {
+  if (windowDays < 0) return [];
+  const entries = collectBirthdayEntries(members, referenceDate);
+  return entries.filter((entry) => entry.daysUntil <= windowDays).slice(0, 3);
+}
+
+export function getNextBirthday(
+  members: FamilyMember[],
+  referenceDate: Date = new Date(),
+): UpcomingBirthdayEntry | null {
+  const entries = collectBirthdayEntries(members, referenceDate);
+  return entries.length > 0 ? entries[0] : null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { runViewCleanups } from "./utils/viewLifecycle";
 import { initTheme } from "@ui/ThemeToggle";
 import { getStartupWindow } from "@lib/ipc/startup";
 import { ensureDbHealthReport, recheckDbHealth } from "./services/dbHealth";
+import { ENABLE_FAMILY_EXPANSION } from "./config/flags";
 import { recoveryText } from "@strings/recovery";
 import { mountMacToolbar, setAppToolbarTitle } from "@ui/AppToolbar";
 import { initAmbientBackground, type AmbientBackgroundController } from "@ui/AmbientBackground";
@@ -425,6 +426,26 @@ function updatePageBanner(route: RouteDefinition): void {
   const bannerEl = document.getElementById("page-banner") as HTMLDivElement | null;
   if (!bannerEl) return;
   const body = document.body;
+  const isFamilyInteractive = ENABLE_FAMILY_EXPANSION && route.id === "family";
+
+  if (isFamilyInteractive) {
+    bannerEl.hidden = false;
+    bannerEl.style.removeProperty("background-image");
+    bannerEl.style.removeProperty("--banner-pos-x");
+    bannerEl.style.removeProperty("--banner-pos-y");
+    bannerEl.setAttribute("aria-hidden", "false");
+    bannerEl.setAttribute("role", "complementary");
+    bannerEl.removeAttribute("aria-label");
+    bannerEl.dataset.bannerMode = "interactive";
+    body.dataset.bannerVisibility = "visible";
+    return;
+  }
+
+  if (bannerEl.dataset.bannerMode === "interactive") {
+    delete bannerEl.dataset.bannerMode;
+    bannerEl.innerHTML = "";
+    bannerEl.setAttribute("role", "img");
+  }
   const key = route.id.toLowerCase();
   const label = route.display?.label ?? key;
   const url = bannerFor(key);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @use "./styles/manage";
 @use "./ui/styles/logs";
+@use "./styles/family-shell";
 
 :root {
   --radius-sm: 6px;
@@ -122,6 +123,20 @@ main.container {
   background-size: cover;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
   opacity: 0.98;
+}
+
+.page-banner[data-banner-mode="interactive"] {
+  background: none;
+  border-left: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--space-4, 24px);
+}
+
+.page-banner[data-banner-mode="interactive"] > * {
+  width: 100%;
+  max-width: 360px;
 }
 
 body[data-banner-visibility="hidden"] .page-banner,

--- a/src/styles/_family-shell.scss
+++ b/src/styles/_family-shell.scss
@@ -1,0 +1,213 @@
+.family-shell {
+  --family-gap: var(--space-4, 24px);
+  --family-gap-sm: var(--space-3, 16px);
+  --family-radius: var(--radius-lg, 16px);
+  --family-border: color-mix(in srgb, var(--color-border, #CBD5E1) 45%, transparent);
+  --family-shadow: var(
+    --shadow-lg,
+    0 18px 36px rgba(15, 23, 42, 0.1)
+  );
+  display: grid;
+  gap: var(--family-gap);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "header"
+    "content";
+  align-items: start;
+}
+
+.family-shell--inline-banner {
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+  grid-template-areas:
+    "header banner"
+    "content content";
+}
+
+.family-shell__header {
+  grid-area: header;
+}
+
+.family-shell__banner {
+  grid-area: banner;
+}
+
+.family-shell__content {
+  grid-area: content;
+  min-height: 320px;
+}
+
+.family-header {
+  background: var(--color-panel, #fff);
+  border-radius: var(--family-radius);
+  border: 1px solid var(--family-border);
+  box-shadow: var(--family-shadow);
+  padding: clamp(18px, 2vw, 28px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--family-gap-sm);
+}
+
+.family-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.family-header__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw + 0.5rem, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.family-header__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: var(--color-text-muted, #475569);
+}
+
+.family-header__members,
+.family-header__next {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.family-header__members::before {
+  content: "•";
+  color: var(--color-accent, #00C896);
+}
+
+.family-header__next::before {
+  content: "•";
+  color: color-mix(in srgb, var(--color-accent, #00C896) 60%, #2563EB 40%);
+}
+
+.family-header__cta {
+  background: var(--color-accent, #00C896);
+  color: var(--color-accent-text, #fff);
+  border: none;
+  border-radius: var(--radius-pill, 9999px);
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  box-shadow: 0 10px 20px rgba(0, 200, 150, 0.2);
+}
+
+.family-header__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(0, 200, 150, 0.25);
+}
+
+.family-header__cta:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-accent, #00C896) 60%, #ffffff 40%);
+  outline-offset: 3px;
+}
+
+.family-banner {
+  background: var(--color-panel, #fff);
+  border-radius: var(--family-radius);
+  border: 1px solid var(--family-border);
+  box-shadow: var(--family-shadow);
+  padding: clamp(18px, 2vw, 26px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--family-gap-sm);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.family-banner--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.family-banner__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.family-banner__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.family-banner__item {
+  margin: 0;
+  padding: 0;
+}
+
+.family-banner__card {
+  background: color-mix(in srgb, var(--color-accent-soft, #E6FFFA) 70%, #ffffff 30%);
+  border-radius: calc(var(--family-radius) - 4px);
+  padding: 16px 18px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  row-gap: 4px;
+  border-left: 4px solid var(--color-accent, #00C896);
+}
+
+.family-banner__icon {
+  font-size: 1.5rem;
+  line-height: 1;
+  grid-row: span 2;
+  align-self: center;
+}
+
+.family-banner__name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.family-banner__detail {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text, #0F172A);
+}
+
+.family-banner__date {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #475569);
+}
+
+.family-banner__empty {
+  margin-top: 4px;
+  font-size: 0.95rem;
+  color: var(--color-text-muted, #475569);
+}
+
+@media (max-width: 959px) {
+  .family-shell--inline-banner {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "header"
+      "banner"
+      "content";
+  }
+
+  .family-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .family-header__cta {
+    width: 100%;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- mount the Family upcoming-birthdays widget into the shared #page-banner host and toggle the layout via the feature flag
- update the Family shell/banner styles for the interactive host while keeping an inline fallback for environments without the global banner
- emit banner update metrics and centralise the 60-day window constant with refreshed unit coverage

## Testing
- npx vitest run src/features/family/__tests__/family.utils.test.ts
- npm run typecheck # fails due to existing issues in unrelated modules


------
https://chatgpt.com/codex/tasks/task_e_68e77eb1dbac832a852977ba4efa6214