### PR TITLE
Family PR7 — Member Detail Drawer (Personal, Finance, Audit)

### DIFF
--- a/src/features/family/FamilyDrawer/DrawerTabs.ts
+++ b/src/features/family/FamilyDrawer/DrawerTabs.ts
@@ -1,0 +1,129 @@
+export type FamilyDrawerTabId = "personal" | "finance" | "audit";
+
+export interface DrawerTabDefinition {
+  id: FamilyDrawerTabId;
+  label: string;
+  panel: HTMLElement;
+}
+
+export interface DrawerTabsInstance {
+  element: HTMLElement;
+  panelsHost: HTMLElement;
+  readonly activeId: FamilyDrawerTabId;
+  setActive(id: FamilyDrawerTabId): void;
+  setHasError(id: FamilyDrawerTabId, hasError: boolean): void;
+}
+
+const ERROR_DOT_CLASS = "family-drawer__tab-error";
+
+export function createDrawerTabs(definitions: DrawerTabDefinition[]): DrawerTabsInstance {
+  if (definitions.length === 0) {
+    throw new Error("Family drawer tabs require at least one tab definition.");
+  }
+
+  const element = document.createElement("div");
+  element.className = "family-drawer__tabs";
+
+  const list = document.createElement("div");
+  list.className = "family-drawer__tablist";
+  list.setAttribute("role", "tablist");
+  element.appendChild(list);
+
+  const panelsHost = document.createElement("div");
+  panelsHost.className = "family-drawer__panels";
+  element.appendChild(panelsHost);
+
+  let activeId: FamilyDrawerTabId = definitions[0].id;
+  const buttons = new Map<FamilyDrawerTabId, HTMLButtonElement>();
+
+  const setActive = (id: FamilyDrawerTabId) => {
+    if (activeId === id) return;
+    activeId = id;
+    syncState();
+  };
+
+  const syncState = () => {
+    for (const definition of definitions) {
+      const button = buttons.get(definition.id);
+      const selected = definition.id === activeId;
+      if (button) {
+        button.setAttribute("aria-selected", selected ? "true" : "false");
+        button.tabIndex = selected ? 0 : -1;
+      }
+      definition.panel.hidden = !selected;
+    }
+  };
+
+  const focusButton = (id: FamilyDrawerTabId) => {
+    const button = buttons.get(id);
+    if (button) {
+      button.focus();
+    }
+  };
+
+  for (const definition of definitions) {
+    if (!definition.panel.id) {
+      definition.panel.id = `family-drawer-panel-${definition.id}`;
+    }
+    definition.panel.setAttribute("role", "tabpanel");
+    definition.panel.setAttribute("aria-labelledby", `family-drawer-tab-${definition.id}`);
+    panelsHost.appendChild(definition.panel);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.id = `family-drawer-tab-${definition.id}`;
+    button.className = "family-drawer__tab";
+    button.textContent = definition.label;
+    button.dataset.tabId = definition.id;
+    button.setAttribute("role", "tab");
+    button.setAttribute("aria-controls", definition.panel.id);
+    button.setAttribute("aria-selected", definition.id === activeId ? "true" : "false");
+    button.tabIndex = definition.id === activeId ? 0 : -1;
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      setActive(definition.id);
+    });
+    button.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        event.preventDefault();
+        const currentIndex = definitions.findIndex((item) => item.id === definition.id);
+        const next = definitions[(currentIndex + 1) % definitions.length];
+        setActive(next.id);
+        focusButton(next.id);
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const currentIndex = definitions.findIndex((item) => item.id === definition.id);
+        const prev = definitions[(currentIndex - 1 + definitions.length) % definitions.length];
+        setActive(prev.id);
+        focusButton(prev.id);
+      }
+    });
+    list.appendChild(button);
+    buttons.set(definition.id, button);
+  }
+
+  syncState();
+
+  const setHasError = (id: FamilyDrawerTabId, hasError: boolean) => {
+    const button = buttons.get(id);
+    if (!button) return;
+    button.toggleAttribute("data-tab-error", hasError);
+    button.classList.toggle(ERROR_DOT_CLASS, hasError);
+  };
+
+  return {
+    element,
+    panelsHost,
+    get activeId() {
+      return activeId;
+    },
+    setActive(id) {
+      if (activeId === id) return;
+      activeId = id;
+      syncState();
+      focusButton(id);
+    },
+    setHasError,
+  };
+}

--- a/src/features/family/FamilyDrawer/TabAudit.ts
+++ b/src/features/family/FamilyDrawer/TabAudit.ts
@@ -1,0 +1,114 @@
+export interface AuditData {
+  createdAt: number | null;
+  updatedAt: number | null;
+  lastVerified: number | null;
+  verifiedBy: string | null;
+}
+
+export interface TabAuditInstance {
+  element: HTMLElement;
+  setData(data: AuditData): void;
+  getData(): AuditData;
+  setMarkVerifiedHandler(handler: (() => Promise<void> | void) | null): void;
+  applyVerification(patch: { lastVerified: number; verifiedBy: string }): void;
+}
+
+function formatDate(value: number | null): string {
+  if (value === null || value === undefined) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function createAuditTab(): TabAuditInstance {
+  const element = document.createElement("div");
+  element.className = "family-drawer__panel";
+  element.id = "family-drawer-panel-audit";
+
+  const list = document.createElement("dl");
+  list.className = "family-drawer__audit-list";
+  element.appendChild(list);
+
+  const createRow = (label: string, id: string) => {
+    const dt = document.createElement("dt");
+    dt.className = "family-drawer__audit-term";
+    dt.textContent = label;
+    dt.id = id;
+    const dd = document.createElement("dd");
+    dd.className = "family-drawer__audit-value";
+    dd.setAttribute("aria-labelledby", id);
+    list.append(dt, dd);
+    return dd;
+  };
+
+  const createdValue = createRow("Created", "family-drawer-audit-created");
+  const updatedValue = createRow("Last updated", "family-drawer-audit-updated");
+  const verifiedValue = createRow("Last verified", "family-drawer-audit-verified");
+  const verifiedByValue = createRow("Verified by", "family-drawer-audit-verified-by");
+
+  const controls = document.createElement("div");
+  controls.className = "family-drawer__audit-actions";
+  element.appendChild(controls);
+
+  const markButton = document.createElement("button");
+  markButton.type = "button";
+  markButton.className = "family-drawer__primary";
+  markButton.textContent = "Mark verified";
+  markButton.setAttribute("aria-label", "Mark member as verified");
+  controls.appendChild(markButton);
+
+  let currentData: AuditData = { createdAt: null, updatedAt: null, lastVerified: null, verifiedBy: null };
+  let handler: (() => Promise<void> | void) | null = null;
+  let busy = false;
+
+  const setBusy = (value: boolean) => {
+    busy = value;
+    markButton.disabled = !handler || busy;
+  };
+
+  const render = () => {
+    createdValue.textContent = formatDate(currentData.createdAt);
+    updatedValue.textContent = formatDate(currentData.updatedAt);
+    verifiedValue.textContent = currentData.lastVerified ? formatDate(currentData.lastVerified) : "Never";
+    verifiedByValue.textContent = currentData.verifiedBy && currentData.verifiedBy.length > 0 ? currentData.verifiedBy : "—";
+  };
+
+  markButton.addEventListener("click", async (event) => {
+    event.preventDefault();
+    if (!handler || busy) return;
+    setBusy(true);
+    try {
+      await handler();
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  render();
+
+  return {
+    element,
+    setData(data) {
+      currentData = { ...data };
+      render();
+    },
+    getData() {
+      return { ...currentData };
+    },
+    setMarkVerifiedHandler(next) {
+      handler = next;
+      setBusy(false);
+    },
+    applyVerification(patch) {
+      currentData.lastVerified = patch.lastVerified;
+      currentData.verifiedBy = patch.verifiedBy;
+      render();
+    },
+  };
+}

--- a/src/features/family/FamilyDrawer/TabFinance.ts
+++ b/src/features/family/FamilyDrawer/TabFinance.ts
@@ -1,0 +1,181 @@
+import { canParseJson, collectNumericFieldErrors, parseJsonOrNull, stringifyJson } from "./validators";
+
+export interface FinanceFormData {
+  bankAccounts: unknown | null;
+  pensionDetails: unknown | null;
+  insuranceRefs: string;
+}
+
+export interface FinanceTabValue {
+  bankAccountsRaw: string;
+  pensionDetailsRaw: string;
+  insuranceRefs: string;
+}
+
+export interface FinanceValidationResult {
+  valid: boolean;
+  focus?: () => void;
+  bankAccounts?: unknown | null;
+  pensionDetails?: unknown | null;
+}
+
+export interface TabFinanceInstance {
+  element: HTMLElement;
+  getData(): FinanceTabValue;
+  setData(data: FinanceFormData): void;
+  validate(): FinanceValidationResult;
+}
+
+function createTextarea(labelText: string, id: string): {
+  wrapper: HTMLDivElement;
+  textarea: HTMLTextAreaElement;
+  error: HTMLDivElement;
+} {
+  const wrapper = document.createElement("div");
+  wrapper.className = "family-drawer__field";
+
+  const label = document.createElement("label");
+  label.className = "family-drawer__label";
+  label.textContent = labelText;
+  label.htmlFor = id;
+  wrapper.appendChild(label);
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "family-drawer__textarea";
+  textarea.id = id;
+  textarea.rows = 6;
+  wrapper.appendChild(textarea);
+
+  const error = document.createElement("div");
+  error.className = "family-drawer__error";
+  error.id = `${id}-error`;
+  error.hidden = true;
+  wrapper.appendChild(error);
+
+  textarea.setAttribute("aria-describedby", error.id);
+
+  return { wrapper, textarea, error };
+}
+
+function setError(entry: { wrapper: HTMLElement; error: HTMLElement; textarea?: HTMLTextAreaElement }, message: string | null) {
+  if (message) {
+    entry.error.textContent = message;
+    entry.error.hidden = false;
+    entry.wrapper.setAttribute("data-invalid", "true");
+    entry.textarea?.setAttribute("aria-invalid", "true");
+  } else {
+    entry.error.textContent = "";
+    entry.error.hidden = true;
+    entry.wrapper.removeAttribute("data-invalid");
+    entry.textarea?.removeAttribute("aria-invalid");
+  }
+}
+
+export function createFinanceTab(): TabFinanceInstance {
+  const element = document.createElement("div");
+  element.className = "family-drawer__panel";
+  element.id = "family-drawer-panel-finance";
+
+  const bankField = createTextarea("Bank accounts (JSON)", "family-drawer-bank");
+  element.appendChild(bankField.wrapper);
+
+  const pensionField = createTextarea("Pension details (JSON)", "family-drawer-pension");
+  element.appendChild(pensionField.wrapper);
+
+  const insuranceFieldWrapper = document.createElement("div");
+  insuranceFieldWrapper.className = "family-drawer__field";
+  const insuranceLabel = document.createElement("label");
+  insuranceLabel.className = "family-drawer__label";
+  insuranceLabel.textContent = "Insurance references";
+  insuranceLabel.htmlFor = "family-drawer-insurance";
+  insuranceFieldWrapper.appendChild(insuranceLabel);
+
+  const insuranceInput = document.createElement("input");
+  insuranceInput.className = "family-drawer__input";
+  insuranceInput.id = "family-drawer-insurance";
+  insuranceFieldWrapper.appendChild(insuranceInput);
+
+  const insuranceError = document.createElement("div");
+  insuranceError.className = "family-drawer__error";
+  insuranceError.id = "family-drawer-insurance-error";
+  insuranceError.hidden = true;
+  insuranceFieldWrapper.appendChild(insuranceError);
+
+  insuranceInput.setAttribute("aria-describedby", insuranceError.id);
+
+  element.appendChild(insuranceFieldWrapper);
+
+  const getData = (): FinanceTabValue => ({
+    bankAccountsRaw: bankField.textarea.value,
+    pensionDetailsRaw: pensionField.textarea.value,
+    insuranceRefs: insuranceInput.value.trim(),
+  });
+
+  const setData = (data: FinanceFormData) => {
+    bankField.textarea.value = stringifyJson(data.bankAccounts);
+    pensionField.textarea.value = stringifyJson(data.pensionDetails);
+    insuranceInput.value = data.insuranceRefs ?? "";
+    setError(bankField, null);
+    setError(pensionField, null);
+    setError({ wrapper: insuranceFieldWrapper, error: insuranceError }, null);
+  };
+
+  const validate = (): FinanceValidationResult => {
+    const { bankAccountsRaw, pensionDetailsRaw } = getData();
+    let parsedBank: unknown | null = null;
+    let parsedPension: unknown | null = null;
+    let firstInvalid: (() => void) | undefined;
+
+    const ensureFirst = (focus: () => void) => {
+      if (!firstInvalid) firstInvalid = focus;
+    };
+
+    if (!canParseJson(bankAccountsRaw)) {
+      setError(bankField, "Enter valid JSON for bank accounts.");
+      ensureFirst(() => bankField.textarea.focus());
+    } else {
+      setError(bankField, null);
+      try {
+        parsedBank = parseJsonOrNull(bankAccountsRaw);
+      } catch {
+        parsedBank = null;
+      }
+      if (parsedBank) {
+        const numericErrors = collectNumericFieldErrors(parsedBank);
+        if (numericErrors.length > 0) {
+          setError(bankField, numericErrors[0]);
+          ensureFirst(() => bankField.textarea.focus());
+          parsedBank = null;
+        }
+      }
+    }
+
+    if (!canParseJson(pensionDetailsRaw)) {
+      setError(pensionField, "Enter valid JSON for pension details.");
+      ensureFirst(() => pensionField.textarea.focus());
+    } else {
+      setError(pensionField, null);
+      try {
+        parsedPension = parseJsonOrNull(pensionDetailsRaw);
+      } catch {
+        parsedPension = null;
+      }
+    }
+
+    setError({ wrapper: insuranceFieldWrapper, error: insuranceError }, null);
+
+    return {
+      valid: !firstInvalid,
+      focus: firstInvalid,
+      bankAccounts: parsedBank,
+      pensionDetails: parsedPension,
+    };
+  };
+
+  return {
+    element,
+    getData,
+    setData,
+    validate,
+  };
+}

--- a/src/features/family/FamilyDrawer/TabPersonal.ts
+++ b/src/features/family/FamilyDrawer/TabPersonal.ts
@@ -1,0 +1,453 @@
+import { isValidEmail, isValidPhone, isValidUrl } from "./validators";
+
+export interface SocialLinkRow {
+  key: string;
+  value: string;
+}
+
+export interface PersonalFormData {
+  nickname: string;
+  fullName: string;
+  relationship: string;
+  address: string;
+  emails: string[];
+  phoneMobile: string;
+  phoneHome: string;
+  phoneWork: string;
+  website: string;
+  socialLinks: SocialLinkRow[];
+}
+
+export interface PersonalValidationResult {
+  valid: boolean;
+  focus?: () => void;
+}
+
+export interface TabPersonalInstance {
+  element: HTMLElement;
+  setData(data: PersonalFormData): void;
+  getData(): PersonalFormData;
+  validate(): PersonalValidationResult;
+}
+
+interface FieldEntry {
+  wrapper: HTMLDivElement;
+  input: HTMLInputElement | HTMLTextAreaElement;
+  error: HTMLDivElement;
+}
+
+interface EmailEntry {
+  wrapper: HTMLDivElement;
+  input: HTMLInputElement;
+  removeButton: HTMLButtonElement;
+  error: HTMLDivElement;
+}
+
+interface SocialEntry {
+  wrapper: HTMLDivElement;
+  keyInput: HTMLInputElement;
+  valueInput: HTMLInputElement;
+  removeButton: HTMLButtonElement;
+  error: HTMLDivElement;
+}
+
+const DATASET_INVALID = "data-invalid";
+
+function createField(labelText: string, options?: { multiline?: boolean; required?: boolean; name?: string }): FieldEntry {
+  const wrapper = document.createElement("div");
+  wrapper.className = "family-drawer__field";
+
+  const label = document.createElement("label");
+  label.className = "family-drawer__label";
+  label.textContent = labelText;
+  if (options?.name) {
+    label.htmlFor = `family-drawer-personal-${options.name}`;
+  }
+  wrapper.appendChild(label);
+
+  const input = options?.multiline ? document.createElement("textarea") : document.createElement("input");
+  input.className = "family-drawer__input";
+  if (options?.required) {
+    input.required = true;
+  }
+  if (options?.name) {
+    input.id = `family-drawer-personal-${options.name}`;
+    input.setAttribute("name", options.name);
+  }
+  if (options?.multiline) {
+    (input as HTMLTextAreaElement).rows = 3;
+  }
+  wrapper.appendChild(input);
+
+  const error = document.createElement("div");
+  error.className = "family-drawer__error";
+  error.id = `${input.id}-error`;
+  error.setAttribute("role", "status");
+  error.hidden = true;
+  wrapper.appendChild(error);
+
+  if (input.id) {
+    input.setAttribute("aria-describedby", error.id);
+  }
+
+  return { wrapper, input, error };
+}
+
+function setFieldError(entry: FieldEntry | EmailEntry | SocialEntry, message: string | null): void {
+  const { error } = entry;
+  const input = (entry as FieldEntry).input ?? (entry as EmailEntry).input ?? (entry as SocialEntry).keyInput;
+  if (message) {
+    error.textContent = message;
+    error.hidden = false;
+    entry.wrapper.setAttribute(DATASET_INVALID, "true");
+    if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+      input.setAttribute("aria-invalid", "true");
+    }
+  } else {
+    error.textContent = "";
+    error.hidden = true;
+    entry.wrapper.removeAttribute(DATASET_INVALID);
+    if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+      input.removeAttribute("aria-invalid");
+    }
+  }
+}
+
+function normalizeString(value: string): string {
+  return value.trim();
+}
+
+export function createPersonalTab(): TabPersonalInstance {
+  const element = document.createElement("div");
+  element.className = "family-drawer__panel";
+  element.id = "family-drawer-panel-personal";
+
+  const nicknameField = createField("Nickname", { required: true, name: "nickname" });
+  nicknameField.input.setAttribute("aria-required", "true");
+  element.appendChild(nicknameField.wrapper);
+
+  const fullNameField = createField("Full name", { name: "full-name" });
+  element.appendChild(fullNameField.wrapper);
+
+  const relationshipField = createField("Relationship", { name: "relationship" });
+  element.appendChild(relationshipField.wrapper);
+
+  const addressField = createField("Address", { multiline: true, name: "address" });
+  element.appendChild(addressField.wrapper);
+
+  const emailSection = document.createElement("section");
+  emailSection.className = "family-drawer__section";
+  const emailHeading = document.createElement("h3");
+  emailHeading.className = "family-drawer__section-heading";
+  emailHeading.textContent = "Email addresses";
+  emailSection.appendChild(emailHeading);
+
+  const emailList = document.createElement("div");
+  emailList.className = "family-drawer__list";
+  emailSection.appendChild(emailList);
+
+  const addEmailButton = document.createElement("button");
+  addEmailButton.type = "button";
+  addEmailButton.className = "family-drawer__add";
+  addEmailButton.textContent = "Add email";
+  emailSection.appendChild(addEmailButton);
+
+  element.appendChild(emailSection);
+
+  const phoneSection = document.createElement("section");
+  phoneSection.className = "family-drawer__section";
+  const phoneHeading = document.createElement("h3");
+  phoneHeading.className = "family-drawer__section-heading";
+  phoneHeading.textContent = "Phone numbers";
+  phoneSection.appendChild(phoneHeading);
+
+  const phoneList = document.createElement("div");
+  phoneList.className = "family-drawer__phone-list";
+  phoneSection.appendChild(phoneList);
+
+  element.appendChild(phoneSection);
+
+  const websiteField = createField("Website", { name: "website" });
+  websiteField.input.placeholder = "https://";
+  element.appendChild(websiteField.wrapper);
+
+  const socialSection = document.createElement("section");
+  socialSection.className = "family-drawer__section";
+  const socialHeading = document.createElement("h3");
+  socialHeading.className = "family-drawer__section-heading";
+  socialHeading.textContent = "Social links";
+  socialSection.appendChild(socialHeading);
+
+  const socialList = document.createElement("div");
+  socialList.className = "family-drawer__list";
+  socialSection.appendChild(socialList);
+
+  const addSocialButton = document.createElement("button");
+  addSocialButton.type = "button";
+  addSocialButton.className = "family-drawer__add";
+  addSocialButton.textContent = "Add link";
+  socialSection.appendChild(addSocialButton);
+
+  element.appendChild(socialSection);
+
+  const emailEntries: EmailEntry[] = [];
+  const phoneEntries: Record<string, FieldEntry> = {};
+  const socialEntries: SocialEntry[] = [];
+
+  const createEmailEntry = (value = ""): EmailEntry => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "family-drawer__list-item";
+
+    const input = document.createElement("input");
+    input.type = "email";
+    input.className = "family-drawer__input";
+    input.value = value;
+    wrapper.appendChild(input);
+
+    const controls = document.createElement("div");
+    controls.className = "family-drawer__item-controls";
+    wrapper.appendChild(controls);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "family-drawer__remove";
+    removeButton.textContent = "Remove";
+    controls.appendChild(removeButton);
+
+    const error = document.createElement("div");
+    error.className = "family-drawer__error";
+    error.hidden = true;
+    wrapper.appendChild(error);
+
+    const entry: EmailEntry = { wrapper, input, removeButton, error };
+
+    removeButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      if (emailEntries.length === 1) {
+        entry.input.value = "";
+        setFieldError(entry, null);
+        return;
+      }
+      const index = emailEntries.indexOf(entry);
+      if (index >= 0) {
+        emailEntries.splice(index, 1);
+      }
+      wrapper.remove();
+    });
+
+    emailEntries.push(entry);
+    emailList.appendChild(wrapper);
+    return entry;
+  };
+
+  const ensureEmailRow = () => {
+    if (emailEntries.length === 0) {
+      createEmailEntry();
+    }
+  };
+
+  addEmailButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    const entry = createEmailEntry();
+    entry.input.focus();
+  });
+
+  const PHONE_FIELDS: Array<{ key: keyof PersonalFormData; label: string }> = [
+    { key: "phoneMobile", label: "Mobile" },
+    { key: "phoneHome", label: "Home" },
+    { key: "phoneWork", label: "Work" },
+  ];
+
+  for (const field of PHONE_FIELDS) {
+    const entry = createField(field.label);
+    entry.input.setAttribute("data-phone-field", field.key);
+    phoneList.appendChild(entry.wrapper);
+    phoneEntries[field.key] = entry;
+  }
+
+  const createSocialEntry = (keyValue: SocialLinkRow = { key: "", value: "" }): SocialEntry => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "family-drawer__social-item";
+
+    const keyInput = document.createElement("input");
+    keyInput.type = "text";
+    keyInput.className = "family-drawer__input family-drawer__input--small";
+    keyInput.placeholder = "Label";
+    keyInput.value = keyValue.key;
+
+    const valueInput = document.createElement("input");
+    valueInput.type = "url";
+    valueInput.className = "family-drawer__input family-drawer__input--wide";
+    valueInput.placeholder = "https://";
+    valueInput.value = keyValue.value;
+
+    wrapper.append(keyInput, valueInput);
+
+    const controls = document.createElement("div");
+    controls.className = "family-drawer__item-controls";
+    wrapper.appendChild(controls);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "family-drawer__remove";
+    removeButton.textContent = "Remove";
+    controls.appendChild(removeButton);
+
+    const error = document.createElement("div");
+    error.className = "family-drawer__error";
+    error.hidden = true;
+    wrapper.appendChild(error);
+
+    const entry: SocialEntry = { wrapper, keyInput, valueInput, removeButton, error };
+
+    removeButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      const index = socialEntries.indexOf(entry);
+      if (index >= 0) {
+        socialEntries.splice(index, 1);
+      }
+      wrapper.remove();
+    });
+
+    socialEntries.push(entry);
+    socialList.appendChild(wrapper);
+    return entry;
+  };
+
+  addSocialButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    const entry = createSocialEntry();
+    entry.keyInput.focus();
+  });
+
+  ensureEmailRow();
+
+  const getData = (): PersonalFormData => {
+    const emails = emailEntries.map((entry) => normalizeString(entry.input.value)).filter((value) => value.length > 0);
+    return {
+      nickname: normalizeString((nicknameField.input as HTMLInputElement).value),
+      fullName: normalizeString((fullNameField.input as HTMLInputElement).value),
+      relationship: normalizeString((relationshipField.input as HTMLInputElement).value),
+      address: normalizeString((addressField.input as HTMLTextAreaElement).value),
+      emails,
+      phoneMobile: normalizeString((phoneEntries.phoneMobile.input as HTMLInputElement).value),
+      phoneHome: normalizeString((phoneEntries.phoneHome.input as HTMLInputElement).value),
+      phoneWork: normalizeString((phoneEntries.phoneWork.input as HTMLInputElement).value),
+      website: normalizeString((websiteField.input as HTMLInputElement).value),
+      socialLinks: socialEntries
+        .map((entry) => ({ key: normalizeString(entry.keyInput.value), value: normalizeString(entry.valueInput.value) }))
+        .filter((item) => item.key.length > 0 || item.value.length > 0),
+    };
+  };
+
+  const setData = (data: PersonalFormData) => {
+    (nicknameField.input as HTMLInputElement).value = data.nickname ?? "";
+    (fullNameField.input as HTMLInputElement).value = data.fullName ?? "";
+    (relationshipField.input as HTMLInputElement).value = data.relationship ?? "";
+    (addressField.input as HTMLTextAreaElement).value = data.address ?? "";
+    (websiteField.input as HTMLInputElement).value = data.website ?? "";
+
+    emailEntries.splice(0, emailEntries.length);
+    emailList.replaceChildren();
+    const emailValues = data.emails && data.emails.length > 0 ? data.emails : [""];
+    for (const value of emailValues) {
+      createEmailEntry(value ?? "");
+    }
+
+    (phoneEntries.phoneMobile.input as HTMLInputElement).value = data.phoneMobile ?? "";
+    (phoneEntries.phoneHome.input as HTMLInputElement).value = data.phoneHome ?? "";
+    (phoneEntries.phoneWork.input as HTMLInputElement).value = data.phoneWork ?? "";
+
+    socialEntries.splice(0, socialEntries.length);
+    socialList.replaceChildren();
+    if (data.socialLinks && data.socialLinks.length > 0) {
+      for (const entry of data.socialLinks) {
+        createSocialEntry(entry);
+      }
+    } else {
+      createSocialEntry();
+    }
+
+    ensureEmailRow();
+  };
+
+  const validate = (): PersonalValidationResult => {
+    let firstInvalid: (() => void) | undefined;
+
+    const assignError = (entry: FieldEntry | EmailEntry | SocialEntry, message: string | null) => {
+      setFieldError(entry, message);
+      if (message && !firstInvalid) {
+        firstInvalid = () => {
+          const input = (entry as FieldEntry).input ?? (entry as EmailEntry).input ?? (entry as SocialEntry).keyInput;
+          input.focus();
+        };
+      }
+    };
+
+    const data = getData();
+
+    assignError(nicknameField, data.nickname.length === 0 ? "Nickname is required." : null);
+
+    for (const emailEntry of emailEntries) {
+      const value = emailEntry.input.value.trim();
+      if (value.length === 0) {
+        assignError(emailEntry, null);
+        continue;
+      }
+      if (!isValidEmail(value)) {
+        assignError(emailEntry, "Enter a valid email address.");
+      } else {
+        assignError(emailEntry, null);
+      }
+    }
+
+    const phoneMap: Array<[keyof PersonalFormData, FieldEntry, string]> = [
+      ["phoneMobile", phoneEntries.phoneMobile, "Enter a valid mobile number."],
+      ["phoneHome", phoneEntries.phoneHome, "Enter a valid home number."],
+      ["phoneWork", phoneEntries.phoneWork, "Enter a valid work number."],
+    ];
+
+    for (const [key, entry, message] of phoneMap) {
+      const value = (data[key] as string) ?? "";
+      if (!value) {
+        assignError(entry, null);
+        continue;
+      }
+      assignError(entry, isValidPhone(value) ? null : message);
+    }
+
+    if (data.website) {
+      assignError(websiteField, isValidUrl(data.website) ? null : "Enter a valid URL.");
+    } else {
+      assignError(websiteField, null);
+    }
+
+    for (const socialEntry of socialEntries) {
+      const key = socialEntry.keyInput.value.trim();
+      const value = socialEntry.valueInput.value.trim();
+      if (!key && !value) {
+        assignError(socialEntry, null);
+        continue;
+      }
+      if (!key) {
+        assignError(socialEntry, "Add a label for this link.");
+        continue;
+      }
+      if (!value) {
+        assignError(socialEntry, "Add a URL for this link.");
+        continue;
+      }
+      assignError(socialEntry, isValidUrl(value) ? null : "Enter a valid URL.");
+    }
+
+    const valid = !firstInvalid;
+    return { valid, focus: firstInvalid };
+  };
+
+  return {
+    element,
+    setData,
+    getData,
+    validate,
+  };
+}

--- a/src/features/family/FamilyDrawer/validators.ts
+++ b/src/features/family/FamilyDrawer/validators.ts
@@ -1,0 +1,101 @@
+export function isValidEmail(value: string): boolean {
+  if (!value) return false;
+  const normalized = value.trim();
+  if (normalized.length === 0) return false;
+  const emailPattern =
+    /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\u0001-\u0008\u000b\u000c\u000e-\u001f!#-[^-~]|\\[\u0001-\u0009\u000b\u000c\u000e-\u007f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\u0001-\u0008\u000b\u000c\u000e-\u001f!#-[^-~]|\\[\u0001-\u0009\u000b\u000c\u000e-\u007f])+))$/i;
+  return emailPattern.test(normalized);
+}
+
+export function isValidPhone(value: string): boolean {
+  if (!value) return false;
+  const normalized = value.replace(/\s+/g, "");
+  if (normalized.length === 0) return false;
+  const localPattern = /^(?:\+?[0-9]{7,15}|0[0-9]{9,14})$/;
+  return localPattern.test(normalized);
+}
+
+export function isValidUrl(value: string): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function canParseJson(value: string): boolean {
+  if (!value) return true;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseJsonOrNull<T = unknown>(value: string): T | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    throw new Error("Invalid JSON");
+  }
+}
+
+export function stringifyJson(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return "";
+    try {
+      const parsed = JSON.parse(trimmed);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return trimmed;
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function collectNumericFieldErrors(data: unknown): string[] {
+  const errors: string[] = [];
+
+  const checkValue = (key: string, value: unknown) => {
+    if (typeof value !== "string") return;
+    const normalized = value.replace(/[\s-]+/g, "");
+    if (normalized.length === 0 || /\D/.test(normalized)) {
+      errors.push(`${key} must contain digits only.`);
+    }
+  };
+
+  const walk = (node: unknown) => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        const lower = key.toLowerCase();
+        if (lower === "accountnumber" || lower === "account_number") {
+          checkValue("Account number", value);
+        }
+        if (lower === "sortcode" || lower === "sort_code") {
+          checkValue("Sort code", value);
+        }
+        walk(value);
+      }
+    }
+  };
+
+  walk(data);
+  return Array.from(new Set(errors));
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,7 @@
 @use "./styles/manage";
 @use "./ui/styles/logs";
 @use "./styles/family-shell";
+@use "./styles/family-drawer";
 
 :root {
   --radius-sm: 6px;

--- a/src/styles/_family-drawer.scss
+++ b/src/styles/_family-drawer.scss
@@ -1,0 +1,265 @@
+.family-drawer__overlay {
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(3px);
+}
+
+.family-drawer {
+  width: 420px;
+  max-width: min(420px, 90vw);
+  height: 100%;
+  margin: 0;
+  border-radius: 0;
+  background: var(--surface, #ffffff);
+  box-shadow: -20px 0 40px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  align-self: stretch;
+}
+
+.family-drawer__container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.family-drawer__header {
+  padding: var(--space-4, 24px) var(--space-5, 32px) var(--space-3, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.family-drawer__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text-strong, #0f172a);
+}
+
+.family-drawer__summary {
+  margin: 0;
+  color: var(--color-text-muted, #475569);
+  font-size: 0.9rem;
+}
+
+.family-drawer__actions {
+  display: flex;
+  gap: var(--space-2, 12px);
+  padding: 0 var(--space-5, 32px) var(--space-3, 16px);
+}
+
+.family-drawer__primary,
+.family-drawer__ghost,
+.family-drawer__remove,
+.family-drawer__add {
+  font: inherit;
+  border-radius: var(--radius-sm, 6px);
+  border: none;
+  cursor: pointer;
+  padding: 10px 16px;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.family-drawer__primary {
+  background: var(--color-accent, #2563eb);
+  color: #ffffff;
+}
+
+.family-drawer__primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.family-drawer__ghost {
+  background: transparent;
+  color: var(--color-text-strong, #0f172a);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.family-drawer__ghost:hover {
+  background: rgba(15, 23, 42, 0.05);
+}
+
+.family-drawer__tabs {
+  padding: 0 var(--space-5, 32px);
+}
+
+.family-drawer__tablist {
+  display: flex;
+  gap: var(--space-2, 12px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding-bottom: var(--space-2, 12px);
+}
+
+.family-drawer__tab {
+  background: transparent;
+  border: none;
+  font: inherit;
+  padding: 8px 2px;
+  cursor: pointer;
+  position: relative;
+  color: var(--color-text-muted, #475569);
+}
+
+.family-drawer__tab[data-tab-error]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  right: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-danger, #ef4444);
+}
+
+.family-drawer__tab[aria-selected="true"] {
+  color: var(--color-text-strong, #0f172a);
+  font-weight: 600;
+}
+
+.family-drawer__panels {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4, 24px) var(--space-5, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 24px);
+}
+
+.family-drawer__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 16px);
+}
+
+.family-drawer__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.family-drawer__label {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #475569);
+}
+
+.family-drawer__input,
+.family-drawer__textarea {
+  font: inherit;
+  padding: 10px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--color-text-strong, #0f172a);
+}
+
+.family-drawer__input:focus,
+.family-drawer__textarea:focus {
+  outline: 2px solid var(--color-accent, #2563eb);
+  outline-offset: 2px;
+}
+
+.family-drawer__textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.family-drawer__error {
+  color: var(--color-danger, #dc2626);
+  font-size: 0.78rem;
+  min-height: 0.9rem;
+}
+
+.family-drawer__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.family-drawer__section-heading {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-strong, #0f172a);
+}
+
+.family-drawer__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.family-drawer__list-item,
+.family-drawer__social-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-sm, 6px);
+  padding: var(--space-2, 12px);
+}
+
+.family-drawer__social-item {
+  gap: 8px;
+}
+
+.family-drawer__item-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.family-drawer__remove {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-danger, #dc2626);
+  padding: 6px 12px;
+}
+
+.family-drawer__add {
+  align-self: flex-start;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-accent, #2563eb);
+  padding: 8px 14px;
+}
+
+.family-drawer__phone-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 12px);
+}
+
+.family-drawer__input--small {
+  max-width: 140px;
+}
+
+.family-drawer__input--wide {
+  flex: 1;
+}
+
+.family-drawer__audit-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+}
+
+.family-drawer__audit-term {
+  font-weight: 600;
+  color: var(--color-text-muted, #475569);
+  margin: 0;
+}
+
+.family-drawer__audit-value {
+  margin: 0;
+  color: var(--color-text-strong, #0f172a);
+}
+
+.family-drawer__audit-actions {
+  margin-top: var(--space-3, 16px);
+  display: flex;
+}
+
+.family-drawer__panel [data-invalid] .family-drawer__input,
+.family-drawer__panel [data-invalid] .family-drawer__textarea {
+  border-color: var(--color-danger, #dc2626);
+}


### PR DESCRIPTION
## Summary
- guard the family drawer entry behind the feature flag, standardise the grid selection log namespace, and allow asynchronous verifier resolution
- enhance the drawer with keyboard save support, ARIA fixes, immediate mark-verified persistence, and error-aware toast/log handling
- improve tab semantics and finance validation by exposing correct ARIA state and accepting formatted numeric input

## Testing
- npm run typecheck *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a1252194832aa56d44d428501b30