### PR TITLE
Enhance family notes filtering options

### DIFF
--- a/src/features/family/family.test.ts
+++ b/src/features/family/family.test.ts
@@ -139,11 +139,33 @@ describe("familyRepo adapters", () => {
     const notes: (Note & { member_id?: string; memberId?: string })[] = [
       { id: "n1", household_id: "hh-1", text: "A", created_at: 1, updated_at: 1, member_id: "mem-1" } as any,
       { id: "n2", household_id: "hh-1", text: "B", created_at: 1, updated_at: 1, member_id: "mem-2" } as any,
+      { id: "n3", household_id: "hh-1", text: "C", created_at: 1, updated_at: 1, member_id: null } as any,
     ];
 
     const filtered = familyRepo.notes.listByMember(notes as Note[], "mem-1");
     expect(filtered).toHaveLength(1);
     expect(filtered[0].id).toBe("n1");
+  });
+
+  it("optionally includes household notes when toggled", () => {
+    const notes: (Note & { member_id?: string | null })[] = [
+      { id: "n1", household_id: "hh-1", text: "A", created_at: 1, updated_at: 1, member_id: "mem-1" } as any,
+      { id: "n2", household_id: "hh-1", text: "B", created_at: 1, updated_at: 1, member_id: null } as any,
+      { id: "n3", household_id: "hh-1", text: "C", created_at: 1, updated_at: 1, member_id: "mem-2" } as any,
+    ];
+
+    const filtered = familyRepo.notes.listByMember(notes as Note[], "mem-1", { includeHousehold: true });
+    expect(filtered.map((note) => note.id)).toEqual(["n1", "n2"]);
+  });
+
+  it("returns household notes when member id is null", () => {
+    const notes: (Note & { member_id?: string | null })[] = [
+      { id: "n1", household_id: "hh-1", text: "A", created_at: 1, updated_at: 1, member_id: "mem-1" } as any,
+      { id: "n2", household_id: "hh-1", text: "B", created_at: 1, updated_at: 1, member_id: null } as any,
+    ];
+
+    const filtered = familyRepo.notes.listByMember(notes as Note[], null);
+    expect(filtered).toEqual([{ id: "n2", household_id: "hh-1", text: "B", created_at: 1, updated_at: 1, member_id: null } as any]);
   });
 });
 

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -285,10 +285,29 @@ export const familyRepo = {
     },
   },
   notes: {
-    listByMember(notes: Note[], memberId: string): Note[] {
-      return notes.filter((note: Note & { member_id?: string; memberId?: string }) => {
-        const linked = note.member_id ?? note.memberId;
-        return typeof linked === "string" && linked === memberId;
+    listByMember(
+      notes: Note[],
+      memberId: string | null,
+      options?: { includeHousehold?: boolean },
+    ): Note[] {
+      const includeHousehold = Boolean(options?.includeHousehold);
+
+      return notes.filter((note: Note & { member_id?: string | null; memberId?: string | null }) => {
+        const linked = note.member_id ?? note.memberId ?? null;
+
+        if (memberId == null) {
+          return linked == null;
+        }
+
+        if (typeof linked === "string" && linked === memberId) {
+          return true;
+        }
+
+        if (includeHousehold && linked == null) {
+          return true;
+        }
+
+        return false;
       });
     },
   },


### PR DESCRIPTION
## Summary
- allow familyRepo notes filtering helper to accept null members and include household notes when requested
- expand family repo unit tests to cover the new filtering scenarios

## Testing
- npx vitest run src/features/family/family.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e7bea055d0832aa86c6d3e3ee19fad