### PR TITLE
docs: add pets domain index README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,3 +2,6 @@
 
 ## Active Features
 - [Logging](./logging/OVERVIEW.md) — in-app log viewer, IPC contract, export format
+
+## Domains
+- [Pets](./pets/README.md)

--- a/docs/pets/README.md
+++ b/docs/pets/README.md
@@ -1,0 +1,19 @@
+# Pets Domain Overview
+
+The Pets feature manages companion records, medical reminders, and associated household state inside Arklowdun. It bridges Household membership with Family workflows by tracking each pet’s identity, health cadence, and diagnostics trail alongside the broader vault rules.
+
+## Documentation Index
+- [Architecture](./architecture.md)
+- [Database Schema](./database.md)
+- [IPC & Validation](./ipc.md)
+- [Reminders Engine](./reminders.md)
+- [User Interface](./ui.md)
+- [Diagnostics & Logging](./diagnostics.md)
+- [Rollout Plan](./plan/overview.md)
+- [Acceptance Checklist](./plan/checklist.md)
+- [Cross-References](./references.md)
+
+## Status
+- Last verified: 2025-10-10
+- Owner: Ged McSneggle
+- Related domains: [Family](../family/README.md), [Vault](../architecture/vault-enforcement.md)


### PR DESCRIPTION
## Summary
- add a landing README in docs/pets that indexes the existing Pets domain references
- link the Pets domain index from the primary docs README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8f9e91500832a987ee7d195c42811