### PR TITLE
Handle pets reorder edge cases and reload on failure

### DIFF
--- a/src/PetsView.ts
+++ b/src/PetsView.ts
@@ -190,11 +190,20 @@ export async function PetsView(container: HTMLElement) {
     });
 
     try {
-      await Promise.all(
-        changed.map((pet) =>
-          petsRepo.update(hh, pet.id, { position: pet.position } as Partial<Pet>),
-        ),
-      );
+      const TEMP_OFFSET = pets.length + 1000;
+
+      for (let i = 0; i < changed.length; i += 1) {
+        const pet = changed[i]!;
+        await petsRepo.update(
+          hh,
+          pet.id,
+          { position: TEMP_OFFSET + i } as Partial<Pet>,
+        );
+      }
+
+      for (const pet of changed) {
+        await petsRepo.update(hh, pet.id, { position: pet.position } as Partial<Pet>);
+      }
       logUI("INFO", "ui.pets.order_persist", {
         changed: changed.length,
         household_id: hh,

--- a/src/PetsView.ts
+++ b/src/PetsView.ts
@@ -1,10 +1,19 @@
 import type { Pet } from "./models";
-import { PetDetailView } from "./ui/pets/PetDetailView";
+import { PetDetailView, type PetDetailController } from "./ui/pets/PetDetailView";
 import { getHouseholdIdForCalls } from "./db/household";
 import { petsRepo } from "./repos";
 import { reminderScheduler } from "@features/pets/reminderScheduler";
 import { runViewCleanups, registerViewCleanup } from "./utils/viewLifecycle";
 import { createPetsPage, createFilterModels, type FilteredPet } from "@features/pets/PetsPage";
+import { toast } from "./ui/Toast";
+import { logUI } from "@lib/uiLog";
+import { incrementDiagnosticsCounter } from "./diagnostics/runtime";
+import {
+  registerPetsListController,
+  unregisterPetsListController,
+  type PetsListController,
+} from "@features/pets/pageController";
+import { isMacPlatform } from "@ui/keys";
 
 function toReminderRecords(pets: Pet[]): {
   records: Array<{
@@ -54,7 +63,18 @@ interface FiltersState {
 export async function PetsView(container: HTMLElement) {
   runViewCleanups(container);
 
+  let listController: PetsListController | null = null;
   const page = createPetsPage(container);
+
+  listController = {
+    focusCreate: () => page.focusCreate(),
+    focusSearch: () => page.focusSearch(),
+    submitCreateForm: () => page.submitCreateForm(),
+    clearSearch: () => page.clearSearch(),
+    getSearchValue: () => page.getSearchValue(),
+    focusRow: (id) => page.focusRow(id),
+  };
+  registerPetsListController(listController);
 
   registerViewCleanup(container, () => {
     try {
@@ -63,6 +83,10 @@ export async function PetsView(container: HTMLElement) {
       // ignore
     }
     reminderScheduler.cancelAll();
+    if (listController) {
+      unregisterPetsListController(listController);
+      listController = null;
+    }
   });
 
   const hh = await getHouseholdIdForCalls();
@@ -75,6 +99,9 @@ export async function PetsView(container: HTMLElement) {
   let filters: FiltersState = { query: "", models: [] };
   let searchHandle: number | undefined;
   let lastScroll = 0;
+  let detailController: PetDetailController | null = null;
+  let detailActive = false;
+  let reorderLock = false;
 
   function applyFilters() {
     filters = { ...filters, models: createFilterModels(pets, filters.query) };
@@ -82,9 +109,28 @@ export async function PetsView(container: HTMLElement) {
     page.setFilter(filters.models);
   }
 
+  function consumeFocusAnchor(): "search" | "create" | null {
+    if (typeof window === "undefined") return null;
+    const hash = window.location.hash ?? "";
+    const parts = hash.split("#");
+    if (parts.length < 3) return null;
+    const action = parts[2];
+    const base = `#${parts[1] ?? ""}`;
+    try {
+      history.replaceState(null, "", base);
+    } catch {
+      window.location.hash = base;
+    }
+    if (action === "focus-search") return "search";
+    if (action === "focus-create") return "create";
+    return null;
+  }
+
   function showList() {
     page.showList();
     page.setScrollOffset(lastScroll);
+    detailController = null;
+    detailActive = false;
   }
 
   async function refresh(affected?: string[]) {
@@ -108,6 +154,129 @@ export async function PetsView(container: HTMLElement) {
       householdId: hh,
       petNames: context.petNames,
     });
+  }
+
+  async function movePet(id: string, delta: number) {
+    if (reorderLock) return;
+    if (!Number.isFinite(delta) || delta === 0) return;
+    const currentIndex = pets.findIndex((pet) => pet.id === id);
+    if (currentIndex === -1) return;
+    const targetIndex = currentIndex + delta;
+    if (targetIndex < 0 || targetIndex >= pets.length) return;
+
+    reorderLock = true;
+    const snapshot = pets.map((pet) => ({ ...pet }));
+
+    const nextOrder = [...pets];
+    const [moved] = nextOrder.splice(currentIndex, 1);
+    nextOrder.splice(targetIndex, 0, moved);
+    const normalized = nextOrder.map((pet, index) => ({ ...pet, position: index }));
+    pets = normalized;
+    applyFilters();
+    page.focusRow(id);
+
+    logUI("INFO", "ui.pets.order_move", {
+      id,
+      from: currentIndex,
+      to: targetIndex,
+      total: normalized.length,
+      household_id: hh,
+    });
+    incrementDiagnosticsCounter("pets", "ordering_moves");
+
+    const changed = normalized.filter((pet) => {
+      const previous = snapshot.find((item) => item.id === pet.id);
+      return previous?.position !== pet.position;
+    });
+
+    try {
+      await Promise.all(
+        changed.map((pet) =>
+          petsRepo.update(hh, pet.id, { position: pet.position } as Partial<Pet>),
+        ),
+      );
+      logUI("INFO", "ui.pets.order_persist", {
+        changed: changed.length,
+        household_id: hh,
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error ?? "unknown");
+      logUI("WARN", "ui.pets.order_revert", { reason, household_id: hh });
+      toast.show({ kind: "error", message: "Could not reorder pets." });
+      pets = snapshot.map((pet) => ({ ...pet }));
+      applyFilters();
+      page.focusRow(id);
+      await refresh();
+      page.focusRow(id);
+    } finally {
+      reorderLock = false;
+    }
+  }
+
+  function handleShortcut(event: KeyboardEvent) {
+    if (event.defaultPrevented) return;
+    const target = event.target as HTMLElement | null;
+    const isEditableTarget = Boolean(
+      target?.closest("input, textarea, select, [contenteditable='true']"),
+    ) || Boolean(target?.isContentEditable);
+    const key = event.key;
+    const lower = key.length === 1 ? key.toLowerCase() : key;
+    const primaryModifier = isMacPlatform() ? event.metaKey : event.ctrlKey;
+
+    if (document.querySelector('[aria-modal="true"]')) {
+      return;
+    }
+
+    if (!event.altKey && !event.metaKey && !event.ctrlKey && lower === "n" && !event.shiftKey) {
+      if (isEditableTarget) return;
+      event.preventDefault();
+      if (detailActive && detailController) {
+        detailController.focusMedicalDate();
+        logUI("INFO", "ui.pets.kbd_shortcut", { key: "N", scope: "detail" });
+      } else {
+        page.focusCreate();
+        logUI("INFO", "ui.pets.kbd_shortcut", { key: "N", scope: "list" });
+      }
+      return;
+    }
+
+    if (key === "/" && !event.altKey && !primaryModifier && !event.shiftKey) {
+      if (isEditableTarget) return;
+      event.preventDefault();
+      page.focusSearch();
+      logUI("INFO", "ui.pets.kbd_shortcut", { key: "/", scope: detailActive ? "detail" : "list" });
+      return;
+    }
+
+    if (key === "Escape" && !event.altKey && !event.shiftKey && !primaryModifier) {
+      event.preventDefault();
+      if (detailActive && detailController) {
+        detailController.handleEscape();
+        logUI("INFO", "ui.pets.kbd_shortcut", { key: "Escape", scope: "detail" });
+      } else {
+        if (page.getSearchValue()) {
+          page.clearSearch();
+        } else {
+          const active = document.activeElement as HTMLElement | null;
+          active?.blur?.();
+        }
+        logUI("INFO", "ui.pets.kbd_shortcut", { key: "Escape", scope: "list" });
+      }
+      return;
+    }
+
+    if (key === "Enter" && primaryModifier && !event.altKey) {
+      event.preventDefault();
+      let valid = false;
+      if (detailActive && detailController) {
+        valid = detailController.submitMedicalForm();
+        logUI("INFO", "ui.pets.form_submit_kbd", { form: "detail-medical", valid });
+      } else {
+        valid = page.submitCreateForm();
+        logUI("INFO", "ui.pets.form_submit_kbd", { form: "list-create", valid });
+      }
+      incrementDiagnosticsCounter("pets", "kbd_submissions");
+    }
   }
 
   async function handleCreate(input: { name: string; type: string }): Promise<Pet> {
@@ -139,6 +308,7 @@ export async function PetsView(container: HTMLElement) {
     lastScroll = page.getScrollOffset();
     const host = document.createElement("div");
     page.showDetail(host);
+    detailActive = true;
 
     const persist = async () => {
       await petsRepo.update(hh, pet.id, {
@@ -149,7 +319,9 @@ export async function PetsView(container: HTMLElement) {
       await refresh([pet.id]);
     };
 
-    await PetDetailView(host, pet, persist, showList);
+    detailController = await PetDetailView(host, pet, persist, () => {
+      showList();
+    });
   }
 
   // Initial render + reminders
@@ -158,10 +330,24 @@ export async function PetsView(container: HTMLElement) {
   const initial = toReminderRecords(pets);
   reminderScheduler.scheduleMany(initial.records, { householdId: hh, petNames: initial.petNames });
 
+  const focusAction = consumeFocusAnchor();
+  if (focusAction === "create") {
+    requestAnimationFrame(() => {
+      page.focusCreate();
+    });
+  } else if (focusAction === "search") {
+    requestAnimationFrame(() => {
+      page.focusSearch();
+    });
+  }
+
   page.setCallbacks({
     onCreate: (input) => handleCreate(input),
     onOpenPet: (pet) => { void openDetail(pet); },
     onEditPet: (pet, patch) => { void handleEdit(pet, patch); },
+    onReorderPet: (id, delta) => {
+      void movePet(id, delta);
+    },
     onSearchChange: (value: string) => {
       if (searchHandle) window.clearTimeout(searchHandle);
       searchHandle = window.setTimeout(() => {
@@ -170,6 +356,13 @@ export async function PetsView(container: HTMLElement) {
       }, 200);
     },
   });
+
+  if (typeof document !== "undefined") {
+    document.addEventListener("keydown", handleShortcut, true);
+    registerViewCleanup(container, () => {
+      document.removeEventListener("keydown", handleShortcut, true);
+    });
+  }
 
   registerViewCleanup(container, () => {
     if (searchHandle) {

--- a/src/features/pets/pageController.ts
+++ b/src/features/pets/pageController.ts
@@ -1,0 +1,54 @@
+export type PetsFocusAction = "search" | "create";
+
+export interface PetsListController {
+  focusCreate(): void;
+  focusSearch(): void;
+  submitCreateForm(): boolean;
+  clearSearch(): void;
+  getSearchValue(): string;
+  focusRow(id: string): void;
+}
+
+let currentController: PetsListController | null = null;
+const pendingActions: PetsFocusAction[] = [];
+
+function flushPending(): void {
+  if (!currentController) return;
+  while (pendingActions.length > 0) {
+    const action = pendingActions.shift();
+    if (!action) continue;
+    if (action === "create") {
+      currentController.focusCreate();
+    } else {
+      currentController.focusSearch();
+    }
+  }
+}
+
+export function registerPetsListController(controller: PetsListController): void {
+  currentController = controller;
+  flushPending();
+}
+
+export function unregisterPetsListController(controller: PetsListController): void {
+  if (currentController !== controller) return;
+  currentController = null;
+}
+
+export function requestPetsFocus(action: PetsFocusAction): void {
+  if (currentController) {
+    if (action === "create") {
+      currentController.focusCreate();
+    } else {
+      currentController.focusSearch();
+    }
+    return;
+  }
+  if (!pendingActions.includes(action)) {
+    pendingActions.push(action);
+  }
+}
+
+export function getPetsListController(): PetsListController | null {
+  return currentController;
+}

--- a/src/styles/_pets.scss
+++ b/src/styles/_pets.scss
@@ -165,6 +165,36 @@
   gap: var(--space-2, 12px);
 }
 
+.pets__order {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+}
+
+.pets__order-btn {
+  border: 1px solid rgba(79, 70, 229, 0.16);
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: var(--radius-xs, 4px);
+  width: 28px;
+  height: 22px;
+  line-height: 1;
+  font-size: 0.75rem;
+  color: rgba(79, 70, 229, 0.8);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.pets__order-btn:hover:not(:disabled) {
+  background: rgba(79, 70, 229, 0.14);
+}
+
+.pets__order-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .pets__action {
   border: 1px solid rgba(79, 70, 229, 0.2);
   background: rgba(255, 255, 255, 0.92);

--- a/src/ui/pets/PetDetailView.ts
+++ b/src/ui/pets/PetDetailView.ts
@@ -19,6 +19,12 @@ type Nullable<T> = T | null | undefined;
 
 const PET_MEDICAL_CATEGORY = "pet_medical" as const;
 
+export interface PetDetailController {
+  focusMedicalDate(): void;
+  submitMedicalForm(): boolean;
+  handleEscape(): void;
+}
+
 const ERROR_MESSAGES: Record<string, string> = {
   INVALID_HOUSEHOLD: "No active household selected. Refresh and try again.",
   PATH_OUT_OF_VAULT: "That file isn’t inside the app’s attachments folder.",
@@ -318,7 +324,7 @@ export async function PetDetailView(
   pet: Pet,
   onChange: () => Promise<void> | void,
   onBack: () => void,
-): Promise<void> {
+): Promise<PetDetailController> {
   const skipAttachmentProbe =
     typeof window !== "undefined" &&
     Boolean((window as unknown as { __ARKLOWDUN_SKIP_ATTACHMENT_PROBE__?: boolean }).__ARKLOWDUN_SKIP_ATTACHMENT_PROBE__);
@@ -1206,4 +1212,22 @@ export async function PetDetailView(
   updateSubmitState();
   dateInput.value = toDateInputValue(Date.now());
   updateSubmitState();
+
+  return {
+    focusMedicalDate() {
+      dateInput.focus();
+    },
+    submitMedicalForm() {
+      const isValid = form.checkValidity();
+      if (!isValid) {
+        form.reportValidity();
+        return false;
+      }
+      form.requestSubmit();
+      return true;
+    },
+    handleEscape() {
+      onBack();
+    },
+  };
 }

--- a/tests/keyboard-map.test.ts
+++ b/tests/keyboard-map.test.ts
@@ -20,6 +20,31 @@ if (!window.matchMedia) {
     ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }) as MediaQueryList;
 }
 
+if (!window.requestAnimationFrame) {
+  window.requestAnimationFrame = (cb: FrameRequestCallback) =>
+    window.setTimeout(() => cb(performance.now()), 16) as unknown as number;
+  window.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+}
+
+if (!("ResizeObserver" in window)) {
+  class ResizeObserverStub {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  }
+  // @ts-expect-error jsdom stub
+  window.ResizeObserver = ResizeObserverStub;
+}
+
+if (!("PerformanceObserver" in window)) {
+  class PerformanceObserverStub {
+    observe() {}
+    disconnect() {}
+  }
+  // @ts-expect-error jsdom stub
+  window.PerformanceObserver = PerformanceObserverStub;
+}
+
 globalThis.window = window as unknown as typeof globalThis & Window;
 globalThis.document = document;
 globalThis.HTMLElement = window.HTMLElement;
@@ -27,6 +52,12 @@ globalThis.HTMLInputElement = window.HTMLInputElement;
 globalThis.Element = window.Element;
 globalThis.KeyboardEvent = window.KeyboardEvent;
 globalThis.Event = window.Event;
+globalThis.requestAnimationFrame = window.requestAnimationFrame.bind(window);
+globalThis.cancelAnimationFrame = window.cancelAnimationFrame.bind(window);
+// @ts-expect-error jsdom stub assignment
+globalThis.ResizeObserver = window.ResizeObserver;
+// @ts-expect-error jsdom stub assignment
+globalThis.PerformanceObserver = window.PerformanceObserver;
 if (!('navigator' in globalThis)) {
   Object.defineProperty(globalThis, 'navigator', {
     get: () => window.navigator as Navigator,
@@ -86,4 +117,234 @@ test('command palette shortcut opens and closes with focus restore', async () =>
   assert.ok(isShortcutReserved(']'), 'next pane shortcut should be reserved');
 
   resetKeys();
+});
+
+test('command palette exposes pets commands', async () => {
+  const { initCommandPalette } = await import('@ui/CommandPalette');
+  const runtime = await import('../src/diagnostics/runtime');
+  runtime.__testing.reset();
+  runtime.__testing.disableFilePersistence();
+  const palette = initCommandPalette();
+  assert.ok(palette, 'palette should initialise');
+  palette?.open();
+
+  const input = document.getElementById('cp-input') as HTMLInputElement;
+  input.value = 'pets';
+  input.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+  await new Promise((resolve) => setTimeout(resolve, 350));
+
+  const options = Array.from(
+    document.querySelectorAll<HTMLLIElement>('#cp-list li[role="option"]'),
+  );
+  assert.ok(options.length > 0, 'static pets commands should appear');
+  const first = options[0];
+  assert.match(first.textContent ?? '', /Pets/i);
+
+  window.location.hash = '#/dashboard';
+  first.click();
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(window.location.hash, '#/pets#focus-search');
+
+  await runtime.__testing.waitForIdle();
+  const snapshot = runtime.__testing.getSnapshot();
+  assert.equal(snapshot.pets?.palette_invocations, 1);
+});
+
+test('pets controller queues focus requests until list registers', async () => {
+  const {
+    requestPetsFocus,
+    registerPetsListController,
+    unregisterPetsListController,
+  } = await import('@features/pets/pageController');
+
+  const flushController = {
+    focusCreate: () => {},
+    focusSearch: () => {},
+    submitCreateForm: () => false,
+    clearSearch: () => {},
+    getSearchValue: () => '',
+    focusRow: () => {},
+  };
+
+  registerPetsListController(flushController);
+  unregisterPetsListController(flushController);
+
+  const actions: string[] = [];
+  requestPetsFocus('create');
+  requestPetsFocus('search');
+
+  const controller = {
+    focusCreate: () => actions.push('create'),
+    focusSearch: () => actions.push('search'),
+    submitCreateForm: () => false,
+    clearSearch: () => {},
+    getSearchValue: () => '',
+    focusRow: () => {},
+  };
+
+  registerPetsListController(controller);
+  assert.deepEqual(actions, ['create', 'search']);
+
+  actions.length = 0;
+  requestPetsFocus('search');
+  assert.deepEqual(actions, ['search']);
+
+  unregisterPetsListController(controller);
+});
+
+async function flushAnimationFrames(times = 1) {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+}
+
+test('pets page reordering controls emit callbacks and restore focus', async () => {
+  const { createPetsPage, createFilterModels } = await import('@features/pets/PetsPage');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const page = createPetsPage(container);
+  page.listViewport.style.height = '400px';
+  page.listViewport.style.width = '400px';
+
+  const pets = [
+    {
+      id: 'pet-1',
+      name: 'Alpha',
+      type: 'Cat',
+      household_id: 'hh',
+      position: 0,
+      created_at: 0,
+      updated_at: 0,
+    },
+    {
+      id: 'pet-2',
+      name: 'Beta',
+      type: 'Dog',
+      household_id: 'hh',
+      position: 1,
+      created_at: 0,
+      updated_at: 0,
+    },
+  ];
+
+  const reorders: Array<{ id: string; delta: number }> = [];
+  page.setCallbacks({
+    onReorderPet: (id, delta) => {
+      reorders.push({ id, delta });
+    },
+  });
+
+  page.setPets(pets as any);
+  page.setFilter(createFilterModels(pets as any, ''));
+
+  await flushAnimationFrames(2);
+
+  const rows = Array.from(container.querySelectorAll<HTMLDivElement>('.pets__row'));
+  assert.equal(rows.length >= 2, true, 'expected rows to be rendered');
+
+  const focusCalls: Array<string | undefined> = [];
+  const originalFocus = window.HTMLElement.prototype.focus;
+  window.HTMLElement.prototype.focus = function focusProxy(this: HTMLElement, ...args: unknown[]) {
+    focusCalls.push(this.dataset?.id ?? this.id ?? this.className);
+    return originalFocus.apply(this, args as []);
+  };
+
+  try {
+    page.focusRow('pet-2');
+    await flushAnimationFrames(3);
+  } finally {
+    window.HTMLElement.prototype.focus = originalFocus;
+  }
+
+  assert.ok(
+    focusCalls.some((id) => id === 'pet-2' || id?.includes('pets__row')),
+    'expected focusRow to invoke focus on the active row',
+  );
+
+  const moveEvent = new window.KeyboardEvent('keydown', {
+    key: 'ArrowUp',
+    altKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  rows[1]?.dispatchEvent(moveEvent);
+
+  assert.equal(moveEvent.defaultPrevented, true);
+  assert.deepEqual(reorders, [{ id: 'pet-2', delta: -1 }]);
+
+  page.destroy();
+  container.remove();
+});
+
+test('pets page ignores reorder shortcuts while editing inline', async () => {
+  const { createPetsPage, createFilterModels } = await import('@features/pets/PetsPage');
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const page = createPetsPage(container);
+  page.listViewport.style.height = '400px';
+  page.listViewport.style.width = '400px';
+
+  const pets = [
+    {
+      id: 'pet-1',
+      name: 'Alpha',
+      type: 'Cat',
+      household_id: 'hh',
+      position: 0,
+      created_at: 0,
+      updated_at: 0,
+    },
+    {
+      id: 'pet-2',
+      name: 'Beta',
+      type: 'Dog',
+      household_id: 'hh',
+      position: 1,
+      created_at: 0,
+      updated_at: 0,
+    },
+  ];
+
+  const reorders: Array<{ id: string; delta: number }> = [];
+  page.setCallbacks({
+    onReorderPet: (id, delta) => {
+      reorders.push({ id, delta });
+    },
+  });
+
+  page.setPets(pets as any);
+  page.setFilter(createFilterModels(pets as any, ''));
+
+  await flushAnimationFrames(2);
+
+  const rows = Array.from(container.querySelectorAll<HTMLDivElement>('.pets__row'));
+  assert.equal(rows.length >= 2, true, 'expected rows to be rendered');
+  const editBtn = Array.from(rows[1]?.querySelectorAll('button') ?? []).find(
+    (button) => button.textContent === 'Edit',
+  ) as HTMLButtonElement | undefined;
+  assert.ok(editBtn, 'edit button should exist');
+  editBtn?.click();
+
+  await flushAnimationFrames(1);
+
+  const nameInput = rows[1]?.querySelector('input');
+  assert.ok(nameInput, 'inline editor should render name input');
+
+  const moveEvent = new window.KeyboardEvent('keydown', {
+    key: 'ArrowUp',
+    altKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  nameInput?.dispatchEvent(moveEvent);
+
+  assert.equal(moveEvent.defaultPrevented, false, 'reorder shortcut should not fire while editing');
+  assert.deepEqual(reorders, []);
+
+  page.destroy();
+  container.remove();
 });


### PR DESCRIPTION
## Summary
- add a shared pets list controller so views and palette can request focus targets
- update the command palette pets commands to request queued focus and render static matches immediately
- expand keyboard-map tests to cover controller queuing, diagnostics counters, and Alt+Arrow reorder shortcuts
- guard inline editing against Alt+Arrow reorders, reload the list after persist failures, and suspend global shortcuts when a modal dialog is active

## Testing
- node --import ./scripts/test-preload.mjs --test tests/keyboard-map.test.ts
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e975ca389c832a8001d263f31ad98e