### PR TITLE
Refine pets header and modal creation flow

### DIFF
--- a/docs/pets/plan/overview.md
+++ b/docs/pets/plan/overview.md
@@ -130,6 +130,7 @@ These placeholders exist purely for traceability and future planning, not curren
 | PR8    | TBD            | Diagnostics counters integrated.                      |
 | PR9    | TBD            | Accessibility audit complete.                         |
 | PR10   | TBD            | Tests & fixtures hardened; Intel + ARM CI matrix green. |
+| PR11   | TBD            | Header inputs removed; create-in-modal.               |
 
 All PR checklists are to be created incrementally under `/docs/pets/plan/`.
 

--- a/src/features/pets/pageController.ts
+++ b/src/features/pets/pageController.ts
@@ -4,8 +4,6 @@ export interface PetsListController {
   focusCreate(): void;
   focusSearch(): void;
   submitCreateForm(): boolean;
-  clearSearch(): void;
-  getSearchValue(): string;
   focusRow(id: string): void;
 }
 

--- a/src/styles/_pets.scss
+++ b/src/styles/_pets.scss
@@ -45,81 +45,26 @@
 .pets__header {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--space-4, 24px);
 }
 
-.pets__header h1 {
+.pets__title {
   margin: 0;
   font-size: 1.75rem;
   font-weight: 600;
 }
 
-.pets__controls {
-  display: flex;
-  flex: 1;
-  justify-content: flex-end;
-  gap: var(--space-3, 16px);
-  flex-wrap: wrap;
-}
-
-.pets__create {
+.pets__actions {
   display: flex;
   align-items: center;
-  gap: var(--space-2, 12px);
+  gap: var(--space-3, 16px);
+  margin-left: auto;
 }
 
-.pets__search,
-.pets__input {
-  min-width: 200px;
-  padding: 0.5rem 0.75rem;
-  border-radius: var(--radius-sm, 6px);
-  border: 1px solid var(--pets-border);
-  background: var(--pets-surface);
-  color: inherit;
-  font: inherit;
-  transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
-}
-
-.pets__input {
-  min-width: 160px;
-}
-
-.pets__search:hover,
-.pets__input:hover {
-  background: var(--pets-surface-alt);
-}
-
-.pets__search:focus-visible,
-.pets__input:focus-visible {
-  outline: none;
-  border-color: var(--pets-focus-ring);
-  box-shadow: 0 0 0 3px var(--pets-focus-shadow);
-}
-
-.pets__submit {
-  padding: 0.5rem 1.25rem;
-  border-radius: var(--radius-sm, 6px);
-  border: none;
-  background: var(--color-accent, #6366f1);
-  color: var(--color-accent-text, #fff);
-  font-weight: 600;
-  cursor: pointer;
-  transition: filter 160ms ease, box-shadow 160ms ease;
-}
-
-.pets__submit:hover:not(:disabled) {
-  filter: brightness(1.05);
-}
-
-.pets__submit:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--pets-focus-shadow);
-}
-
-.pets__submit:disabled {
-  opacity: 0.6;
-  cursor: default;
+.pets__add-button {
+  min-width: 0;
 }
 
 .pets__body {
@@ -1257,6 +1202,104 @@
   margin-block-start: var(--space-2, 8px);
 }
 
+.pets-create-modal__overlay {
+  padding: var(--space-6, 24px);
+}
+
+.pets-create-modal {
+  width: min(480px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 24px);
+  padding: clamp(24px, 3vw, 32px);
+  border-radius: var(--radius-lg, 18px);
+  background: var(--pets-card-bg);
+  border: 1px solid color-mix(in srgb, var(--pets-card-border) 75%, transparent);
+  box-shadow: var(--pets-card-shadow);
+}
+
+.pets-create-modal__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 8px);
+}
+
+.pets-create-modal__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.pets-create-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 24px);
+}
+
+.pets-create-modal__description {
+  margin: 0;
+  color: var(--pets-muted);
+}
+
+.pets-create-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 16px);
+}
+
+.pets-create-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 8px);
+}
+
+.pets-create-modal__label {
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+}
+
+.pets-create-modal__input {
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--pets-border);
+  background: var(--pets-surface);
+  color: inherit;
+  font: inherit;
+  transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.pets-create-modal__input:hover {
+  background: var(--pets-surface-alt);
+}
+
+.pets-create-modal__input:focus-visible {
+  outline: none;
+  border-color: var(--pets-focus-ring);
+  box-shadow: 0 0 0 3px var(--pets-focus-shadow);
+}
+
+.pets-create-modal__input[aria-invalid="true"] {
+  border-color: var(--color-danger, #dc2626);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-danger, #dc2626) 45%, transparent);
+}
+
+.pets-create-modal__error {
+  margin: 0;
+  color: var(--color-danger, #dc2626);
+  font-size: 0.875rem;
+}
+
+.pets-create-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3, 16px);
+}
+
+.pets-create-modal__footer .btn {
+  min-width: 0;
+}
+
 @media (max-width: 900px) {
   .pet-detail__identity {
     flex-direction: column;
@@ -1275,9 +1318,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pets__search,
-  .pets__input,
-  .pets__submit,
+  .pets__add-button,
+  .pets-create-modal__input,
   .pets__row,
   .pets__action,
   .pets__order-btn,

--- a/tests/keyboard-map.test.ts
+++ b/tests/keyboard-map.test.ts
@@ -163,8 +163,6 @@ test('pets controller queues focus requests until list registers', async () => {
     focusCreate: () => {},
     focusSearch: () => {},
     submitCreateForm: () => false,
-    clearSearch: () => {},
-    getSearchValue: () => '',
     focusRow: () => {},
   };
 
@@ -179,8 +177,6 @@ test('pets controller queues focus requests until list registers', async () => {
     focusCreate: () => actions.push('create'),
     focusSearch: () => actions.push('search'),
     submitCreateForm: () => false,
-    clearSearch: () => {},
-    getSearchValue: () => '',
     focusRow: () => {},
   };
 

--- a/tests/ui/pets-view-change-photo.test.ts
+++ b/tests/ui/pets-view-change-photo.test.ts
@@ -30,8 +30,6 @@ vi.mock('@features/pets/PetsPage', () => {
       patchPet: vi.fn(),
       focusCreate: vi.fn(),
       focusSearch: vi.fn(),
-      clearSearch: vi.fn(),
-      getSearchValue: vi.fn(() => ''),
       submitCreateForm: vi.fn(() => false),
       focusRow: vi.fn(),
       showDetail: vi.fn(),


### PR DESCRIPTION
## Summary
- streamline the pets header to show only the title and Add pet action
- add an accessible Add pet modal with validation, telemetry, and list updates
- refresh documentation, styles, and tests to reflect the modal-based creation flow

## Testing
- npm test -- tests/ui/pets-page.test.ts tests/keyboard-map.test.ts tests/ui/pets-view-change-photo.test.ts *(fails: suite expects IPC adapter and legacy tests outside pets domain run automatically)*
- npm run typecheck *(fails: existing repository TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc43d6eec832ab4fca226713a3f7f