### PR TITLE
Align vehicles IPC contracts with schema parity requirements

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1113,9 +1113,6 @@ fn vehicle_to_value(vehicle: Vehicle) -> AppResult<Value> {
 #[derive(Debug, Clone)]
 struct VehicleState {
     household_id: String,
-    name: String,
-    make: Option<String>,
-    model: Option<String>,
     reg: Option<String>,
     vin: Option<String>,
     deleted_at: Option<i64>,
@@ -1286,7 +1283,7 @@ fn map_vehicle_db_error(err: AppError) -> AppError {
 async fn vehicle_state(pool: &SqlitePool, id: &str) -> AppResult<Option<VehicleState>> {
     let record = sqlx::query::<Sqlite>(
         r#"
-            SELECT household_id, name, make, model, reg, vin, deleted_at
+            SELECT household_id, reg, vin, deleted_at
             FROM vehicles
             WHERE id = ?1
         "#,
@@ -1298,11 +1295,6 @@ async fn vehicle_state(pool: &SqlitePool, id: &str) -> AppResult<Option<VehicleS
 
     Ok(record.map(|row| VehicleState {
         household_id: row.try_get::<String, _>("household_id").unwrap_or_default(),
-        name: row.try_get::<String, _>("name").unwrap_or_default(),
-        make: row.try_get::<Option<String>, _>("make").unwrap_or_default(),
-        model: row
-            .try_get::<Option<String>, _>("model")
-            .unwrap_or_default(),
         reg: row.try_get::<Option<String>, _>("reg").unwrap_or_default(),
         vin: row.try_get::<Option<String>, _>("vin").unwrap_or_default(),
         deleted_at: row

--- a/src-tauri/src/db/schema_rebuild.rs
+++ b/src-tauri/src/db/schema_rebuild.rs
@@ -118,7 +118,12 @@ pub fn rebuild_schema_baseline(dest: &Path) -> AppResult<()> {
     let baseline = MIGRATIONS_DIR
         .files()
         .find(|f| f.path().file_name().and_then(|n| n.to_str()) == Some("0001_baseline.sql"))
-        .ok_or_else(|| AppError::new("DB_SCHEMA_REBUILD/BASELINE_MISSING", "Baseline migration not found"))?;
+        .ok_or_else(|| {
+            AppError::new(
+                "DB_SCHEMA_REBUILD/BASELINE_MISSING",
+                "Baseline migration not found",
+            )
+        })?;
 
     let sql = baseline.contents_utf8().ok_or_else(|| {
         AppError::new(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -965,7 +965,6 @@ gen_domain_cmds_ns!(
     property_documents,
     inventory_items,
     vehicle_maintenance,
-    vehicles,
     pets,
     pet_medical,
     family_members,
@@ -973,6 +972,119 @@ gen_domain_cmds_ns!(
     expenses,
     shopping_items,
 );
+
+#[tauri::command]
+pub async fn vehicles_list(
+    state: State<'_, AppState>,
+    household_id: String,
+    order_by: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+) -> AppResult<Vec<serde_json::Value>> {
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        async move {
+            commands::list_command(
+                &pool,
+                "vehicles",
+                &household_id,
+                order_by.as_deref(),
+                limit,
+                offset,
+            )
+            .await
+        }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn vehicles_get(
+    state: State<'_, AppState>,
+    household_id: String,
+    id: String,
+) -> AppResult<Option<serde_json::Value>> {
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        let id = id.clone();
+        async move { commands::get_vehicle(&pool, &household_id, &id).await }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn vehicles_create(
+    state: State<'_, AppState>,
+    household_id: String,
+    data: serde_json::Map<String, serde_json::Value>,
+) -> AppResult<serde_json::Value> {
+    let _permit = guard::ensure_db_writable(&state)?;
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        let data = data.clone();
+        async move { commands::vehicles_create(&pool, &household_id, data).await }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn vehicles_update(
+    state: State<'_, AppState>,
+    household_id: String,
+    id: String,
+    data: serde_json::Map<String, serde_json::Value>,
+) -> AppResult<serde_json::Value> {
+    let _permit = guard::ensure_db_writable(&state)?;
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        let id = id.clone();
+        let data = data.clone();
+        async move { commands::vehicles_update(&pool, &id, data, &household_id).await }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn vehicles_delete(
+    state: State<'_, AppState>,
+    household_id: String,
+    id: String,
+) -> AppResult<serde_json::Value> {
+    let _permit = guard::ensure_db_writable(&state)?;
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        let id = id.clone();
+        async move { commands::vehicles_delete(&pool, &household_id, &id).await }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn vehicles_restore(
+    state: State<'_, AppState>,
+    household_id: String,
+    id: String,
+) -> AppResult<serde_json::Value> {
+    let _permit = guard::ensure_db_writable(&state)?;
+    let pool = state.pool_clone();
+    dispatch_async_app_result(move || {
+        let pool = pool.clone();
+        let household_id = household_id.clone();
+        let id = id.clone();
+        async move { commands::vehicles_restore(&pool, &household_id, &id).await }
+    })
+    .await
+}
 
 #[tauri::command]
 async fn pets_delete_soft(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -973,117 +973,121 @@ gen_domain_cmds_ns!(
     shopping_items,
 );
 
-#[tauri::command]
-pub async fn vehicles_list(
-    state: State<'_, AppState>,
-    household_id: String,
-    order_by: Option<String>,
-    limit: Option<i64>,
-    offset: Option<i64>,
-) -> AppResult<Vec<serde_json::Value>> {
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        async move {
-            commands::list_command(
-                &pool,
-                "vehicles",
-                &household_id,
-                order_by.as_deref(),
-                limit,
-                offset,
-            )
-            .await
-        }
-    })
-    .await
-}
+pub mod vehicles_api {
+    use super::*;
 
-#[tauri::command]
-pub async fn vehicles_get(
-    state: State<'_, AppState>,
-    household_id: String,
-    id: String,
-) -> AppResult<Option<serde_json::Value>> {
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        let id = id.clone();
-        async move { commands::get_vehicle(&pool, &household_id, &id).await }
-    })
-    .await
-}
+    #[tauri::command]
+    pub async fn vehicles_list(
+        state: State<'_, AppState>,
+        household_id: String,
+        order_by: Option<String>,
+        limit: Option<i64>,
+        offset: Option<i64>,
+    ) -> AppResult<Vec<serde_json::Value>> {
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            async move {
+                commands::list_command(
+                    &pool,
+                    "vehicles",
+                    &household_id,
+                    order_by.as_deref(),
+                    limit,
+                    offset,
+                )
+                .await
+            }
+        })
+        .await
+    }
 
-#[tauri::command]
-pub async fn vehicles_create(
-    state: State<'_, AppState>,
-    household_id: String,
-    data: serde_json::Map<String, serde_json::Value>,
-) -> AppResult<serde_json::Value> {
-    let _permit = guard::ensure_db_writable(&state)?;
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        let data = data.clone();
-        async move { commands::vehicles_create(&pool, &household_id, data).await }
-    })
-    .await
-}
+    #[tauri::command]
+    pub async fn vehicles_get(
+        state: State<'_, AppState>,
+        household_id: String,
+        id: String,
+    ) -> AppResult<Option<serde_json::Value>> {
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            let id = id.clone();
+            async move { commands::get_vehicle(&pool, &household_id, &id).await }
+        })
+        .await
+    }
 
-#[tauri::command]
-pub async fn vehicles_update(
-    state: State<'_, AppState>,
-    household_id: String,
-    id: String,
-    data: serde_json::Map<String, serde_json::Value>,
-) -> AppResult<serde_json::Value> {
-    let _permit = guard::ensure_db_writable(&state)?;
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        let id = id.clone();
-        let data = data.clone();
-        async move { commands::vehicles_update(&pool, &id, data, &household_id).await }
-    })
-    .await
-}
+    #[tauri::command]
+    pub async fn vehicles_create(
+        state: State<'_, AppState>,
+        household_id: String,
+        data: serde_json::Map<String, serde_json::Value>,
+    ) -> AppResult<serde_json::Value> {
+        let _permit = guard::ensure_db_writable(&state)?;
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            let data = data.clone();
+            async move { commands::vehicles_create(&pool, &household_id, data).await }
+        })
+        .await
+    }
 
-#[tauri::command]
-pub async fn vehicles_delete(
-    state: State<'_, AppState>,
-    household_id: String,
-    id: String,
-) -> AppResult<serde_json::Value> {
-    let _permit = guard::ensure_db_writable(&state)?;
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        let id = id.clone();
-        async move { commands::vehicles_delete(&pool, &household_id, &id).await }
-    })
-    .await
-}
+    #[tauri::command]
+    pub async fn vehicles_update(
+        state: State<'_, AppState>,
+        household_id: String,
+        id: String,
+        data: serde_json::Map<String, serde_json::Value>,
+    ) -> AppResult<serde_json::Value> {
+        let _permit = guard::ensure_db_writable(&state)?;
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            let id = id.clone();
+            let data = data.clone();
+            async move { commands::vehicles_update(&pool, &id, data, &household_id).await }
+        })
+        .await
+    }
 
-#[tauri::command]
-pub async fn vehicles_restore(
-    state: State<'_, AppState>,
-    household_id: String,
-    id: String,
-) -> AppResult<serde_json::Value> {
-    let _permit = guard::ensure_db_writable(&state)?;
-    let pool = state.pool_clone();
-    dispatch_async_app_result(move || {
-        let pool = pool.clone();
-        let household_id = household_id.clone();
-        let id = id.clone();
-        async move { commands::vehicles_restore(&pool, &household_id, &id).await }
-    })
-    .await
+    #[tauri::command]
+    pub async fn vehicles_delete(
+        state: State<'_, AppState>,
+        household_id: String,
+        id: String,
+    ) -> AppResult<serde_json::Value> {
+        let _permit = guard::ensure_db_writable(&state)?;
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            let id = id.clone();
+            async move { commands::vehicles_delete(&pool, &household_id, &id).await }
+        })
+        .await
+    }
+
+    #[tauri::command]
+    pub async fn vehicles_restore(
+        state: State<'_, AppState>,
+        household_id: String,
+        id: String,
+    ) -> AppResult<serde_json::Value> {
+        let _permit = guard::ensure_db_writable(&state)?;
+        let pool = state.pool_clone();
+        dispatch_async_app_result(move || {
+            let pool = pool.clone();
+            let household_id = household_id.clone();
+            let id = id.clone();
+            async move { commands::vehicles_restore(&pool, &household_id, &id).await }
+        })
+        .await
+    }
 }
 
 #[tauri::command]
@@ -5662,12 +5666,12 @@ macro_rules! app_commands {
             inventory_items_update,
             inventory_items_delete,
             inventory_items_restore,
-            vehicles_list,
-            vehicles_get,
-            vehicles_create,
-            vehicles_update,
-            vehicles_delete,
-            vehicles_restore,
+            vehicles_api::vehicles_list,
+            vehicles_api::vehicles_get,
+            vehicles_api::vehicles_create,
+            vehicles_api::vehicles_update,
+            vehicles_api::vehicles_delete,
+            vehicles_api::vehicles_restore,
             vehicle_maintenance_list,
             vehicle_maintenance_get,
             vehicle_maintenance_create,

--- a/src-tauri/src/migrate.rs
+++ b/src-tauri/src/migrate.rs
@@ -488,11 +488,13 @@ pub async fn apply_migrations(pool: &SqlitePool) -> anyhow::Result<()> {
             // Ensure the in-flight transaction is rolled back so we release locks
             // before writing to schema_migrations outside a tx.
             let _ = tx.rollback().await;
-            sqlx::query("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)")
-                .bind(&file_name)
-                .bind(now_ms())
-                .execute(pool)
-                .await?;
+            sqlx::query(
+                "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+            )
+            .bind(&file_name)
+            .bind(now_ms())
+            .execute(pool)
+            .await?;
             applied.insert(file_name.clone());
             continue;
         }

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value};
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Column, Executor, Row, SqlitePool, TypeInfo, ValueRef};
+use sqlx::{Column, Executor, Row, Sqlite, SqlitePool, TypeInfo, ValueRef};
 
 use crate::db::with_tx;
 use crate::time::now_ms;
@@ -420,7 +420,7 @@ pub mod items {
         WHERE id IN (SELECT id FROM ordered)
         "#,
                 );
-                tx.execute(sqlx::query(&renumber_sql).bind(&household_id))
+                tx.execute(sqlx::query::<Sqlite>(&renumber_sql).bind(&household_id))
                     .await?;
                 Ok(())
             })
@@ -450,7 +450,12 @@ pub mod items {
                      WHERE household_id = ? AND id = ?"
                 );
                 let res = tx
-                    .execute(sqlx::query(&sql).bind(now).bind(&household_id).bind(&id))
+                    .execute(
+                        sqlx::query::<Sqlite>(&sql)
+                            .bind(now)
+                            .bind(&household_id)
+                            .bind(&id),
+                    )
                     .await?;
                 if res.rows_affected() == 0 {
                     anyhow::bail!("id not found");
@@ -471,7 +476,7 @@ pub mod items {
         WHERE id IN (SELECT id FROM ordered)
         "#,
                 );
-                tx.execute(sqlx::query(&renumber_sql).bind(&household_id))
+                tx.execute(sqlx::query::<Sqlite>(&renumber_sql).bind(&household_id))
                     .await?;
                 Ok(())
             })
@@ -506,7 +511,10 @@ where
         WHERE id IN (SELECT id FROM ordered)
         "#
     );
-    sqlx::query(&sql).bind(household_id).execute(exec).await?;
+    sqlx::query::<Sqlite>(&sql)
+        .bind(household_id)
+        .execute(exec)
+        .await?;
     Ok(())
 }
 

--- a/src-tauri/src/repo.rs
+++ b/src-tauri/src/repo.rs
@@ -420,7 +420,7 @@ pub mod items {
         WHERE id IN (SELECT id FROM ordered)
         "#,
                 );
-                tx.execute(sqlx::query::<Sqlite>(&renumber_sql).bind(&household_id))
+                tx.execute(sqlx::query::<sqlx::Sqlite>(&renumber_sql).bind(&household_id))
                     .await?;
                 Ok(())
             })
@@ -451,7 +451,7 @@ pub mod items {
                 );
                 let res = tx
                     .execute(
-                        sqlx::query::<Sqlite>(&sql)
+                        sqlx::query::<sqlx::Sqlite>(&sql)
                             .bind(now)
                             .bind(&household_id)
                             .bind(&id),
@@ -476,7 +476,7 @@ pub mod items {
         WHERE id IN (SELECT id FROM ordered)
         "#,
                 );
-                tx.execute(sqlx::query::<Sqlite>(&renumber_sql).bind(&household_id))
+                tx.execute(sqlx::query::<sqlx::Sqlite>(&renumber_sql).bind(&household_id))
                     .await?;
                 Ok(())
             })

--- a/src-tauri/tests/vehicles_schema.rs
+++ b/src-tauri/tests/vehicles_schema.rs
@@ -222,35 +222,46 @@ async fn vehicles_unique_indices_enforced() -> Result<()> {
         }))
     };
 
-    vehicles_create(app.state(), "default".into(), base("UNI-001", "VINUNIQUETEST001")).await?;
+    vehicles_create(
+        app.state(),
+        "default".into(),
+        base("UNI-001", "VINUNIQUETEST001"),
+    )
+    .await?;
 
     let dup_reg = vehicles_create(
         app.state(),
         "default".into(),
         base("UNI-001", "VINUNIQUETEST002"),
     )
-        .await
-        .expect_err("duplicate reg should fail");
+    .await
+    .expect_err("duplicate reg should fail");
     assert_eq!(dup_reg.code(), "DUPLICATE_REG");
     assert_eq!(
         dup_reg.context().get("constraint_name"),
         Some(&"uq_vehicles_household_reg".to_string())
     );
-    assert_eq!(dup_reg.context().get("sqlite_code"), Some(&"2067".to_string()));
+    assert_eq!(
+        dup_reg.context().get("sqlite_code"),
+        Some(&"2067".to_string())
+    );
 
     let dup_vin = vehicles_create(
         app.state(),
         "default".into(),
         base("UNI-002", "VINUNIQUETEST001"),
     )
-        .await
-        .expect_err("duplicate vin should fail");
+    .await
+    .expect_err("duplicate vin should fail");
     assert_eq!(dup_vin.code(), "DUPLICATE_VIN");
     assert_eq!(
         dup_vin.context().get("constraint_name"),
         Some(&"uq_vehicles_household_vin".to_string())
     );
-    assert_eq!(dup_vin.context().get("sqlite_code"), Some(&"2067".to_string()));
+    assert_eq!(
+        dup_vin.context().get("sqlite_code"),
+        Some(&"2067".to_string())
+    );
 
     Ok(())
 }

--- a/src-tauri/tests/vehicles_schema.rs
+++ b/src-tauri/tests/vehicles_schema.rs
@@ -133,14 +133,14 @@ async fn vehicles_round_trip_fields_preserved() -> Result<()> {
     let dir = TempDir::new()?;
     let (app, _pool, _db_path) = build_app_state(&dir).await?;
 
-    let created = vehicles_create(app.state(), sample_vehicle_payload()).await?;
+    let created = vehicles_create(app.state(), "default".into(), sample_vehicle_payload()).await?;
     let id = created
         .get("id")
         .and_then(Value::as_str)
         .expect("id present")
         .to_string();
 
-    let fetched = vehicles_get(app.state(), Some("default".into()), id.clone())
+    let fetched = vehicles_get(app.state(), "default".into(), id.clone())
         .await?
         .expect("vehicle returned");
 
@@ -163,7 +163,7 @@ async fn vehicles_round_trip_fields_preserved() -> Result<()> {
     // Ensure we can update and soft delete / restore without error.
     let mut update = Map::new();
     update.insert("notes".into(), Value::from("Updated"));
-    vehicles_update(app.state(), id.clone(), update, Some("default".into())).await?;
+    vehicles_update(app.state(), "default".into(), id.clone(), update).await?;
     vehicles_delete(app.state(), "default".into(), id.clone()).await?;
     vehicles_restore(app.state(), "default".into(), id.clone()).await?;
     Ok(())
@@ -174,7 +174,7 @@ async fn vehicles_list_includes_extended_fields() -> Result<()> {
     let dir = TempDir::new()?;
     let (app, _pool, _db_path) = build_app_state(&dir).await?;
 
-    let created = vehicles_create(app.state(), sample_vehicle_payload()).await?;
+    let created = vehicles_create(app.state(), "default".into(), sample_vehicle_payload()).await?;
     let id = created
         .get("id")
         .and_then(Value::as_str)
@@ -222,25 +222,35 @@ async fn vehicles_unique_indices_enforced() -> Result<()> {
         }))
     };
 
-    vehicles_create(app.state(), base("UNI-001", "VINUNIQUETEST001")).await?;
+    vehicles_create(app.state(), "default".into(), base("UNI-001", "VINUNIQUETEST001")).await?;
 
-    let dup_reg = vehicles_create(app.state(), base("UNI-001", "VINUNIQUETEST002"))
+    let dup_reg = vehicles_create(
+        app.state(),
+        "default".into(),
+        base("UNI-001", "VINUNIQUETEST002"),
+    )
         .await
         .expect_err("duplicate reg should fail");
-    assert_eq!(dup_reg.code(), "Sqlite/2067");
+    assert_eq!(dup_reg.code(), "DUPLICATE_REG");
     assert_eq!(
-        dup_reg.context().get("constraint"),
+        dup_reg.context().get("constraint_name"),
         Some(&"uq_vehicles_household_reg".to_string())
     );
+    assert_eq!(dup_reg.context().get("sqlite_code"), Some(&"2067".to_string()));
 
-    let dup_vin = vehicles_create(app.state(), base("UNI-002", "VINUNIQUETEST001"))
+    let dup_vin = vehicles_create(
+        app.state(),
+        "default".into(),
+        base("UNI-002", "VINUNIQUETEST001"),
+    )
         .await
         .expect_err("duplicate vin should fail");
-    assert_eq!(dup_vin.code(), "Sqlite/2067");
+    assert_eq!(dup_vin.code(), "DUPLICATE_VIN");
     assert_eq!(
-        dup_vin.context().get("constraint"),
+        dup_vin.context().get("constraint_name"),
         Some(&"uq_vehicles_household_vin".to_string())
     );
+    assert_eq!(dup_vin.context().get("sqlite_code"), Some(&"2067".to_string()));
 
     Ok(())
 }
@@ -252,6 +262,7 @@ async fn household_delete_cascades_vehicle_records() -> Result<()> {
 
     let created = vehicles_create(
         app.state(),
+        "default".into(),
         as_object(json!({
             "household_id": "default",
             "name": "Cascade",

--- a/src/db/vehiclesRepo.ts
+++ b/src/db/vehiclesRepo.ts
@@ -1,42 +1,155 @@
 import { call } from "@lib/ipc/call";
 import type { Vehicle } from "../bindings/Vehicle";
 
-function normalize(v: Vehicle): Vehicle {
+type VehicleListCache = {
+  householdId: string;
+  vehicles: Vehicle[];
+};
+
+let listCache: VehicleListCache | null = null;
+
+function normalizeInbound(vehicle: Vehicle): Vehicle {
   return {
-    ...v,
-    next_mot_due: v.next_mot_due && v.next_mot_due > 0 ? v.next_mot_due : undefined,
-    next_service_due: v.next_service_due && v.next_service_due > 0 ? v.next_service_due : undefined,
+    ...vehicle,
+    next_mot_due:
+      vehicle.next_mot_due && vehicle.next_mot_due > 0 ? vehicle.next_mot_due : undefined,
+    next_service_due:
+      vehicle.next_service_due && vehicle.next_service_due > 0
+        ? vehicle.next_service_due
+        : undefined,
   };
 }
 
+function cacheVehicles(householdId: string, vehicles: Vehicle[]): Vehicle[] {
+  const snapshot = vehicles.map((vehicle) => ({ ...vehicle }));
+  listCache = { householdId, vehicles: snapshot };
+  return vehicles.map((vehicle) => ({ ...vehicle }));
+}
+
+function vehiclesFromCache(householdId: string): Vehicle[] | null {
+  if (!listCache || listCache.householdId !== householdId) {
+    return null;
+  }
+  return listCache.vehicles.map((vehicle) => ({ ...vehicle }));
+}
+
+function clearListCache(): void {
+  listCache = null;
+}
+
+function normalizeRegistrationOutbound(value: unknown): string | null | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed.replace(/\s+/g, " ").toUpperCase();
+  }
+  if (value === null) {
+    return null;
+  }
+  return undefined;
+}
+
+function normalizeVinOutbound(value: unknown): string | null | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return trimmed.toUpperCase();
+  }
+  if (value === null) {
+    return null;
+  }
+  return undefined;
+}
+
+function normalizeOutbound(data: Partial<Vehicle>): Partial<Vehicle> {
+  const next: Partial<Vehicle> = { ...data };
+  if (Object.prototype.hasOwnProperty.call(next, "reg")) {
+    const normalized = normalizeRegistrationOutbound(next.reg);
+    if (normalized === undefined) {
+      delete next.reg;
+    } else {
+      next.reg = normalized ?? null;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(next, "vin")) {
+    const normalized = normalizeVinOutbound(next.vin);
+    if (normalized === undefined) {
+      delete next.vin;
+    } else {
+      next.vin = normalized ?? null;
+    }
+  }
+  return next;
+}
+
+async function fetchVehicles(householdId: string): Promise<Vehicle[]> {
+  const rows = await call<Vehicle[]>("vehicles_list", { householdId });
+  const normalized = rows.map(normalizeInbound);
+  return cacheVehicles(householdId, normalized);
+}
+
 export const vehiclesRepo = {
-  async list(householdId: string): Promise<Vehicle[]> {
-    const rows = await call<Vehicle[]>("vehicles_list", { householdId });
-    return rows.map(normalize);
+  async list(householdId: string, options?: { refresh?: boolean }): Promise<Vehicle[]> {
+    if (!options?.refresh) {
+      const cached = vehiclesFromCache(householdId);
+      if (cached) {
+        return cached;
+      }
+    }
+    return fetchVehicles(householdId);
   },
 
-    async get(id: string, householdId: string): Promise<Vehicle | null> {
-      const row = await call<Vehicle | null>("vehicles_get", { id, householdId });
-      return row ? normalize(row) : null;
-    },
+  async refresh(householdId: string): Promise<Vehicle[]> {
+    return fetchVehicles(householdId);
+  },
+
+  async get(id: string, householdId: string): Promise<Vehicle | null> {
+    const cached = vehiclesFromCache(householdId)?.find((vehicle) => vehicle.id === id);
+    if (cached) {
+      return { ...cached };
+    }
+    const row = await call<Vehicle | null>("vehicles_get", { householdId, id });
+    return row ? normalizeInbound(row) : null;
+  },
 
   async create(householdId: string, data: Partial<Vehicle>): Promise<Vehicle> {
+    const outbound = normalizeOutbound({ ...data, household_id: householdId });
     const row = await call<Vehicle>("vehicles_create", {
-      data: { ...data, household_id: householdId },
+      householdId,
+      data: outbound,
     });
-    return normalize(row);
+    clearListCache();
+    return normalizeInbound(row);
   },
 
-  async update(householdId: string, id: string, data: Partial<Vehicle>): Promise<void> {
-    await call("vehicles_update", { id, data, householdId });
+  async update(
+    householdId: string,
+    id: string,
+    data: Partial<Vehicle>,
+  ): Promise<Vehicle> {
+    const outbound = normalizeOutbound(data);
+    const row = await call<Vehicle>("vehicles_update", {
+      householdId,
+      id,
+      data: outbound,
+    });
+    clearListCache();
+    return normalizeInbound(row);
   },
 
   async delete(householdId: string, id: string): Promise<void> {
     await call("vehicles_delete", { householdId, id });
+    clearListCache();
   },
 
-  async restore(householdId: string, id: string): Promise<void> {
-    await call("vehicles_restore", { householdId, id });
+  async restore(householdId: string, id: string): Promise<Vehicle> {
+    const row = await call<Vehicle>("vehicles_restore", { householdId, id });
+    clearListCache();
+    return normalizeInbound(row);
   },
 };
 

--- a/src/lib/ipc/call.ts
+++ b/src/lib/ipc/call.ts
@@ -16,6 +16,16 @@ const ERROR_MESSAGE_OVERRIDES: Record<string, string> = {
   "SQLX/UNIQUE": "Duplicate entry detected.",
   "SQLX/NOTNULL": "Required field missing.",
   "PATH_OUT_OF_VAULT": "File path outside vault boundary.",
+  VEHICLE_NOT_FOUND: "Vehicle not found.",
+  HOUSEHOLD_SCOPE_VIOLATION: "Vehicle belongs to a different household.",
+  VALIDATION_REG_OR_VIN_REQUIRED: "Provide a registration number or VIN.",
+  VALIDATION_VIN_INVALID: "Vehicle VIN is invalid.",
+  DUPLICATE_REG: "A vehicle with this registration already exists.",
+  DUPLICATE_VIN: "A vehicle with this VIN already exists.",
+  SQL_CONSTRAINT_VIOLATION: "Vehicle update failed due to a database constraint.",
+  VALIDATION_REQUIRED_FIELD: "A required vehicle field is missing.",
+  VALIDATION_TYPE_MISMATCH: "Vehicle field contains an invalid value.",
+  VALIDATION_NO_FIELDS: "No vehicle fields were provided for the update.",
   [FALLBACK_CODE]: "Unexpected error occurred.",
 };
 

--- a/tests/contracts/ipc-contracts.spec.ts
+++ b/tests/contracts/ipc-contracts.spec.ts
@@ -105,7 +105,23 @@ const scenarioDefinition: ScenarioDefinition = {
       return notesResponse;
     },
     vehicles_create: async (payload) => {
+      assert.equal(payload.householdId, "h1");
       assert.equal(payload.data.household_id, "h1");
+      return vehiclesResponse;
+    },
+    vehicles_update: async (payload) => {
+      assert.equal(payload.householdId, "h1");
+      assert.equal(payload.id, "veh-1");
+      return vehiclesResponse;
+    },
+    vehicles_delete: async (payload) => {
+      assert.equal(payload.householdId, "h1");
+      assert.equal(payload.id, "veh-1");
+      return { ok: true };
+    },
+    vehicles_restore: async (payload) => {
+      assert.equal(payload.householdId, "h1");
+      assert.equal(payload.id, "veh-1");
       return vehiclesResponse;
     },
     pets_list: async (payload) => {
@@ -219,7 +235,25 @@ registerCommand(
 );
 registerCommand(
   "vehicles_create",
-  { data: { household_id: "h1", name: "Car" } },
+  {
+    householdId: "h1",
+    data: { household_id: "h1", name: "Car", make: "Ford", model: "Focus", reg: "REG-1" },
+  },
+  vehiclesResponse,
+);
+registerCommand(
+  "vehicles_update",
+  {
+    householdId: "h1",
+    id: "veh-1",
+    data: { name: "Car", make: "Ford", model: "Focus", reg: "REG-2" },
+  },
+  vehiclesResponse,
+);
+registerCommand("vehicles_delete", { householdId: "h1", id: "veh-1" }, { ok: true });
+registerCommand(
+  "vehicles_restore",
+  { householdId: "h1", id: "veh-1" },
   vehiclesResponse,
 );
 registerCommand(

--- a/tests/contracts/schema-compat.spec.ts
+++ b/tests/contracts/schema-compat.spec.ts
@@ -27,13 +27,20 @@ test("household_list tolerates records without colour fields", () => {
 test("vehicles_create gracefully handles missing optional maintenance dates", () => {
   const contract = getContract("vehicles_create");
   assert.doesNotThrow(() =>
-    contract.request.parse({ data: { household_id: "h1", name: "Car" } }),
+    contract.request.parse({
+      householdId: "h1",
+      data: { household_id: "h1", name: "Car", make: "Ford", model: "Focus", reg: "REG-1" },
+    }),
   );
   assert.doesNotThrow(() =>
     contract.request.parse({
+      householdId: "h1",
       data: {
         household_id: "h1",
         name: "Car",
+        make: "Ford",
+        model: "Focus",
+        vin: "VINVINVINVINVINV",
         next_mot_due: 1000,
         next_service_due: null,
       },

--- a/tests/scenarios/base.ts
+++ b/tests/scenarios/base.ts
@@ -682,11 +682,13 @@ export function createScenario(config: ScenarioConfig): ScenarioDefinition {
       return vehicle ? { ...vehicle } : null;
     },
     vehicles_create: (payload, ctx) => {
-      const args = (payload as { data?: Partial<Vehicle> }).data ?? (payload as any);
+      const params = payload as { householdId?: string; data?: Partial<Vehicle> };
+      const args = params.data ?? (payload as any);
+      const householdId = params.householdId ?? (args?.household_id as string) ?? state.activeHouseholdId;
       const now = Math.floor(ctx.clock.now().getTime() / 1000);
       const vehicle: Vehicle = {
         id: nextId(state, "vehicle", ctx.rng.next()),
-        household_id: args?.household_id as string ?? state.activeHouseholdId,
+        household_id: householdId,
         name: (args?.name as string) ?? "Vehicle",
         make: (args?.make as string) ?? "",
         model: (args?.model as string) ?? "",
@@ -711,7 +713,7 @@ export function createScenario(config: ScenarioConfig): ScenarioDefinition {
         Object.assign(vehicle, data);
         vehicle.updated_at = Math.floor(ctx.clock.now().getTime() / 1000);
       }
-      return null;
+      return vehicle ? { ...vehicle } : null;
     },
     vehicles_delete: (payload, ctx) => {
       const id = (payload as { id?: string }).id ?? (payload as any)?.args?.id;
@@ -719,7 +721,7 @@ export function createScenario(config: ScenarioConfig): ScenarioDefinition {
       if (vehicle) {
         vehicle.deleted_at = Math.floor(ctx.clock.now().getTime() / 1000);
       }
-      return null;
+      return { ok: true };
     },
     vehicles_restore: (payload) => {
       const id = (payload as { id?: string }).id ?? (payload as any)?.args?.id;
@@ -727,7 +729,7 @@ export function createScenario(config: ScenarioConfig): ScenarioDefinition {
       if (vehicle) {
         vehicle.deleted_at = undefined;
       }
-      return null;
+      return vehicle ? { ...vehicle } : null;
     },
   } satisfies ScenarioHandlers;
 


### PR DESCRIPTION
## Summary
- add server-side validation, normalization, and error mapping for vehicles CRUD commands
- return vehicles from create/update/restore, emit {ok: true} on delete, and expose new error codes in the IPC layer
- tighten TypeScript IPC contracts, normalise outbound reg/VIN, add list caching, and update tests/scenarios to match

## Testing
- cargo test vehicles_schema *(fails: missing glib on test runner)*
- npm test tests/contracts/schema-compat.spec.ts tests/contracts/ipc-contracts.spec.ts *(fails: node test suite expects full environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed622369a0832aab6f155b3d4f3f59